### PR TITLE
Fix/webhook redis delay

### DIFF
--- a/src/adapter/handler/message_handlers.rs
+++ b/src/adapter/handler/message_handlers.rs
@@ -156,10 +156,16 @@ impl ConnectionHandler {
         let webhook_request = request.clone();
         let webhook_handler = self.webhook_integration.clone();
         tokio::spawn(async move {
-            if let Some(webhook_integration) = webhook_handler {
-                if let Err(e) = Self::send_client_event_webhook_static(&webhook_integration, &webhook_socket_id, &webhook_app_config, &webhook_request).await {
-                    tracing::error!("Failed to send client event webhook: {}", e);
-                }
+            if let Some(webhook_integration) = webhook_handler
+                && let Err(e) = Self::send_client_event_webhook_static(
+                    &webhook_integration,
+                    &webhook_socket_id,
+                    &webhook_app_config,
+                    &webhook_request,
+                )
+                .await
+            {
+                tracing::error!("Failed to send client event webhook: {}", e);
             }
         });
 

--- a/src/adapter/handler/subscription_management.rs
+++ b/src/adapter/handler/subscription_management.rs
@@ -104,16 +104,6 @@ impl ConnectionHandler {
         request: &SubscriptionRequest,
         subscription_result: &SubscriptionResult,
     ) -> Result<()> {
-        // Send webhooks if this is the first connection to the channel
-        if subscription_result.channel_connections == Some(1)
-            && let Some(webhook_integration) = &self.webhook_integration
-        {
-            webhook_integration
-                .send_channel_occupied(app_config, &request.channel)
-                .await
-                .ok();
-        }
-
         // Update connection state
         self.update_connection_subscription_state(
             socket_id,
@@ -123,7 +113,7 @@ impl ConnectionHandler {
         )
         .await?;
 
-        // Handle channel-specific logic
+        // Handle channel-specific logic - send subscription success response first
         let channel_type = ChannelType::from_name(&request.channel);
         match channel_type {
             ChannelType::Presence => {
@@ -139,6 +129,16 @@ impl ConnectionHandler {
                 self.send_subscription_succeeded(socket_id, app_config, &request.channel, None)
                     .await?;
             }
+        }
+
+        // Send webhooks after subscription success response (non-blocking for client)
+        if subscription_result.channel_connections == Some(1)
+            && let Some(webhook_integration) = &self.webhook_integration
+        {
+            webhook_integration
+                .send_channel_occupied(app_config, &request.channel)
+                .await
+                .ok();
         }
 
         // Send subscription count webhook for non-presence channels

--- a/src/adapter/handler/types.rs
+++ b/src/adapter/handler/types.rs
@@ -10,7 +10,7 @@ pub struct SubscriptionRequest {
     pub channel_data: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ClientEventRequest {
     pub event: String,
     pub channel: String,

--- a/src/adapter/handler/webhook_management.rs
+++ b/src/adapter/handler/webhook_management.rs
@@ -55,32 +55,4 @@ impl ConnectionHandler {
 
         Ok(())
     }
-
-    pub async fn send_client_event_webhook_static(
-        webhook_integration: &std::sync::Arc<crate::webhook::integration::WebhookIntegration>,
-        socket_id: &SocketId,
-        app_config: &App,
-        request: &ClientEventRequest,
-    ) -> Result<()> {
-        // For async spawned webhooks, we skip presence user_id lookup to avoid
-        // holding connection manager locks across spawn boundaries
-        webhook_integration
-            .send_client_event(
-                app_config,
-                &request.channel,
-                &request.event,
-                request.data.clone(),
-                Some(socket_id.as_ref()),
-                None, // Skip user_id for async webhooks to avoid lock dependencies
-            )
-            .await
-            .unwrap_or_else(|e| {
-                warn!(
-                    "Failed to send client_event webhook for {}: {}",
-                    request.channel, e
-                );
-            });
-
-        Ok(())
-    }
 }


### PR DESCRIPTION
## Description
Fix a small delay when subscribing to an empty channel with a channel_occupied webhook event configured.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring