### PR TITLE
Add cache to DynamoDB App Manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,16 @@ jobs:
             sleep 2
           done
 
+          # Wait for DynamoDB Local
+          for i in {1..30}; do
+            if curl -s http://localhost:18000 | grep -q 'MissingAuthenticationToken'; then
+              echo "DynamoDB Local is ready!"
+              break
+            fi
+            echo "Waiting for DynamoDB Local... ($i/30)"
+            sleep 2
+          done
+
       - name: Show running services
         run: |
           echo "=== Running Docker containers ==="
@@ -157,6 +167,7 @@ jobs:
           docker port $(docker ps -q -f "name=mysql-test") || true
           docker port $(docker ps -q -f "name=scylladb-test") || true
           docker port $(docker ps -q -f "name=postgres-test") || true
+          docker port $(docker ps -q -f "name=dynamodb-test") || true
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -197,6 +208,10 @@ jobs:
           DATABASE_POSTGRES_USER: postgres
           DATABASE_POSTGRES_PASSWORD: postgres123
           DATABASE_POSTGRES_DATABASE: sockudo_test
+
+          # DynamoDB Local configurations (matching docker-compose.test.yml)
+          DYNAMODB_ENDPOINT: http://localhost:18000
+          DYNAMODB_REGION: us-east-1
 
       - name: Cleanup test services
         if: always()

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -142,6 +142,23 @@ services:
       retries: 5
       start_period: 10s
 
+  # DynamoDB Local for testing
+  dynamodb-test:
+    image: amazon/dynamodb-local:latest
+    command: -jar DynamoDBLocal.jar -sharedDb -inMemory
+    ports:
+      - "18000:8000"
+    networks:
+      - sockudo-network
+    mem_limit: 256m
+    cpus: "0.5"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:8000 | grep -q 'MissingAuthenticationToken'"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
 networks:
   sockudo-network:
     driver: bridge

--- a/src/app/factory.rs
+++ b/src/app/factory.rs
@@ -58,6 +58,8 @@ impl AppManagerFactory {
                     access_key: dynamo_settings.aws_access_key_id.clone(),
                     secret_key: dynamo_settings.aws_secret_access_key.clone(),
                     profile_name: dynamo_settings.aws_profile_name.clone(),
+                    cache_ttl: dynamo_settings.cache_ttl,
+                    cache_max_capacity: dynamo_settings.cache_max_capacity,
                 };
                 match DynamoDbAppManager::new(dynamo_app_config).await {
                     Ok(manager) => Ok(Arc::new(manager)),

--- a/src/options.rs
+++ b/src/options.rs
@@ -93,7 +93,8 @@ pub struct DynamoDbSettings {
     pub aws_access_key_id: Option<String>,
     pub aws_secret_access_key: Option<String>,
     pub aws_profile_name: Option<String>,
-    // cache_ttl for app_manager is already in AppManagerConfig.cache.ttl
+    pub cache_ttl: u64,
+    pub cache_max_capacity: u64,
 }
 
 impl Default for DynamoDbSettings {
@@ -105,6 +106,8 @@ impl Default for DynamoDbSettings {
             aws_access_key_id: None,
             aws_secret_access_key: None,
             aws_profile_name: None,
+            cache_ttl: 3600,
+            cache_max_capacity: 10000,
         }
     }
 }
@@ -1591,6 +1594,8 @@ impl ServerOptions {
             self.channel_limits.cache_ttl = cache_ttl;
             self.database.mysql.cache_ttl = cache_ttl;
             self.database.postgres.cache_ttl = cache_ttl;
+            self.database.dynamodb.cache_ttl = cache_ttl;
+            self.database.scylladb.cache_ttl = cache_ttl;
             self.cache.memory.ttl = cache_ttl;
         }
         if let Some(cleanup_interval) = parse_env_optional::<u64>("CACHE_CLEANUP_INTERVAL") {
@@ -1601,6 +1606,8 @@ impl ServerOptions {
         if let Some(max_capacity) = parse_env_optional::<u64>("CACHE_MAX_CAPACITY") {
             self.database.mysql.cache_max_capacity = max_capacity;
             self.database.postgres.cache_max_capacity = max_capacity;
+            self.database.dynamodb.cache_max_capacity = max_capacity;
+            self.database.scylladb.cache_max_capacity = max_capacity;
             self.cache.memory.max_capacity = max_capacity;
         }
 


### PR DESCRIPTION
The DynamoDB App Manager was missing in-memory caching, causing every `find_by_id()` call to query DynamoDB directly.

- Add Moka cache with configurable TTL and max capacity
- Cache apps on create, update, and retrieval
- Invalidate cache on delete
- Support global CACHE_TTL_SECONDS and CACHE_MAX_CAPACITY env vars
- Add DynamoDB Local to docker-compose.test.yml and CI workflow
- Add unit tests for cache behavior, invalidation, and TTL expiration

This matches the caching pattern already used in other app managers.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->