### PR TITLE
Use Arc<T> instead of &Arc<T>

### DIFF
--- a/src/adapter/connection_manager.rs
+++ b/src/adapter/connection_manager.rs
@@ -49,7 +49,7 @@ pub trait ConnectionManager: Send + Sync {
         socket_id: SocketId,
         socket: WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>,
         app_id: &str,
-        app_manager: &Arc<dyn AppManager + Send + Sync>,
+        app_manager: Arc<dyn AppManager + Send + Sync>,
     ) -> Result<()>;
 
     async fn get_connection(&mut self, socket_id: &SocketId, app_id: &str) -> Option<WebSocketRef>;

--- a/src/adapter/handler/mod.rs
+++ b/src/adapter/handler/mod.rs
@@ -256,7 +256,7 @@ impl ConnectionHandler {
                     socket_id.clone(),
                     socket_tx,
                     &app_config.id,
-                    &self.app_manager,
+                    Arc::clone(&self.app_manager),
                 )
                 .await?;
         } // Lock released - atomic operation complete

--- a/src/adapter/handler/subscription_management.rs
+++ b/src/adapter/handler/subscription_management.rs
@@ -11,6 +11,7 @@ use crate::utils::is_cache_channel;
 use crate::websocket::SocketId;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct SubscriptionResult {
@@ -230,7 +231,7 @@ impl ConnectionHandler {
         if let Some(ref presence_member) = subscription_result.member {
             // Use centralized presence member addition logic (handles both webhook and broadcast)
             PresenceManager::handle_member_added(
-                &self.connection_manager,
+                Arc::clone(&self.connection_manager),
                 self.webhook_integration.as_ref(),
                 app_config,
                 &request.channel,

--- a/src/adapter/horizontal_adapter_base.rs
+++ b/src/adapter/horizontal_adapter_base.rs
@@ -724,7 +724,7 @@ where
         socket_id: SocketId,
         socket: WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>,
         app_id: &str,
-        app_manager: &Arc<dyn AppManager + Send + Sync>,
+        app_manager: Arc<dyn AppManager + Send + Sync>,
     ) -> Result<()> {
         let mut horizontal = self.horizontal.lock().await;
         horizontal

--- a/src/adapter/local_adapter.rs
+++ b/src/adapter/local_adapter.rs
@@ -147,7 +147,7 @@ impl ConnectionManager for LocalAdapter {
         socket_id: SocketId,
         socket: WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>,
         app_id: &str,
-        app_manager: &Arc<dyn AppManager + Send + Sync>,
+        app_manager: Arc<dyn AppManager + Send + Sync>,
     ) -> Result<()> {
         let namespace = self.get_or_create_namespace(app_id).await;
         namespace.add_socket(socket_id, socket, app_manager).await?;

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -42,7 +42,7 @@ impl Namespace {
         &self,
         socket_id: SocketId,
         socket_writer: WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>,
-        app_manager: &Arc<dyn AppManager + Send + Sync>,
+        app_manager: Arc<dyn AppManager + Send + Sync>,
     ) -> Result<WebSocketRef> {
         // Fetch the application configuration first
         let app_config = match app_manager.find_by_id(&self.app_id).await {

--- a/tests/http_handler/up_endpoint_test.rs
+++ b/tests/http_handler/up_endpoint_test.rs
@@ -357,7 +357,7 @@ impl sockudo::adapter::ConnectionManager for FailingAdapter {
             tokio::io::WriteHalf<hyper_util::rt::TokioIo<hyper::upgrade::Upgraded>>,
         >,
         _app_id: &str,
-        _app_manager: &Arc<dyn sockudo::app::manager::AppManager + Send + Sync>,
+        _app_manager: Arc<dyn sockudo::app::manager::AppManager + Send + Sync>,
     ) -> sockudo::error::Result<()> {
         Ok(())
     }

--- a/tests/mocks/connection_handler_mock.rs
+++ b/tests/mocks/connection_handler_mock.rs
@@ -48,7 +48,7 @@ impl ConnectionManager for MockAdapter {
         _socket_id: SocketId,
         _socket: WebSocketWrite<WriteHalf<TokioIo<Upgraded>>>,
         _app_id: &str,
-        _app_manager: &Arc<dyn AppManager + Send + Sync>,
+        _app_manager: Arc<dyn AppManager + Send + Sync>,
     ) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
## Description
In places where Arc<T> can be moved (for example: initialize_socket_with_quota_check in src/adapter/handler/mod.rs), Arc<T> should be more performant than passing it by reference.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->