### PR TITLE
fix: add missing channel and data fields for cache channel Pusher com…

### DIFF
--- a/src/http_handler.rs
+++ b/src/http_handler.rs
@@ -161,7 +161,11 @@ struct UsageResponse {
 // --- Helper Functions ---
 
 /// Helper to build cache payload string
-fn build_cache_payload(event_name: &str, event_data: &Value, channel: &str) -> Result<String, serde_json::Error> {
+fn build_cache_payload(
+    event_name: &str,
+    event_data: &Value,
+    channel: &str,
+) -> Result<String, serde_json::Error> {
     serde_json::to_string(&json!({
         "event": event_name,
         "channel": channel,

--- a/src/http_handler.rs
+++ b/src/http_handler.rs
@@ -161,13 +161,13 @@ struct UsageResponse {
 // --- Helper Functions ---
 
 /// Helper to build cache payload string
-fn build_cache_payload(event_name: &str, event_data: &Value) -> Result<String, serde_json::Error> {
+fn build_cache_payload(event_name: &str, event_data: &Value, channel: &str) -> Result<String, serde_json::Error> {
     serde_json::to_string(&json!({
         "event": event_name,
+        "channel": channel,
         "data": event_data,
     }))
 }
-
 /// Records API metrics (helper async function)
 #[instrument(skip(handler, incoming_request_size, outgoing_response_size), fields(app_id = %app_id))]
 async fn record_api_metrics(
@@ -418,7 +418,7 @@ async fn process_single_event_parallel(
                 let message_data = serde_json::to_value(&message_data)
                     .map_err(AppError::SerializationError)?;
                 // Attempt to build the cache payload string.
-                match build_cache_payload(&event_name_for_task, &message_data) {
+                match build_cache_payload(&event_name_for_task, &message_data, &target_channel_str) {
                     Ok(cache_payload_str) => {
                         let mut cache_manager_locked = handler_clone.cache_manager.lock().await;
                         let cache_key_str =

--- a/src/main.rs
+++ b/src/main.rs
@@ -693,8 +693,8 @@ impl SockudoServer {
         let rate_limiter_middleware_layer = if self.config.rate_limiter.enabled {
             if let Some(rate_limiter_instance) = &self.state.http_api_rate_limiter {
                 let options = crate::rate_limiter::middleware::RateLimitOptions {
-                    include_headers: true,                // Include X-RateLimit-* headers
-                    fail_open: false,                     // If rate limiter fails, deny request
+                    include_headers: true,               // Include X-RateLimit-* headers
+                    fail_open: false,                    // If rate limiter fails, deny request
                     key_prefix: Some("api".to_string()), // Prefix for keys in store
                 };
                 // Get trust_hops from config, default to 0 if not present

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -320,7 +320,7 @@ impl PusherMessage {
         Self {
             event: Some("pusher:cache_miss".to_string()),
             channel: Some(channel),
-            data: Some(MessageData::String("{}".to_string())),
+            data: Some(MessageData::Json(json!({}))),
             name: None,
             user_id: None,
         }

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -320,7 +320,7 @@ impl PusherMessage {
         Self {
             event: Some("pusher:cache_miss".to_string()),
             channel: Some(channel),
-            data: None,
+            data: Some(MessageData::String("{}".to_string())),
             name: None,
             user_id: None,
         }


### PR DESCRIPTION
fix: add missing channel and data fields for cache channel Pusher compatibility

- Add missing 'channel' field to cached event payloads in build_cache_payload
- Add missing 'data' field with empty JSON object to pusher:cache_miss events
- Ensures full compatibility with official Pusher protocol and client libraries

Fixes cache channel protocol deviations that could cause parsing errors
in pusher-js and other Pusher-compatible client libraries.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->