### PR TITLE
Fix dynamodb adapter find_by_key

### DIFF
--- a/src/app/dynamodb_app_manager.rs
+++ b/src/app/dynamodb_app_manager.rs
@@ -534,7 +534,8 @@ impl AppManager for DynamoDbAppManager {
             .query()
             .table_name(&self.config.table_name)
             .index_name("KeyIndex")
-            .key_condition_expression("key = :key_val")
+            .key_condition_expression("#app_key = :key_val")
+            .expression_attribute_names("#app_key", "key")
             .expression_attribute_values(
                 ":key_val",
                 aws_sdk_dynamodb::types::AttributeValue::S(key.to_string()),


### PR DESCRIPTION
Fix `find_by_key` failing with `ValidationException` when querying the `KeyIndex` GSI.

`key` is a [DynamoDB reserved keyword](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html).

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->