### PR TITLE
Fix Redis rate limiter sliding window cleanup

### DIFF
--- a/src/rate_limiter/redis_cluster_limiter.rs
+++ b/src/rate_limiter/redis_cluster_limiter.rs
@@ -91,7 +91,7 @@ impl RedisClusterRateLimiter {
 
         // Remove all elements older than our window
         let _: () = conn
-            .zrevrangebyscore(&redis_key, 0, window_start as i64)
+            .zrembyscore(&redis_key, 0, window_start as i64)
             .await
             .map_err(|e| Error::Redis(format!("Failed to clean up Redis sorted set: {e}")))?;
 

--- a/src/rate_limiter/redis_limiter.rs
+++ b/src/rate_limiter/redis_limiter.rs
@@ -110,7 +110,7 @@ impl RedisRateLimiter {
 
         // Remove all elements older than our window
         let _: () = conn
-            .zrevrangebyscore(&redis_key, 0, window_start as i64)
+            .zrembyscore(&redis_key, 0, window_start as i64)
             .await
             .map_err(|e| Error::Redis(format!("Failed to clean up Redis sorted set: {e}")))?;
 


### PR DESCRIPTION
## Summary

This Pull Request fixes a bug in the Redis-based rate limiter (both single-node and cluster variants) where old entries in the sliding window were never removed. Under sustained traffic, this could cause individual rate-limit keys to remain permanently "full" and reject all subsequent requests with HTTP 429, even after the configured time window had elapsed.

## Background

The Redis rate limiter uses a sorted set per key to implement a sliding-window algorithm:

- Each request is stored as a timestamp in a Redis ZSET.
- On each check, entries older than the configured window are supposed to be removed.
- The current request count is then derived from the ZSET's cardinality.

In both `RedisRateLimiter` and `RedisClusterRateLimiter`, the cleanup logic was implemented as:

```rust
// Remove all elements older than our window
let _: () = conn
    .zrevrangebyscore(&redis_key, 0, window_start as i64)
    .await
    .map_err(|e| Error::Redis(format!("Failed to clean up Redis sorted set: {e}")))?;
```

`ZREVRANGEBYSCORE` only reads the matching members; it does not delete them. Because the result was ignored and there was no additional cleanup, old timestamps were never removed from the ZSET. When combined with the periodic `EXPIRE` on the key, a hot key could end up in a state where:

- The sorted set keeps accumulating entries.
- `ZCARD` eventually returns a value greater than or equal to `max_requests`.
- The key's TTL is constantly extended via `EXPIRE`, so it never naturally expires.
- The limiter reports `remaining = 0` and rejects all new requests indefinitely for that key.

The only way out of this state was an explicit `DEL` on the key (e.g., via `reset()` or manual intervention in Redis).

## Changes

The fix is minimal and targeted:

- In `src/rate_limiter/redis_limiter.rs` and `src/rate_limiter/redis_cluster_limiter.rs`, replace the cleanup call:

  ```rust
  // Remove all elements older than our window
  let _: () = conn
      .zrevrangebyscore(&redis_key, 0, window_start as i64)
      .await
      .map_err(|e| Error::Redis(format!("Failed to clean up Redis sorted set: {e}")))?;
  ```

  with:

  ```rust
  // Remove all elements older than our window
  let _: () = conn
      .zrembyscore(&redis_key, 0, window_start as i64)
      .await
      .map_err(|e| Error::Redis(format!("Failed to clean up Redis sorted set: {e}")))?;
  ```

- No configuration fields, public types, or external interfaces are changed.

## Impact

With this change:

- The sliding window behaves as intended:
  - Entries older than the configured window are actually removed from the ZSET.
  - Keys that see bursts of traffic recover naturally once the window has passed.
- The bug where a hot key could become permanently rate-limited is eliminated.
- The behavior of the limiter is now consistent with the existing comments and the expected semantics of a sliding-window algorithm.

This change is backward compatible from a configuration and API perspective and only affects the internal cleanup semantics of the rate limiter.

## Testing

- `cargo check` passes locally.
- Manual validation with Redis-backed rate limiting:
  - Generate requests up to and beyond the configured `max_requests` within the window and observe `429` as expected.
  - Wait for the window to elapse and confirm that:
    - the ZSET cardinality decreases as old entries are removed, and
    - new requests are accepted again without requiring manual Redis key deletion.
