### PR TITLE
fix: correct WebSocket close codes to match Pusher protocol specifica…

### DIFF
--- a/docs/ORIGIN_VALIDATION.md
+++ b/docs/ORIGIN_VALIDATION.md
@@ -208,13 +208,13 @@ When a connection is rejected due to origin validation, the client receives a Pu
 {
   "event": "pusher:error",
   "data": {
-    "code": 4200,
+    "code": 4009,
     "message": "Origin not allowed"
   }
 }
 ```
 
-Error code 4200 allows PusherJS clients to automatically reconnect after authentication failures.
+Error code 4009 indicates the connection is unauthorized and the client should not automatically reconnect with the same credentials.
 
 ### Implementation Details
 

--- a/src/adapter/handler/timeout_management.rs
+++ b/src/adapter/handler/timeout_management.rs
@@ -198,7 +198,7 @@ impl ConnectionHandler {
                 if !ws.state.is_authenticated() {
                     let _ = ws
                         .close(
-                            4200,
+                            4009,
                             "Connection not authorized within timeout.".to_string(),
                         )
                         .await;

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -74,9 +74,6 @@ pub enum Error {
     #[error("Invalid signature")]
     InvalidSignature,
 
-    #[error("Invalid key")]
-    InvalidKey,
-
     // Connection errors
     #[error("Connection error: {0}")]
     Connection(String),
@@ -182,8 +179,8 @@ impl Error {
             Error::InvalidVersionFormat => 4006,
             Error::UnsupportedProtocolVersion(_) => 4007,
             Error::NoProtocolVersion => 4008,
-            Error::Unauthorized => 4200,
-            Error::OriginNotAllowed => 4200,
+            Error::Unauthorized => 4009,
+            Error::OriginNotAllowed => 4009,
 
             // 4100-4199: Reconnect with backoff
             Error::OverCapacity => 4100,
@@ -207,7 +204,9 @@ impl Error {
 
             Error::ClientEvent(_) => 4301,
 
-            Error::Auth(_) | Error::InvalidSignature | Error::InvalidKey => 4200,
+            Error::Auth(_) | Error::InvalidSignature => 4009,
+
+            Error::InvalidAppKey => 4001,
 
             Error::Connection(_) | Error::ConnectionExists | Error::ConnectionNotFound => 4000,
 
@@ -226,6 +225,11 @@ impl Error {
                 | Error::InvalidVersionFormat
                 | Error::UnsupportedProtocolVersion(_)
                 | Error::NoProtocolVersion
+                | Error::Unauthorized
+                | Error::OriginNotAllowed
+                | Error::Auth(_)
+                | Error::InvalidSignature
+                | Error::InvalidAppKey
         )
     }
 
@@ -236,11 +240,6 @@ impl Error {
                 | Error::ReconnectImmediately
                 | Error::PongNotReceived
                 | Error::InactivityTimeout
-                | Error::Unauthorized
-                | Error::OriginNotAllowed
-                | Error::Auth(_)
-                | Error::InvalidSignature
-                | Error::InvalidKey
         )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1293,9 +1293,8 @@ impl SockudoServer {
                     .map(|(_app_id, ws_raw_obj)| {
                         async move {
                             let mut ws = ws_raw_obj.inner.lock().await; // Lock the WebSocketRef
-                            if let Err(e) = ws
-                                .close(4200, "You got disconnected by the app.".to_string())
-                                .await
+                            if let Err(e) =
+                                ws.close(4009, "User terminated by app.".to_string()).await
                             {
                                 error!("Failed to close WebSocket: {:?}", e);
                             }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -242,7 +242,7 @@ impl Namespace {
                 .iter()
                 .map(|ws_ref| async move {
                     if let Err(e) = ws_ref
-                        .close(4200, "You got disconnected by the app.".to_string())
+                        .close(4009, "User terminated by app.".to_string())
                         .await
                     {
                         warn!("Failed to close connection: {}", e);


### PR DESCRIPTION
…tion

Reverts incorrect close code changes from PR #138 that used 4200 for authentication failures. According to Pusher protocol and Soketi reference:

**Close Code Changes:**
- Auth errors (Unauthorized, Auth, InvalidSignature): 4200 → 4009
- OriginNotAllowed: 4200 → 4009
- InvalidAppKey: now correctly mapped to 4001
- Auth timeout: 4200 → 4009
- User terminated by app: 4200 → 4009

**Close Code Meanings:**
- 4001: Application does not exist (don't reconnect)
- 4009: Connection is unauthorized (don't reconnect with same credentials)
- 4200: Server issue, reconnect immediately (e.g., server shutdown)

**Why This Matters:**
Using 4200 for auth failures tells clients to "reconnect immediately", creating infinite reconnection loops when credentials are invalid. Code 4009 properly signals that authentication failed and clients should NOT automatically reconnect with the same credentials.

**Additional Changes:**
- Removed unused `InvalidKey` error variant (dead code)
- Updated ORIGIN_VALIDATION.md documentation
- Updated is_fatal() to include auth errors (4000-4099 range)
- Removed auth errors from should_reconnect() (they shouldn't reconnect)

**Comparison with Soketi:**
| Error Type              | Sockudo (Before) | Soketi | Sockudo (Fixed) |
|-------------------------|------------------|--------|-----------------|
| Invalid App Key         | 4200             | 4001   | 4001            |
| Auth Failure            | 4200             | 4009   | 4009            |
| Origin Not Allowed      | 4200             | 4009   | 4009            |
| User Terminated by App  | 4200             | 4009   | 4009            |
| Server Shutdown         | 4200             | 4200   | 4200            |

All tests pass successfully.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->