### PR TITLE
build(docker): bump runtime to debian trixie to fix libc compat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN strip target/release/sockudo
 # -----------------------------------------------------------------------------
 # Runtime Stage: Create minimal runtime image
 # -----------------------------------------------------------------------------
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Currently the v2.6.0 docker images crash instantly with:
```
sockudo: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by sockudo)
sockudo: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by sockudo)
```

Updating to the new Debian stable (trixie) appears to resolve this, bookworm had 2.36. All I've tested is that the image builds and runs.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->