### PR TITLE
FIX webhook integration not using queue url_override as it should

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -327,10 +327,14 @@ impl SockudoServer {
             None
         };
 
-        let webhook_redis_url = format!(
-            "redis://{}:{}",
-            config.database.redis.host, config.database.redis.port
-        );
+        let webhook_redis_url = if let Some(url_override) = config.queue.redis.url_override.as_ref() {
+            url_override.clone()
+        } else {
+            format!(
+                "redis://{}:{}",
+                config.database.redis.host, config.database.redis.port
+            )
+        };
 
         let webhook_config_for_integration = WebhookConfig {
             enabled: true, // Assuming webhooks are generally enabled if configured


### PR DESCRIPTION
This PR fixes an issue where the webhook integration was not using the REDIS_URL environment variable when it is set.