### PR TITLE
Fix/member removed not sent on cleanup

### DIFF
--- a/docker-compose.multinode.yml
+++ b/docker-compose.multinode.yml
@@ -56,7 +56,7 @@ services:
       - ./target:/app/target:ro
       - ./config:/app/config:ro
     environment:
-      - DEBUG=false
+      - DEBUG=true
       - ADAPTER_DRIVER=redis
       - ADAPTER_REDIS_URL=redis://redis:6380/0
       - ADAPTER_REDIS_PREFIX="test:"

--- a/src/adapter/connection_manager.rs
+++ b/src/adapter/connection_manager.rs
@@ -97,6 +97,7 @@ pub trait ConnectionManager: Send + Sync {
     async fn add_user(&mut self, ws: WebSocketRef) -> Result<()>;
     async fn remove_user(&mut self, ws: WebSocketRef) -> Result<()>;
     async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()>;
+    async fn has_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize>;
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/connection_manager.rs
+++ b/src/adapter/connection_manager.rs
@@ -96,8 +96,19 @@ pub trait ConnectionManager: Send + Sync {
     async fn terminate_user_connections(&mut self, app_id: &str, user_id: &str) -> Result<()>;
     async fn add_user(&mut self, ws: WebSocketRef) -> Result<()>;
     async fn remove_user(&mut self, ws: WebSocketRef) -> Result<()>;
-    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()>;
-    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize>;
+    async fn remove_user_socket(
+        &mut self,
+        user_id: &str,
+        socket_id: &SocketId,
+        app_id: &str,
+    ) -> Result<()>;
+    async fn count_user_connections_in_channel(
+        &mut self,
+        user_id: &str,
+        app_id: &str,
+        channel: &str,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<usize>;
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/connection_manager.rs
+++ b/src/adapter/connection_manager.rs
@@ -97,7 +97,7 @@ pub trait ConnectionManager: Send + Sync {
     async fn add_user(&mut self, ws: WebSocketRef) -> Result<()>;
     async fn remove_user(&mut self, ws: WebSocketRef) -> Result<()>;
     async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()>;
-    async fn has_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize>;
+    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize>;
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/connection_manager.rs
+++ b/src/adapter/connection_manager.rs
@@ -96,6 +96,7 @@ pub trait ConnectionManager: Send + Sync {
     async fn terminate_user_connections(&mut self, app_id: &str, user_id: &str) -> Result<()>;
     async fn add_user(&mut self, ws: WebSocketRef) -> Result<()>;
     async fn remove_user(&mut self, ws: WebSocketRef) -> Result<()>;
+    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()>;
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/handler/core.rs
+++ b/src/adapter/handler/core.rs
@@ -3,6 +3,7 @@ use super::ConnectionHandler;
 use crate::app::config::App;
 use crate::cleanup::{AuthInfo, ConnectionCleanupInfo, DisconnectTask};
 use crate::error::{Error, Result};
+use crate::presence::PresenceManager;
 use crate::protocol::messages::{ErrorData, MessageData, PusherMessage};
 use crate::websocket::SocketId;
 use serde_json::Value;
@@ -104,34 +105,16 @@ impl ConnectionHandler {
         // Handle presence channel member removal
         if channel_name.starts_with("presence-") {
             if let Some(user_id_str) = user_id {
-                let has_other_connections = self
-                    .user_has_other_connections_in_presence_channel(
-                        &app_config.id,
-                        &channel_name,
-                        &user_id_str,
-                    )
-                    .await?;
-
-                if !has_other_connections {
-                    // Send member_removed webhook
-                    if let Some(webhook_integration) = &self.webhook_integration {
-                        webhook_integration
-                            .send_member_removed(app_config, &channel_name, &user_id_str)
-                            .await
-                            .ok();
-                    }
-
-                    // Send member_removed event to channel
-                    let member_removed_msg =
-                        PusherMessage::member_removed(channel_name.clone(), user_id_str);
-                    self.broadcast_to_channel(
-                        app_config,
-                        &channel_name,
-                        member_removed_msg,
-                        Some(socket_id),
-                    )
-                    .await?;
-                }
+                // Use centralized presence member removal logic
+                PresenceManager::handle_member_removed(
+                    &self.connection_manager,
+                    self.webhook_integration.as_ref(),
+                    app_config,
+                    &channel_name,
+                    &user_id_str,
+                    Some(socket_id),
+                )
+                .await?;
             }
         } else {
             // Send subscription count webhook for non-presence channels
@@ -579,37 +562,17 @@ impl ConnectionHandler {
     ) -> Result<()> {
         if channel_str.starts_with("presence-") {
             if let Some(disconnected_user_id) = user_id {
-                let has_other_connections = self
-                    .user_has_other_connections_in_presence_channel(
-                        &app_config.id,
-                        channel_str,
-                        disconnected_user_id,
-                    )
-                    .await?;
-
-                if !has_other_connections {
-                    // Send member_removed webhook
-                    if let Some(webhook_integration) = &self.webhook_integration {
-                        webhook_integration
-                            .send_member_removed(app_config, channel_str, disconnected_user_id)
-                            .await
-                            .ok();
-                    }
-
-                    // Send member_removed event to channel
-                    let member_removed_msg = PusherMessage::member_removed(
-                        channel_str.to_string(),
-                        disconnected_user_id.clone(),
-                    );
-                    self.broadcast_to_channel(
-                        app_config,
-                        channel_str,
-                        member_removed_msg,
-                        Some(socket_id),
-                    )
-                    .await
-                    .ok();
-                }
+                // Use centralized presence member removal logic
+                PresenceManager::handle_member_removed(
+                    &self.connection_manager,
+                    self.webhook_integration.as_ref(),
+                    app_config,
+                    channel_str,
+                    disconnected_user_id,
+                    Some(socket_id),
+                )
+                .await
+                .ok();
             }
         } else {
             // Send subscription count webhook for non-presence channels
@@ -762,6 +725,7 @@ impl ConnectionHandler {
     }
 
     /// Helper to check if a user has any other connections to a specific presence channel.
+    #[allow(dead_code)]
     async fn user_has_other_connections_in_presence_channel(
         &self,
         app_id: &str,

--- a/src/adapter/handler/subscription_management.rs
+++ b/src/adapter/handler/subscription_management.rs
@@ -4,6 +4,7 @@ use super::types::*;
 use crate::app::config::App;
 use crate::channel::{ChannelType, PresenceMemberInfo};
 use crate::error::Result;
+use crate::presence::PresenceManager;
 use crate::protocol::messages::{MessageData, PresenceData, PusherMessage};
 use crate::utils::is_cache_channel;
 use crate::websocket::SocketId;
@@ -190,6 +191,21 @@ impl ConnectionHandler {
                 };
 
                 conn_locked.add_presence_info(request.channel.clone(), presence_info);
+                
+                // Release the connection lock before calling add_user
+                drop(conn_locked);
+                drop(connection_manager);
+                
+                // Add user to the user-socket mapping so get_user_sockets() can find it
+                self.connection_manager
+                    .lock()
+                    .await
+                    .add_user(conn_arc.clone())
+                    .await?;
+            } else {
+                // Release locks when not needed
+                drop(conn_locked);
+                drop(connection_manager);
             }
         }
 
@@ -204,24 +220,17 @@ impl ConnectionHandler {
         subscription_result: &SubscriptionResult,
     ) -> Result<()> {
         if let Some(ref presence_member) = subscription_result.member {
-            // Send member_added event to existing members
-            let member_added_msg = PusherMessage::member_added(
-                request.channel.clone(),
-                presence_member.user_id.clone(),
-                Some(presence_member.user_info.clone()),
-            );
-
-            self.connection_manager
-                .lock()
-                .await
-                .send(
-                    &request.channel,
-                    member_added_msg,
-                    Some(socket_id),
-                    &app_config.id,
-                    None, // No timing info for presence member added
-                )
-                .await?;
+            // Use centralized presence member addition logic (handles both webhook and broadcast)
+            PresenceManager::handle_member_added(
+                &self.connection_manager,
+                self.webhook_integration.as_ref(),
+                app_config,
+                &request.channel,
+                &presence_member.user_id,
+                Some(&presence_member.user_info),
+                Some(socket_id),
+            )
+            .await?;
 
             // Get current members and send presence data to new member
             let members_map = self
@@ -247,14 +256,6 @@ impl ConnectionHandler {
                 Some(presence_data),
             )
             .await?;
-
-            // Send member_added webhook
-            if let Some(webhook_integration) = &self.webhook_integration {
-                webhook_integration
-                    .send_member_added(app_config, &request.channel, &presence_member.user_id)
-                    .await
-                    .ok();
-            }
         }
 
         Ok(())

--- a/src/adapter/handler/subscription_management.rs
+++ b/src/adapter/handler/subscription_management.rs
@@ -191,11 +191,11 @@ impl ConnectionHandler {
                 };
 
                 conn_locked.add_presence_info(request.channel.clone(), presence_info);
-                
+
                 // Release the connection lock before calling add_user
                 drop(conn_locked);
                 drop(connection_manager);
-                
+
                 // Add user to the user-socket mapping so get_user_sockets() can find it
                 self.connection_manager
                     .lock()

--- a/src/adapter/horizontal_adapter.rs
+++ b/src/adapter/horizontal_adapter.rs
@@ -297,7 +297,7 @@ impl HorizontalAdapter {
                     // Count user's connections in the specific channel on this node
                     response.sockets_count = self
                         .local_adapter
-                        .has_user_connections_in_channel(user_id, &request.app_id, channel, None)
+                        .count_user_connections_in_channel(user_id, &request.app_id, channel, None)
                         .await?;
                 }
             }

--- a/src/adapter/horizontal_adapter.rs
+++ b/src/adapter/horizontal_adapter.rs
@@ -30,10 +30,10 @@ pub enum RequestType {
     ChannelsWithSocketsCount, // Get channels with socket counts
 
     // New request types
-    Sockets,             // Get all sockets
-    Channels,            // Get all channels
-    SocketsCount,        // Get count of all sockets
-    ChannelMembersCount, // Get count of members in a channel
+    Sockets,                       // Get all sockets
+    Channels,                      // Get all channels
+    SocketsCount,                  // Get count of all sockets
+    ChannelMembersCount,           // Get count of members in a channel
     CountUserConnectionsInChannel, // Check if user has connections in a specific channel
 }
 

--- a/src/adapter/horizontal_adapter.rs
+++ b/src/adapter/horizontal_adapter.rs
@@ -34,7 +34,7 @@ pub enum RequestType {
     Channels,                      // Get all channels
     SocketsCount,                  // Get count of all sockets
     ChannelMembersCount,           // Get count of members in a channel
-    CountUserConnectionsInChannel, // Check if user has connections in a specific channel
+    CountUserConnectionsInChannel, // Count user's connections in a specific channel
 }
 
 /// Request body for horizontal communication

--- a/src/adapter/horizontal_adapter.rs
+++ b/src/adapter/horizontal_adapter.rs
@@ -34,7 +34,7 @@ pub enum RequestType {
     Channels,            // Get all channels
     SocketsCount,        // Get count of all sockets
     ChannelMembersCount, // Get count of members in a channel
-    HasUserConnectionsInChannel, // Check if user has connections in a specific channel
+    CountUserConnectionsInChannel, // Check if user has connections in a specific channel
 }
 
 /// Request body for horizontal communication
@@ -292,7 +292,7 @@ impl HorizontalAdapter {
                     response.members_count = members.len();
                 }
             }
-            RequestType::HasUserConnectionsInChannel => {
+            RequestType::CountUserConnectionsInChannel => {
                 if let (Some(user_id), Some(channel)) = (&request.user_id, &request.channel) {
                     // Count user's connections in the specific channel on this node
                     response.sockets_count = self
@@ -583,7 +583,7 @@ impl HorizontalAdapter {
                     combined_response.members_count += response.members_count;
                 }
 
-                RequestType::HasUserConnectionsInChannel => {
+                RequestType::CountUserConnectionsInChannel => {
                     // Sum connection counts from all nodes
                     combined_response.sockets_count += response.sockets_count;
                 }

--- a/src/adapter/local_adapter.rs
+++ b/src/adapter/local_adapter.rs
@@ -330,6 +330,11 @@ impl ConnectionManager for LocalAdapter {
         namespace.remove_user_socket(user_id, socket_id).await
     }
 
+    async fn has_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+        let namespace = self.get_namespace(app_id).await.unwrap();
+        namespace.has_user_connections_in_channel(user_id, channel, excluding_socket).await
+    }
+
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/local_adapter.rs
+++ b/src/adapter/local_adapter.rs
@@ -325,6 +325,11 @@ impl ConnectionManager for LocalAdapter {
         namespace.remove_user(ws_ref).await
     }
 
+    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()> {
+        let namespace = self.get_namespace(app_id).await.unwrap();
+        namespace.remove_user_socket(user_id, socket_id).await
+    }
+
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/local_adapter.rs
+++ b/src/adapter/local_adapter.rs
@@ -325,14 +325,27 @@ impl ConnectionManager for LocalAdapter {
         namespace.remove_user(ws_ref).await
     }
 
-    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()> {
+    async fn remove_user_socket(
+        &mut self,
+        user_id: &str,
+        socket_id: &SocketId,
+        app_id: &str,
+    ) -> Result<()> {
         let namespace = self.get_namespace(app_id).await.unwrap();
         namespace.remove_user_socket(user_id, socket_id).await
     }
 
-    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(
+        &mut self,
+        user_id: &str,
+        app_id: &str,
+        channel: &str,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<usize> {
         let namespace = self.get_namespace(app_id).await.unwrap();
-        namespace.count_user_connections_in_channel(user_id, channel, excluding_socket).await
+        namespace
+            .count_user_connections_in_channel(user_id, channel, excluding_socket)
+            .await
     }
 
     async fn get_channels_with_socket_count(

--- a/src/adapter/local_adapter.rs
+++ b/src/adapter/local_adapter.rs
@@ -308,7 +308,7 @@ impl ConnectionManager for LocalAdapter {
         // Get app_id using WebSocketRef async method
         let app_id = {
             let ws_guard = ws_ref.0.lock().await;
-            ws_guard.state.get_app_key()
+            ws_guard.state.get_app_id()
         };
         let namespace = self.get_namespace(&app_id).await.unwrap();
         namespace.add_user(ws_ref).await
@@ -319,7 +319,7 @@ impl ConnectionManager for LocalAdapter {
         // Get app_id using WebSocketRef async method
         let app_id = {
             let ws_guard = ws_ref.0.lock().await;
-            ws_guard.state.get_app_key()
+            ws_guard.state.get_app_id()
         };
         let namespace = self.get_namespace(&app_id).await.unwrap();
         namespace.remove_user(ws_ref).await

--- a/src/adapter/local_adapter.rs
+++ b/src/adapter/local_adapter.rs
@@ -330,9 +330,9 @@ impl ConnectionManager for LocalAdapter {
         namespace.remove_user_socket(user_id, socket_id).await
     }
 
-    async fn has_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
         let namespace = self.get_namespace(app_id).await.unwrap();
-        namespace.has_user_connections_in_channel(user_id, channel, excluding_socket).await
+        namespace.count_user_connections_in_channel(user_id, channel, excluding_socket).await
     }
 
     async fn get_channels_with_socket_count(

--- a/src/adapter/nats_adapter.rs
+++ b/src/adapter/nats_adapter.rs
@@ -855,7 +855,7 @@ impl ConnectionManager for NatsAdapter {
         match self
             .send_request(
                 app_id,
-                RequestType::HasUserConnectionsInChannel,
+                RequestType::CountUserConnectionsInChannel,
                 Some(channel),
                 None,
                 Some(user_id),

--- a/src/adapter/nats_adapter.rs
+++ b/src/adapter/nats_adapter.rs
@@ -836,6 +836,11 @@ impl ConnectionManager for NatsAdapter {
         horizontal.local_adapter.remove_user(ws).await
     }
 
+    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()> {
+        let mut horizontal = self.horizontal.lock().await;
+        horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
+    }
+
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/nats_adapter.rs
+++ b/src/adapter/nats_adapter.rs
@@ -841,13 +841,13 @@ impl ConnectionManager for NatsAdapter {
         horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
     }
 
-    async fn has_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
         // Get local count (with excluding_socket filter)
         let local_count = {
             let mut horizontal = self.horizontal.lock().await;
             horizontal
                 .local_adapter
-                .has_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
+                .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
                 .await?
         };
         

--- a/src/adapter/nats_adapter.rs
+++ b/src/adapter/nats_adapter.rs
@@ -836,12 +836,26 @@ impl ConnectionManager for NatsAdapter {
         horizontal.local_adapter.remove_user(ws).await
     }
 
-    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()> {
+    async fn remove_user_socket(
+        &mut self,
+        user_id: &str,
+        socket_id: &SocketId,
+        app_id: &str,
+    ) -> Result<()> {
         let mut horizontal = self.horizontal.lock().await;
-        horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
+        horizontal
+            .local_adapter
+            .remove_user_socket(user_id, socket_id, app_id)
+            .await
     }
 
-    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(
+        &mut self,
+        user_id: &str,
+        app_id: &str,
+        channel: &str,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<usize> {
         // Get local count (with excluding_socket filter)
         let local_count = {
             let mut horizontal = self.horizontal.lock().await;
@@ -850,7 +864,7 @@ impl ConnectionManager for NatsAdapter {
                 .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
                 .await?
         };
-        
+
         // Get remote count (no excluding_socket since it's local-only)
         match self
             .send_request(

--- a/src/adapter/nats_adapter.rs
+++ b/src/adapter/nats_adapter.rs
@@ -841,6 +841,35 @@ impl ConnectionManager for NatsAdapter {
         horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
     }
 
+    async fn has_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+        // Get local count (with excluding_socket filter)
+        let local_count = {
+            let mut horizontal = self.horizontal.lock().await;
+            horizontal
+                .local_adapter
+                .has_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
+                .await?
+        };
+        
+        // Get remote count (no excluding_socket since it's local-only)
+        match self
+            .send_request(
+                app_id,
+                RequestType::HasUserConnectionsInChannel,
+                Some(channel),
+                None,
+                Some(user_id),
+            )
+            .await
+        {
+            Ok(response) => Ok(local_count + response.sockets_count),
+            Err(e) => {
+                error!("Failed to get remote user connections count: {}", e);
+                Ok(local_count)
+            }
+        }
+    }
+
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/redis_adapter.rs
+++ b/src/adapter/redis_adapter.rs
@@ -950,13 +950,13 @@ impl ConnectionManager for RedisAdapter {
         horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
     }
 
-    async fn has_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
         // Get local count (with excluding_socket filter)
         let local_count = {
             let mut horizontal = self.horizontal.lock().await;
             horizontal
                 .local_adapter
-                .has_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
+                .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
                 .await?
         };
         

--- a/src/adapter/redis_adapter.rs
+++ b/src/adapter/redis_adapter.rs
@@ -950,6 +950,35 @@ impl ConnectionManager for RedisAdapter {
         horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
     }
 
+    async fn has_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+        // Get local count (with excluding_socket filter)
+        let local_count = {
+            let mut horizontal = self.horizontal.lock().await;
+            horizontal
+                .local_adapter
+                .has_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
+                .await?
+        };
+        
+        // Get remote count (no excluding_socket since it's local-only)
+        match self
+            .send_request(
+                app_id,
+                RequestType::HasUserConnectionsInChannel,
+                Some(channel),
+                None,
+                Some(user_id),
+            )
+            .await
+        {
+            Ok(response) => Ok(local_count + response.sockets_count),
+            Err(e) => {
+                error!("Failed to get remote user connections count: {}", e);
+                Ok(local_count)
+            }
+        }
+    }
+
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/redis_adapter.rs
+++ b/src/adapter/redis_adapter.rs
@@ -964,7 +964,7 @@ impl ConnectionManager for RedisAdapter {
         match self
             .send_request(
                 app_id,
-                RequestType::HasUserConnectionsInChannel,
+                RequestType::CountUserConnectionsInChannel,
                 Some(channel),
                 None,
                 Some(user_id),

--- a/src/adapter/redis_adapter.rs
+++ b/src/adapter/redis_adapter.rs
@@ -945,12 +945,26 @@ impl ConnectionManager for RedisAdapter {
         horizontal.local_adapter.remove_user(ws).await
     }
 
-    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()> {
+    async fn remove_user_socket(
+        &mut self,
+        user_id: &str,
+        socket_id: &SocketId,
+        app_id: &str,
+    ) -> Result<()> {
         let mut horizontal = self.horizontal.lock().await;
-        horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
+        horizontal
+            .local_adapter
+            .remove_user_socket(user_id, socket_id, app_id)
+            .await
     }
 
-    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(
+        &mut self,
+        user_id: &str,
+        app_id: &str,
+        channel: &str,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<usize> {
         // Get local count (with excluding_socket filter)
         let local_count = {
             let mut horizontal = self.horizontal.lock().await;
@@ -959,7 +973,7 @@ impl ConnectionManager for RedisAdapter {
                 .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
                 .await?
         };
-        
+
         // Get remote count (no excluding_socket since it's local-only)
         match self
             .send_request(

--- a/src/adapter/redis_adapter.rs
+++ b/src/adapter/redis_adapter.rs
@@ -945,6 +945,11 @@ impl ConnectionManager for RedisAdapter {
         horizontal.local_adapter.remove_user(ws).await
     }
 
+    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()> {
+        let mut horizontal = self.horizontal.lock().await;
+        horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
+    }
+
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/redis_cluster_adapter.rs
+++ b/src/adapter/redis_cluster_adapter.rs
@@ -878,13 +878,13 @@ impl ConnectionManager for RedisClusterAdapter {
         horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
     }
 
-    async fn has_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
         // Get local count (with excluding_socket filter)
         let local_count = {
             let mut horizontal = self.horizontal.lock().await;
             horizontal
                 .local_adapter
-                .has_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
+                .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
                 .await?
         };
         

--- a/src/adapter/redis_cluster_adapter.rs
+++ b/src/adapter/redis_cluster_adapter.rs
@@ -892,7 +892,7 @@ impl ConnectionManager for RedisClusterAdapter {
         match self
             .send_request(
                 app_id,
-                RequestType::HasUserConnectionsInChannel,
+                RequestType::CountUserConnectionsInChannel,
                 Some(channel),
                 None,
                 Some(user_id),

--- a/src/adapter/redis_cluster_adapter.rs
+++ b/src/adapter/redis_cluster_adapter.rs
@@ -873,6 +873,11 @@ impl ConnectionManager for RedisClusterAdapter {
         horizontal.local_adapter.remove_user(ws).await
     }
 
+    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()> {
+        let mut horizontal = self.horizontal.lock().await;
+        horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
+    }
+
     async fn get_channels_with_socket_count(
         &mut self,
         app_id: &str,

--- a/src/adapter/redis_cluster_adapter.rs
+++ b/src/adapter/redis_cluster_adapter.rs
@@ -873,12 +873,26 @@ impl ConnectionManager for RedisClusterAdapter {
         horizontal.local_adapter.remove_user(ws).await
     }
 
-    async fn remove_user_socket(&mut self, user_id: &str, socket_id: &SocketId, app_id: &str) -> Result<()> {
+    async fn remove_user_socket(
+        &mut self,
+        user_id: &str,
+        socket_id: &SocketId,
+        app_id: &str,
+    ) -> Result<()> {
         let mut horizontal = self.horizontal.lock().await;
-        horizontal.local_adapter.remove_user_socket(user_id, socket_id, app_id).await
+        horizontal
+            .local_adapter
+            .remove_user_socket(user_id, socket_id, app_id)
+            .await
     }
 
-    async fn count_user_connections_in_channel(&mut self, user_id: &str, app_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(
+        &mut self,
+        user_id: &str,
+        app_id: &str,
+        channel: &str,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<usize> {
         // Get local count (with excluding_socket filter)
         let local_count = {
             let mut horizontal = self.horizontal.lock().await;
@@ -887,7 +901,7 @@ impl ConnectionManager for RedisClusterAdapter {
                 .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
                 .await?
         };
-        
+
         // Get remote count (no excluding_socket since it's local-only)
         match self
             .send_request(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod http_handler;
 pub mod metrics;
 pub mod namespace;
 pub mod options;
+pub mod presence;
 pub mod protocol;
 pub mod queue;
 pub mod rate_limiter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod metrics;
 mod middleware;
 mod namespace;
 mod options;
+mod presence;
 mod protocol;
 mod queue;
 mod rate_limiter;

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -332,7 +332,7 @@ impl Namespace {
         if let Some(user_sockets_ref) = self.users.get_mut(user_id) {
             // Find and remove the first matching socket (socket_id should be unique)
             let mut found_socket = None;
-            
+
             for ws_ref in user_sockets_ref.iter() {
                 let ws_socket_id = ws_ref.get_socket_id().await;
                 if ws_socket_id == *socket_id {

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -361,7 +361,7 @@ impl Namespace {
         Ok(())
     }
 
-    pub async fn has_user_connections_in_channel(&self, user_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
+    pub async fn count_user_connections_in_channel(&self, user_id: &str, channel: &str, excluding_socket: Option<&SocketId>) -> Result<usize> {
         let mut count = 0;
         
         if let Some(user_sockets_ref) = self.users.get(user_id) {

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -330,19 +330,19 @@ impl Namespace {
 
     pub async fn remove_user_socket(&self, user_id: &str, socket_id: &SocketId) -> Result<()> {
         if let Some(user_sockets_ref) = self.users.get_mut(user_id) {
-            // Find and remove the socket with matching socket_id
-            // We need to collect sockets to remove first, then remove them
-            let mut sockets_to_remove = Vec::new();
-
+            // Find and remove the first matching socket (socket_id should be unique)
+            let mut found_socket = None;
+            
             for ws_ref in user_sockets_ref.iter() {
                 let ws_socket_id = ws_ref.get_socket_id().await;
                 if ws_socket_id == *socket_id {
-                    sockets_to_remove.push(ws_ref.clone());
+                    found_socket = Some(ws_ref.clone());
+                    break;
                 }
             }
 
-            // Remove the matching sockets
-            for ws_ref in sockets_to_remove {
+            // Remove the matching socket if found
+            if let Some(ws_ref) = found_socket {
                 user_sockets_ref.remove(&ws_ref);
             }
 

--- a/src/presence/mod.rs
+++ b/src/presence/mod.rs
@@ -56,7 +56,7 @@ impl PresenceManager {
 
             // Broadcast member_added event to existing clients in the channel
             let member_added_msg = crate::protocol::messages::PusherMessage::member_added(
-                channel.to_string(), 
+                channel.to_string(),
                 user_id.to_string(),
                 user_info.cloned(),
             );
@@ -124,7 +124,8 @@ impl PresenceManager {
             }
 
             // Broadcast member_removed event to remaining clients in the channel
-            let member_removed_msg = PusherMessage::member_removed(channel.to_string(), user_id.to_string());
+            let member_removed_msg =
+                PusherMessage::member_removed(channel.to_string(), user_id.to_string());
             Self::broadcast_to_channel(
                 connection_manager,
                 &app_config.id,
@@ -163,9 +164,9 @@ impl PresenceManager {
         let subscribed_count = connection_manager
             .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
             .await?;
-        
+
         let has_other_connections = subscribed_count > 0;
-        
+
         Ok(has_other_connections)
     }
 

--- a/src/presence/mod.rs
+++ b/src/presence/mod.rs
@@ -158,25 +158,13 @@ impl PresenceManager {
         user_id: &str,
         excluding_socket: Option<&SocketId>,
     ) -> Result<bool> {
-        debug!("=== DEBUG user_has_other_connections_in_presence_channel ===");
-        debug!("  app_id: {}, channel: {}, user_id: {}", app_id, channel, user_id);
-        if let Some(excluding) = excluding_socket {
-            debug!("  excluding_socket: {}", excluding);
-        } else {
-            debug!("  excluding_socket: None");
-        }
-        
         // Use cluster-wide connection check for multi-node support
         let mut connection_manager = connection_manager.lock().await;
         let subscribed_count = connection_manager
             .has_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
             .await?;
         
-        debug!("  Cluster-wide subscribed count for {} in {}: {}", user_id, channel, subscribed_count);
-        
         let has_other_connections = subscribed_count > 0;
-        debug!("  Result: has_other_connections = {}", has_other_connections);
-        debug!("=== END DEBUG ===");
         
         Ok(has_other_connections)
     }

--- a/src/presence/mod.rs
+++ b/src/presence/mod.rs
@@ -14,6 +14,74 @@ use tracing::debug;
 pub struct PresenceManager;
 
 impl PresenceManager {
+    /// Handles presence member addition including both webhook and broadcast
+    /// Only sends events if this is the user's FIRST connection to the presence channel
+    pub async fn handle_member_added(
+        connection_manager: &Arc<Mutex<dyn ConnectionManager + Send + Sync>>,
+        webhook_integration: Option<&Arc<WebhookIntegration>>,
+        app_config: &App,
+        channel: &str,
+        user_id: &str,
+        user_info: Option<&serde_json::Value>,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<()> {
+        debug!(
+            "Processing presence member addition for user {} in channel {} (app: {})",
+            user_id, channel, app_config.id
+        );
+
+        // Check if user already had connections in this presence channel
+        let had_other_connections = Self::user_has_other_connections_in_presence_channel(
+            connection_manager,
+            &app_config.id,
+            channel,
+            user_id,
+        )
+        .await?;
+
+        if !had_other_connections {
+            debug!(
+                "User {} is joining channel {} for the first time, sending member_added events",
+                user_id, channel
+            );
+
+            // Send member_added webhook
+            if let Some(webhook_integration) = webhook_integration {
+                webhook_integration
+                    .send_member_added(app_config, channel, user_id)
+                    .await
+                    .ok(); // Don't fail the entire operation if webhook fails
+            }
+
+            // Broadcast member_added event to existing clients in the channel
+            let member_added_msg = crate::protocol::messages::PusherMessage::member_added(
+                channel.to_string(), 
+                user_id.to_string(),
+                user_info.cloned(),
+            );
+            Self::broadcast_to_channel(
+                connection_manager,
+                &app_config.id,
+                channel,
+                member_added_msg,
+                excluding_socket,
+            )
+            .await?;
+
+            debug!(
+                "Successfully processed member_added for user {} in channel {}",
+                user_id, channel
+            );
+        } else {
+            debug!(
+                "User {} already has connections in channel {}, skipping member_added events",
+                user_id, channel
+            );
+        }
+
+        Ok(())
+    }
+
     /// Handles presence member removal including both webhook and broadcast
     /// This centralizes the logic that was duplicated across sync cleanup,
     /// async cleanup, and direct unsubscribe paths
@@ -87,20 +155,41 @@ impl PresenceManager {
         channel: &str,
         user_id: &str,
     ) -> Result<bool> {
+        debug!("=== DEBUG user_has_other_connections_in_presence_channel ===");
+        debug!("  app_id: {}, channel: {}, user_id: {}", app_id, channel, user_id);
+        
         let mut connection_manager = connection_manager.lock().await;
         
         // Get all sockets for this user across the app
+        debug!("  About to call get_user_sockets with app_id: {}, user_id: {}", app_id, user_id);
         let user_sockets = connection_manager.get_user_sockets(user_id, app_id).await?;
+        debug!("  Found {} sockets for user {}", user_sockets.len(), user_id);
+        
+        let mut subscribed_count = 0;
+        let mut socket_details = Vec::new();
         
         // Check if any of the user's sockets are still subscribed to this channel
-        for ws_ref in user_sockets.iter() {
+        for (index, ws_ref) in user_sockets.iter().enumerate() {
             let socket_state_guard = ws_ref.0.lock().await;
-            if socket_state_guard.state.is_subscribed(channel) {
-                return Ok(true); // User has other connections to this channel
+            let socket_id = &socket_state_guard.state.socket_id;
+            let is_subscribed = socket_state_guard.state.is_subscribed(channel);
+            
+            socket_details.push(format!("socket_{}: {} (subscribed: {})", 
+                index, socket_id, is_subscribed));
+            
+            if is_subscribed {
+                subscribed_count += 1;
             }
         }
         
-        Ok(false) // User has no other connections to this channel
+        debug!("  Socket details: {}", socket_details.join(", "));
+        debug!("  Total subscribed to {}: {}", channel, subscribed_count);
+        
+        let has_other_connections = subscribed_count > 0;
+        debug!("  Result: has_other_connections = {}", has_other_connections);
+        debug!("=== END DEBUG ===");
+        
+        Ok(has_other_connections)
     }
 
     /// Broadcast a message to all clients in a channel, optionally excluding one socket

--- a/src/presence/mod.rs
+++ b/src/presence/mod.rs
@@ -1,0 +1,119 @@
+use crate::adapter::connection_manager::ConnectionManager;
+use crate::app::config::App;
+use crate::error::Result;
+use crate::protocol::messages::PusherMessage;
+use crate::webhook::integration::WebhookIntegration;
+use crate::websocket::SocketId;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::debug;
+
+/// Centralized presence channel management functionality
+/// This module handles presence member removal logic that needs to be
+/// consistent across different disconnect paths (sync, async, direct unsubscribe)
+pub struct PresenceManager;
+
+impl PresenceManager {
+    /// Handles presence member removal including both webhook and broadcast
+    /// This centralizes the logic that was duplicated across sync cleanup,
+    /// async cleanup, and direct unsubscribe paths
+    pub async fn handle_member_removed(
+        connection_manager: &Arc<Mutex<dyn ConnectionManager + Send + Sync>>,
+        webhook_integration: Option<&Arc<WebhookIntegration>>,
+        app_config: &App,
+        channel: &str,
+        user_id: &str,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<()> {
+        debug!(
+            "Processing presence member removal for user {} in channel {} (app: {})",
+            user_id, channel, app_config.id
+        );
+
+        // Check if user has other connections in this presence channel
+        let has_other_connections = Self::user_has_other_connections_in_presence_channel(
+            connection_manager,
+            &app_config.id,
+            channel,
+            user_id,
+        )
+        .await?;
+
+        if !has_other_connections {
+            debug!(
+                "User {} has no other connections in channel {}, sending member_removed events",
+                user_id, channel
+            );
+
+            // Send member_removed webhook
+            if let Some(webhook_integration) = webhook_integration {
+                webhook_integration
+                    .send_member_removed(app_config, channel, user_id)
+                    .await
+                    .ok(); // Don't fail the entire operation if webhook fails
+            }
+
+            // Broadcast member_removed event to remaining clients in the channel
+            let member_removed_msg = PusherMessage::member_removed(channel.to_string(), user_id.to_string());
+            Self::broadcast_to_channel(
+                connection_manager,
+                &app_config.id,
+                channel,
+                member_removed_msg,
+                excluding_socket,
+            )
+            .await?;
+
+            debug!(
+                "Successfully processed member_removed for user {} in channel {}",
+                user_id, channel
+            );
+        } else {
+            debug!(
+                "User {} has other connections in channel {}, skipping member_removed events",
+                user_id, channel
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Check if a user has other connections in a presence channel
+    /// Uses the same logic as the original working implementation:
+    /// Get all user's sockets and check if any are still subscribed to this channel
+    async fn user_has_other_connections_in_presence_channel(
+        connection_manager: &Arc<Mutex<dyn ConnectionManager + Send + Sync>>,
+        app_id: &str,
+        channel: &str,
+        user_id: &str,
+    ) -> Result<bool> {
+        let mut connection_manager = connection_manager.lock().await;
+        
+        // Get all sockets for this user across the app
+        let user_sockets = connection_manager.get_user_sockets(user_id, app_id).await?;
+        
+        // Check if any of the user's sockets are still subscribed to this channel
+        for ws_ref in user_sockets.iter() {
+            let socket_state_guard = ws_ref.0.lock().await;
+            if socket_state_guard.state.is_subscribed(channel) {
+                return Ok(true); // User has other connections to this channel
+            }
+        }
+        
+        Ok(false) // User has no other connections to this channel
+    }
+
+    /// Broadcast a message to all clients in a channel, optionally excluding one socket
+    async fn broadcast_to_channel(
+        connection_manager: &Arc<Mutex<dyn ConnectionManager + Send + Sync>>,
+        app_id: &str,
+        channel: &str,
+        message: PusherMessage,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<()> {
+        let mut connection_manager = connection_manager.lock().await;
+        connection_manager
+            .send(channel, message, excluding_socket, app_id, None)
+            .await
+    }
+}

--- a/src/presence/mod.rs
+++ b/src/presence/mod.rs
@@ -161,7 +161,7 @@ impl PresenceManager {
         // Use cluster-wide connection check for multi-node support
         let mut connection_manager = connection_manager.lock().await;
         let subscribed_count = connection_manager
-            .has_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
+            .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
             .await?;
         
         let has_other_connections = subscribed_count > 0;

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -204,6 +204,13 @@ impl ConnectionState {
             .unwrap_or_default()
     }
 
+    pub fn get_app_id(&self) -> String {
+        self.app
+            .as_ref()
+            .map(|app| app.id.clone())
+            .unwrap_or_default()
+    }
+
     pub fn time_since_last_ping(&self) -> std::time::Duration {
         self.last_ping.elapsed()
     }

--- a/tests/http_handler/up_endpoint_test.rs
+++ b/tests/http_handler/up_endpoint_test.rs
@@ -533,7 +533,7 @@ impl sockudo::adapter::ConnectionManager for FailingAdapter {
         Ok(())
     }
 
-    async fn has_user_connections_in_channel(&mut self, _user_id: &str, _app_id: &str, _channel: &str, _excluding_socket: Option<&sockudo::websocket::SocketId>) -> sockudo::error::Result<usize> {
+    async fn count_user_connections_in_channel(&mut self, _user_id: &str, _app_id: &str, _channel: &str, _excluding_socket: Option<&sockudo::websocket::SocketId>) -> sockudo::error::Result<usize> {
         Ok(0)
     }
 

--- a/tests/http_handler/up_endpoint_test.rs
+++ b/tests/http_handler/up_endpoint_test.rs
@@ -529,6 +529,14 @@ impl sockudo::adapter::ConnectionManager for FailingAdapter {
         self
     }
 
+    async fn remove_user_socket(&mut self, _user_id: &str, _socket_id: &sockudo::websocket::SocketId, _app_id: &str) -> sockudo::error::Result<()> {
+        Ok(())
+    }
+
+    async fn has_user_connections_in_channel(&mut self, _user_id: &str, _app_id: &str, _channel: &str, _excluding_socket: Option<&sockudo::websocket::SocketId>) -> sockudo::error::Result<usize> {
+        Ok(0)
+    }
+
     // This is the key - make health check fail
     async fn check_health(&self) -> sockudo::error::Result<()> {
         Err(sockudo::error::Error::ApplicationNotFound)

--- a/tests/http_handler/up_endpoint_test.rs
+++ b/tests/http_handler/up_endpoint_test.rs
@@ -529,11 +529,22 @@ impl sockudo::adapter::ConnectionManager for FailingAdapter {
         self
     }
 
-    async fn remove_user_socket(&mut self, _user_id: &str, _socket_id: &sockudo::websocket::SocketId, _app_id: &str) -> sockudo::error::Result<()> {
+    async fn remove_user_socket(
+        &mut self,
+        _user_id: &str,
+        _socket_id: &sockudo::websocket::SocketId,
+        _app_id: &str,
+    ) -> sockudo::error::Result<()> {
         Ok(())
     }
 
-    async fn count_user_connections_in_channel(&mut self, _user_id: &str, _app_id: &str, _channel: &str, _excluding_socket: Option<&sockudo::websocket::SocketId>) -> sockudo::error::Result<usize> {
+    async fn count_user_connections_in_channel(
+        &mut self,
+        _user_id: &str,
+        _app_id: &str,
+        _channel: &str,
+        _excluding_socket: Option<&sockudo::websocket::SocketId>,
+    ) -> sockudo::error::Result<usize> {
         Ok(0)
     }
 

--- a/tests/mocks/connection_handler_mock.rs
+++ b/tests/mocks/connection_handler_mock.rs
@@ -193,11 +193,22 @@ impl ConnectionManager for MockAdapter {
         self
     }
 
-    async fn remove_user_socket(&mut self, _user_id: &str, _socket_id: &SocketId, _app_id: &str) -> Result<()> {
+    async fn remove_user_socket(
+        &mut self,
+        _user_id: &str,
+        _socket_id: &SocketId,
+        _app_id: &str,
+    ) -> Result<()> {
         Ok(())
     }
 
-    async fn count_user_connections_in_channel(&mut self, _user_id: &str, _app_id: &str, _channel: &str, _excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(
+        &mut self,
+        _user_id: &str,
+        _app_id: &str,
+        _channel: &str,
+        _excluding_socket: Option<&SocketId>,
+    ) -> Result<usize> {
         Ok(0)
     }
 

--- a/tests/mocks/connection_handler_mock.rs
+++ b/tests/mocks/connection_handler_mock.rs
@@ -193,6 +193,14 @@ impl ConnectionManager for MockAdapter {
         self
     }
 
+    async fn remove_user_socket(&mut self, _user_id: &str, _socket_id: &SocketId, _app_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn has_user_connections_in_channel(&mut self, _user_id: &str, _app_id: &str, _channel: &str, _excluding_socket: Option<&SocketId>) -> Result<usize> {
+        Ok(0)
+    }
+
     async fn check_health(&self) -> Result<()> {
         // Mock adapter is always healthy for testing
         Ok(())

--- a/tests/mocks/connection_handler_mock.rs
+++ b/tests/mocks/connection_handler_mock.rs
@@ -197,7 +197,7 @@ impl ConnectionManager for MockAdapter {
         Ok(())
     }
 
-    async fn has_user_connections_in_channel(&mut self, _user_id: &str, _app_id: &str, _channel: &str, _excluding_socket: Option<&SocketId>) -> Result<usize> {
+    async fn count_user_connections_in_channel(&mut self, _user_id: &str, _app_id: &str, _channel: &str, _excluding_socket: Option<&SocketId>) -> Result<usize> {
         Ok(0)
     }
 


### PR DESCRIPTION
## Description
Fix presence channel events in single-node and multi-node setups

  Problem: Presence channel member_added and member_removed events were not firing correctly:
  - member_added never fired on first connection
  - member_removed only worked on explicit unsubscribe, not on disconnect
  - Multi-node deployments had incorrect presence state due to local-only connection checks

  Solution:
  1. Part 1 (Async cleanup): Added remove_user_socket method to properly clean up user socket mappings during async disconnect cleanup
  2. Part 2 (Sync cleanup): Reordered sync cleanup operations so socket removal happens before presence event processing
  3. Part 3 (Multi-node support): Added cluster-wide user connection queries via CountUserConnectionsInChannel horizontal message type

  Key Changes:
  - Fixed excluding_socket logic for member_added events
  - Added count_user_connections_in_channel method across all adapters for efficient cluster-wide presence queries
  - Updated PresenceManager to use cluster-aware connection checks via CountUserConnectionsInChannel requests
  - Maintains backward compatibility with single-node deployments

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed