### PR TITLE
fix: standardize env vars to _USERNAME and unify config loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           # MySQL configurations (matching docker-compose.test.yml)
           DATABASE_MYSQL_HOST: localhost
           DATABASE_MYSQL_PORT: 13306
-          DATABASE_MYSQL_USER: root
+          DATABASE_MYSQL_USERNAME: root
           DATABASE_MYSQL_PASSWORD: root123
           DATABASE_MYSQL_DATABASE: sockudo
 
@@ -205,7 +205,7 @@ jobs:
           # PostgreSQL configurations (matching docker-compose.test.yml)
           DATABASE_POSTGRES_HOST: localhost
           DATABASE_POSTGRES_PORT: 15432
-          DATABASE_POSTGRES_USER: postgres
+          DATABASE_POSTGRES_USERNAME: postgres
           DATABASE_POSTGRES_PASSWORD: postgres123
           DATABASE_POSTGRES_DATABASE: sockudo_test
 

--- a/src/app/factory.rs
+++ b/src/app/factory.rs
@@ -165,7 +165,7 @@ impl AppManagerFactory {
                 inner,
                 cache_manager,
                 config.cache.clone(),
-            )))
+            )) as Arc<dyn AppManager + Send + Sync>)
         } else {
             Ok(inner)
         }


### PR DESCRIPTION
- Standardize DATABASE_MYSQL_USERNAME/DATABASE_POSTGRES_USERNAME across CI and code
- Refactor tests to use centralized config system instead of direct env access
- Fix AppManagerFactory type consistency
- Maintain consistency with NATS_USERNAME convention

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->