### PR TITLE
Fix gauge counter carrying values after restart

### DIFF
--- a/src/metrics/prometheus.rs
+++ b/src/metrics/prometheus.rs
@@ -246,6 +246,10 @@ impl PrometheusMetricsDriver {
         )
         .unwrap();
 
+        // Reset gauge metrics to 0 on startup - they represent current state, not historical
+        connected_sockets.reset();
+        active_channels.reset();
+
         Self {
             prefix,
             port,


### PR DESCRIPTION
Gauge metrics should reset on startup.

E.g. connected_sockets and active_channels are by definition 0 when the app just started, carrying the value between restarts creates inaccurate stats for these values.