### PR TITLE
fix: correct HTTP status codes for oversized payloads and expired timestamps

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,6 +1,7 @@
 <component name="ProjectDictionaryState">
   <dictionary name="project">
     <words>
+      <w>signin</w>
       <w>sockudo</w>
     </words>
   </dictionary>

--- a/src/http_handler.rs
+++ b/src/http_handler.rs
@@ -60,7 +60,7 @@ impl IntoResponse for AppError {
             AppError::AppValidationFailed(msg) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, json!({ "error": msg }))
             }
-            AppError::ApiAuthFailed(msg) => (StatusCode::FORBIDDEN, json!({ "error": msg })),
+            AppError::ApiAuthFailed(msg) => (StatusCode::UNAUTHORIZED, json!({ "error": msg })),
             AppError::MissingChannelInfo => (
                 StatusCode::BAD_REQUEST,
                 json!({ "error": "Request must contain 'channels' (list) or 'channel' (string)" }),
@@ -79,7 +79,9 @@ impl IntoResponse for AppError {
             AppError::InternalError(msg) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, json!({ "error": msg }))
             }
-            AppError::LimitExceeded(msg) => (StatusCode::BAD_REQUEST, json!({ "error": msg })),
+            AppError::LimitExceeded(msg) => {
+                (StatusCode::PAYLOAD_TOO_LARGE, json!({ "error": msg }))
+            }
             AppError::InvalidInput(msg) => (StatusCode::BAD_REQUEST, json!({ "error": msg })),
         };
         error!(error.message = %self, status_code = %status, "HTTP request failed");


### PR DESCRIPTION
fix: correct HTTP status codes for oversized payloads and expired timestamps

- Change LimitExceeded from 400 Bad Request to 413 Payload Too Large
- Change ApiAuthFailed from 403 Forbidden to 401 Unauthorized
- Ensures compliance with official Pusher API status code conventions
- Improves compatibility with client libraries, proxies, and monitoring tools

Fixes incorrect status codes that could cause unexpected behavior in
systems relying on standard HTTP semantics for error handling.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->