### PR TITLE
Pin rust to 1.89 bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # -----------------------------------------------------------------------------
 # Build Stage: Compile the Rust application
 # -----------------------------------------------------------------------------
-FROM rust:latest AS builder
+FROM rust:1.89-bookworm AS builder
 
 # Use stable toolchain (already default)
 


### PR DESCRIPTION
## Description
2.6.0 was incorrectly built with Rust:latest and they have moved to Trixie.
This cause a crash on startup when using sockudo:2.6.0 amd64 docker image, due to mismatched glibc version requirements

This build reverts to using Bookworm and Rust 1.89

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed