### PR TITLE
fix: prevent NoDelayAcceptor from overwriting RustlsAcceptor on HTTPS path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1249,8 +1249,10 @@ impl SockudoServer {
             // Main HTTPS server
             info!("HTTPS server listening on https://{}", http_addr);
             let running = &self.state.running;
-            let server = axum_server::bind(http_addr)
-                .acceptor(RustlsAcceptor::new(tls_config).acceptor(axum_server::accept::NoDelayAcceptor::new()));
+            let server = axum_server::bind(http_addr).acceptor(
+                RustlsAcceptor::new(tls_config)
+                    .acceptor(axum_server::accept::NoDelayAcceptor::new()),
+            );
 
             tokio::select! {
                 result = server.serve(router_with_middleware_ssl.into_make_service_with_connect_info::<SocketAddr>()) => {


### PR DESCRIPTION
Fixes #172

`.acceptor(NoDelayAcceptor::new())` after `bind_rustls()` was replacing `RustlsAcceptor` instead of composing with it. This caused the HTTPS server to silently serve plain HTTP.

Fix: compose the acceptors so both TLS and TCP_NODELAY work together.