### PR TITLE
Clear user auth timeout on private channel subscriptions

### DIFF
--- a/src/adapter/handler/subscription_management.rs
+++ b/src/adapter/handler/subscription_management.rs
@@ -85,13 +85,17 @@ impl ConnectionHandler {
 
         // Clear user authentication timeout on successful private/presence channel subscription
         // This matches Pusher behavior where channel authentication satisfies the timeout
-        if subscription_result.success {
-            let channel_type = ChannelType::from_name(&request.channel);
-            if channel_type.requires_authentication() {
-                self.clear_user_authentication_timeout(&app_config.id, socket_id)
-                    .await
-                    .ok();
-            }
+        if subscription_result.success
+            && ChannelType::from_name(&request.channel).requires_authentication()
+            && let Err(e) = self
+                .clear_user_authentication_timeout(&app_config.id, socket_id)
+                .await
+        {
+            tracing::warn!(
+                "Failed to clear user auth timeout for socket {}: {}",
+                socket_id,
+                e
+            );
         }
 
         // Convert the channel manager result to our result type


### PR DESCRIPTION
## Description
Clear USER_AUTHENTICATION_TIMEOUT on private/presence channel subscription

Fixes #130 . Matches Soketi/Pusher behavior by clearing the user authentication timeout when clients successfully subscribe to private or presence channels, in addition to `pusher:signin`.

The timeout is now cleared on: `pusher:signin`, successful private-*, presence-*, and private-encrypted-* channel subscriptions. Public or cache channels do not clear the timeout.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring