### PR TITLE
fix: restore close code 4200 for graceful shutdown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1311,8 +1311,7 @@ impl SockudoServer {
                     .map(|(_app_id, ws_raw_obj)| {
                         async move {
                             let mut ws = ws_raw_obj.inner.lock().await; // Lock the WebSocketRef
-                            if let Err(e) =
-                                ws.close(4009, "User terminated by app.".to_string()).await
+                            if let Err(e) = ws.close(4200, "Server shutting down".to_string()).await
                             {
                                 error!("Failed to close WebSocket: {:?}", e);
                             }


### PR DESCRIPTION
PR #139 incorrectly changed the WebSocket close code for graceful server shutdown from 4200 to 4009, breaking pusher-js auto-reconnect behavior.

According to Pusher protocol:
- 4000-4099: Client SHOULD NOT reconnect (auth failures, unauthorized)
- 4200-4299: Client SHOULD reconnect immediately (server going away)

Code 4009 means "Connection is unauthorized" which tells clients not to reconnect. The fix restores 4200 for server shutdown, matching Soketi's behavior.

Note: terminate_user_connections keeps 4009 as this is for API-initiated user termination where the app deliberately kicks users - this matches Soketi and is correct behavior.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->