### PR TITLE
feat: add Redis Sentinel support for high availability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Sockudo uses Cargo feature flags to allow compiling only the backends you need, 
 - `redis-cluster` - Redis Cluster support (implies `redis`)
 - `nats` - NATS adapter for horizontal scaling
 - `mysql` - MySQL app manager
+- `scylla` - ScyllaDB app manager
 - `postgres` - PostgreSQL app manager
 - `dynamodb` - DynamoDB app manager
 - `sqs` - AWS SQS queue backend
@@ -219,7 +220,42 @@ Key variables (see `.env.example` for complete list):
 ### Redis/NATS Configuration
 - Redis: Set `DATABASE_REDIS_HOST`, `DATABASE_REDIS_PORT`, `DATABASE_REDIS_PASSWORD`
 - Redis Cluster: Set `REDIS_CLUSTER_NODES` as comma-separated list
+- Redis Sentinel: Configure via `database.redis.sentinels` array in config file (see below)
 - NATS: Set `NATS_SERVERS` as comma-separated list (e.g., "nats://localhost:4222")
+
+#### Redis Sentinel Configuration
+Redis Sentinel provides high availability for Redis. When sentinels are configured, Sockudo automatically uses the Sentinel protocol to discover the current master.
+
+**Configuration File Example:**
+```json
+{
+  "database": {
+    "redis": {
+      "sentinels": [
+        { "host": "sentinel1.example.com", "port": 26379 },
+        { "host": "sentinel2.example.com", "port": 26379 },
+        { "host": "sentinel3.example.com", "port": 26379 }
+      ],
+      "sentinel_password": "optional-sentinel-auth",
+      "name": "mymaster",
+      "password": "optional-redis-master-password",
+      "db": 0,
+      "key_prefix": "sockudo:"
+    }
+  }
+}
+```
+
+**Configuration Options:**
+- `sentinels` - Array of sentinel nodes with `host` and `port`
+- `sentinel_password` - Optional password for authenticating with sentinel nodes
+- `name` - The master name monitored by sentinels (default: "mymaster")
+- `password` - Optional password for the Redis master instance
+- `username` - Optional username for Redis ACL authentication
+- `db` - Database number to use (default: 0)
+
+When sentinels are configured, the connection URL is automatically built in the format:
+`redis+sentinel://[sentinelpass@]host1:port1,host2:port2/master-name/db[?password=masterpass]`
 
 ## Development Guidelines
 

--- a/config/config.json
+++ b/config/config.json
@@ -83,8 +83,12 @@
       "host": "redis",
       "port": 6379,
       "db": 0,
+      "username": null,
+      "password": null,
       "key_prefix": "sockudo:",
       "sentinels": [],
+      "sentinel_password": null,
+      "name": "mymaster",
       "cluster_nodes": []
     },
     "mysql": {

--- a/src/adapter/factory.rs
+++ b/src/adapter/factory.rs
@@ -43,9 +43,7 @@ impl AdapterFactory {
                     .get("url")
                     .and_then(|v| v.as_str())
                     .map(String::from)
-                    .unwrap_or_else(|| {
-                        format!("redis://{}:{}", db_config.redis.host, db_config.redis.port)
-                    });
+                    .unwrap_or_else(|| db_config.redis.to_url());
 
                 let adapter_options = RedisAdapterOptions {
                     url: redis_url,

--- a/src/cache/factory.rs
+++ b/src/cache/factory.rs
@@ -76,12 +76,11 @@ impl CacheManagerFactory {
             #[cfg(feature = "redis")]
             CacheDriver::Redis => {
                 info!("Cache: Using standalone Redis driver with in-memory fallback.");
-                let redis_url = config.redis.url_override.clone().unwrap_or_else(|| {
-                    format!(
-                        "redis://{}:{}",
-                        global_redis_conn_details.host, global_redis_conn_details.port
-                    )
-                });
+                let redis_url = config
+                    .redis
+                    .url_override
+                    .clone()
+                    .unwrap_or_else(|| global_redis_conn_details.to_url());
 
                 let prefix = config
                     .redis

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,10 +428,7 @@ impl SockudoServer {
                             if let Some(url_override) = config.queue.redis.url_override.as_ref() {
                                 queue_redis_url_arg = Some(url_override.as_str());
                             } else {
-                                owned_default_queue_redis_url = format!(
-                                    "redis://{}:{}",
-                                    config.database.redis.host, config.database.redis.port
-                                );
+                                owned_default_queue_redis_url = config.database.redis.to_url();
                                 queue_redis_url_arg = Some(&owned_default_queue_redis_url);
                             }
 

--- a/src/rate_limiter/factory.rs
+++ b/src/rate_limiter/factory.rs
@@ -73,12 +73,11 @@ impl RateLimiterFactory {
     ) -> Result<Arc<dyn RateLimiter + Send + Sync>> {
         info!("RateLimiter: Using standalone Redis backend.");
 
-        let redis_url = config.redis.url_override.clone().unwrap_or_else(|| {
-            format!(
-                "redis://{}:{}",
-                global_redis_conn_details.host, global_redis_conn_details.port
-            )
-        });
+        let redis_url = config
+            .redis
+            .url_override
+            .clone()
+            .unwrap_or_else(|| global_redis_conn_details.to_url());
 
         let prefix = config
             .redis


### PR DESCRIPTION
- Add helper methods to RedisConnection for building URLs with Sentinel support
  - is_sentinel_configured(): checks if sentinels array is populated
  - to_url(): builds appropriate Redis URL (standard or sentinel)
  - build_sentinel_url(): creates redis+sentinel:// URLs

- Update all factories to use RedisConnection.to_url():
  - adapter/factory.rs
  - cache/factory.rs
  - rate_limiter/factory.rs
  - main.rs (queue initialization)

- Add comprehensive unit tests for URL building

- Update config/config.json with sentinel configuration fields:
  - sentinels array with host/port
  - sentinel_password for sentinel authentication
  - name for master name (default: mymaster)

- Add Redis Sentinel documentation to CLAUDE.md

Sentinel URL format:
redis+sentinel://[sentinelpass@]host1:port1,host2:port2/master-name/db[?password=masterpass]

Closes: Redis sentinels support issue

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->