### PR TITLE
Prevent sending close frame when connection is already shutting down

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -312,13 +312,12 @@ impl MessageSender {
             }
 
             // Try to close gracefully - only if we haven't already sent a close frame
-            if !is_shutting_down {
-                if let Err(e) = socket
+            if !is_shutting_down
+                && let Err(e) = socket
                     .write_frame(Frame::close(1000, b"Normal closure"))
                     .await
-                {
-                    Self::log_connection_error(&e, SocketOperation::SendCloseFrame, frame_count, true);
-                }
+            {
+                Self::log_connection_error(&e, SocketOperation::SendCloseFrame, frame_count, true);
             }
         });
 
@@ -401,13 +400,12 @@ impl MessageSender {
             }
 
             // Try to close gracefully - only if we haven't already sent a close frame
-            if !is_shutting_down {
-                if let Err(e) = socket
+            if !is_shutting_down
+                && let Err(e) = socket
                     .write_frame(Frame::close(1000, b"Normal closure"))
                     .await
-                {
-                    Self::log_connection_error(&e, SocketOperation::SendCloseFrame, frame_count, true);
-                }
+            {
+                Self::log_connection_error(&e, SocketOperation::SendCloseFrame, frame_count, true);
             }
         });
 


### PR DESCRIPTION
## Description
Partially fixes #130: Sockudo was incorrectly sending an additional close frame on 4XXX errors when the connection was already shutting down, leading to infinite retries from clients in some cases.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed