### PR TITLE
fix: handle low level ping manually to update activity timeout

### DIFF
--- a/src/adapter/handler/mod.rs
+++ b/src/adapter/handler/mod.rs
@@ -343,7 +343,8 @@ impl ConnectionHandler {
                     }
                 }
                 OpCode::Ping => {
-                    self.handle_ping_frame(socket_id, app_config).await?;
+                    self.handle_ping_frame(socket_id, app_config, frame.payload)
+                        .await?;
                 }
                 _ => {
                     warn!("Unsupported opcode from {}: {:?}", socket_id, frame.opcode);

--- a/src/adapter/handler/mod.rs
+++ b/src/adapter/handler/mod.rs
@@ -292,7 +292,14 @@ impl ConnectionHandler {
         FragmentCollectorRead<tokio::io::ReadHalf<TokioIo<Upgraded>>>,
         WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>,
     )> {
-        let ws = fut.await.map_err(Error::WebSocket)?;
+        // Perform upgrade. By default fastwebsockets enables auto_pong which
+        // automatically responds to Ping control frames and suppresses them
+        // from the consumer (returning Ok(None) for those frames). We need to
+        // handle Ping frames ourselves so we can update activity timeouts and
+        // drive our own application-level ping/pong semantics. Therefore we
+        // disable auto_pong before splitting so Ping frames are surfaced.
+        let mut ws = fut.await.map_err(Error::WebSocket)?;
+        ws.set_auto_pong(false);
         let (rx, tx) = ws.split(tokio::io::split);
         Ok((FragmentCollectorRead::new(rx), tx))
     }

--- a/src/adapter/handler/timeout_management.rs
+++ b/src/adapter/handler/timeout_management.rs
@@ -3,6 +3,7 @@ use crate::error::Result;
 use crate::protocol::constants::PONG_TIMEOUT;
 use crate::protocol::messages::PusherMessage;
 use crate::websocket::SocketId;
+use fastwebsockets::Payload;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{debug, warn};
@@ -232,6 +233,7 @@ impl ConnectionHandler {
         &self,
         socket_id: &SocketId,
         app_config: &crate::app::config::App,
+        payload: Payload<'static>,
     ) -> Result<()> {
         // Update activity and send pong
         self.update_activity_timeout(&app_config.id, socket_id)
@@ -243,7 +245,7 @@ impl ConnectionHandler {
             // Reset connection status to Active when we receive a ping (client is alive)
             ws.state.status = crate::websocket::ConnectionStatus::Active;
             // Send low-level Pong frame in response because the auto response is disabled to allow custom handling
-            ws.send_frame(fastwebsockets::Frame::pong(Vec::new().into()))?;
+            ws.send_frame(fastwebsockets::Frame::pong(payload))?;
         }
 
         Ok(())

--- a/src/adapter/handler/timeout_management.rs
+++ b/src/adapter/handler/timeout_management.rs
@@ -242,8 +242,14 @@ impl ConnectionHandler {
             let mut ws = conn.inner.lock().await;
             // Reset connection status to Active when we receive a ping (client is alive)
             ws.state.status = crate::websocket::ConnectionStatus::Active;
-            let pong_message = PusherMessage::pong();
-            ws.send_message(&pong_message)?;
+            // Send low-level Pong frame in response because the auto response is disabled to allow custom handling
+            if let Err(e) = ws.send_frame(fastwebsockets::Frame::pong(Vec::<u8>::new().into())) {
+                tracing::debug!(
+                    "Failed to send low-level Pong frame for {}: {}",
+                    socket_id,
+                    e
+                );
+            }
         }
 
         Ok(())

--- a/src/adapter/handler/timeout_management.rs
+++ b/src/adapter/handler/timeout_management.rs
@@ -243,13 +243,7 @@ impl ConnectionHandler {
             // Reset connection status to Active when we receive a ping (client is alive)
             ws.state.status = crate::websocket::ConnectionStatus::Active;
             // Send low-level Pong frame in response because the auto response is disabled to allow custom handling
-            if let Err(e) = ws.send_frame(fastwebsockets::Frame::pong(Vec::<u8>::new().into())) {
-                tracing::debug!(
-                    "Failed to send low-level Pong frame for {}: {}",
-                    socket_id,
-                    e
-                );
-            }
+            ws.send_frame(fastwebsockets::Frame::pong(Vec::new().into()))?;
         }
 
         Ok(())


### PR DESCRIPTION
## Description
Testing with react native code I notice that server will not handle low-level websocket Ping and instead
send a message with `pusher:ping`.

As [specified](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/#ping-and-pong-messages) this is a correct behavior only when the client, like a browser, will not send standard `Ping`.
The logic is already handled, but if fastwebsockets has the `set_auto_pong` set to `true` (default) the frame event loop is not called, so no ping_time update, so connection closed after 240s (default).
Setting the `set_auto_pong` to `false` and send a manual `Pong` to client will handle Server/Native client protocol behavior.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->