### PR TITLE
fix: wire CachedAppManager through AppManagerFactory with shared cache

### DIFF
--- a/src/app/factory.rs
+++ b/src/app/factory.rs
@@ -1,4 +1,5 @@
 // src/app/factory.rs
+use crate::app::cached_app_manager::CachedAppManager;
 #[cfg(feature = "dynamodb")]
 use crate::app::dynamodb_app_manager::{DynamoDbAppManager, DynamoDbConfig};
 use crate::app::manager::AppManager;
@@ -11,8 +12,10 @@ use crate::error::Result;
 use crate::app::pg_app_manager::PgSQLAppManager;
 #[cfg(feature = "scylladb")]
 use crate::app::scylla_app_manager::{ScyllaDbAppManager, ScyllaDbConfig};
+use crate::cache::manager::CacheManager;
 use crate::options::{AppManagerConfig, AppManagerDriver, DatabaseConfig, DatabasePooling};
 use std::sync::Arc;
+use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 pub struct AppManagerFactory;
@@ -23,17 +26,18 @@ impl AppManagerFactory {
         config: &AppManagerConfig,
         db_config: &DatabaseConfig,
         pooling: &DatabasePooling,
+        cache_manager: Arc<Mutex<dyn CacheManager + Send + Sync>>,
     ) -> Result<Arc<dyn AppManager + Send + Sync>> {
         info!(
             "{}",
             format!("Initializing AppManager with driver: {:?}", config.driver)
         );
-        match config.driver {
+        let inner: Arc<dyn AppManager + Send + Sync> = match config.driver {
             #[cfg(feature = "mysql")]
             AppManagerDriver::Mysql => {
                 let mysql_db_config = db_config.mysql.clone();
                 match MySQLAppManager::new(mysql_db_config, pooling.clone()).await {
-                    Ok(manager) => Ok(Arc::new(manager)),
+                    Ok(manager) => Arc::new(manager),
                     Err(e) => {
                         warn!(
                             "{}",
@@ -42,7 +46,7 @@ impl AppManagerFactory {
                                 e
                             )
                         );
-                        Ok(Arc::new(MemoryAppManager::new()))
+                        Arc::new(MemoryAppManager::new())
                     }
                 }
             }
@@ -59,7 +63,7 @@ impl AppManagerFactory {
                     profile_name: dynamo_settings.aws_profile_name.clone(),
                 };
                 match DynamoDbAppManager::new(dynamo_app_config).await {
-                    Ok(manager) => Ok(Arc::new(manager)),
+                    Ok(manager) => Arc::new(manager),
                     Err(e) => {
                         warn!(
                             "{}",
@@ -68,7 +72,7 @@ impl AppManagerFactory {
                                 e
                             )
                         );
-                        Ok(Arc::new(MemoryAppManager::new()))
+                        Arc::new(MemoryAppManager::new())
                     }
                 }
             }
@@ -76,7 +80,7 @@ impl AppManagerFactory {
             AppManagerDriver::PgSql => {
                 let pgsql_db_config = db_config.postgres.clone();
                 match PgSQLAppManager::new(pgsql_db_config, pooling.clone()).await {
-                    Ok(manager) => Ok(Arc::new(manager)),
+                    Ok(manager) => Arc::new(manager),
                     Err(e) => {
                         warn!(
                             "{}",
@@ -85,7 +89,7 @@ impl AppManagerFactory {
                                 e
                             )
                         );
-                        Ok(Arc::new(MemoryAppManager::new()))
+                        Arc::new(MemoryAppManager::new())
                     }
                 }
             }
@@ -103,7 +107,7 @@ impl AppManagerFactory {
                     replication_factor: scylla_settings.replication_factor,
                 };
                 match ScyllaDbAppManager::new(scylla_config).await {
-                    Ok(manager) => Ok(Arc::new(manager)),
+                    Ok(manager) => Arc::new(manager),
                     Err(e) => {
                         warn!(
                             "{}",
@@ -112,13 +116,13 @@ impl AppManagerFactory {
                                 e
                             )
                         );
-                        Ok(Arc::new(MemoryAppManager::new()))
+                        Arc::new(MemoryAppManager::new())
                     }
                 }
             }
             AppManagerDriver::Memory => {
                 info!("{}", "Using memory app manager.".to_string());
-                Ok(Arc::new(MemoryAppManager::new()))
+                Arc::new(MemoryAppManager::new())
             }
             #[cfg(not(feature = "mysql"))]
             AppManagerDriver::Mysql => {
@@ -126,7 +130,7 @@ impl AppManagerFactory {
                     "{}",
                     "MySQL app manager requested but not compiled in. Falling back to memory manager."
                 );
-                Ok(Arc::new(MemoryAppManager::new()))
+                Arc::new(MemoryAppManager::new())
             }
             #[cfg(not(feature = "dynamodb"))]
             AppManagerDriver::Dynamodb => {
@@ -134,7 +138,7 @@ impl AppManagerFactory {
                     "{}",
                     "DynamoDB app manager requested but not compiled in. Falling back to memory manager."
                 );
-                Ok(Arc::new(MemoryAppManager::new()))
+                Arc::new(MemoryAppManager::new())
             }
             #[cfg(not(feature = "postgres"))]
             AppManagerDriver::PgSql => {
@@ -142,7 +146,7 @@ impl AppManagerFactory {
                     "{}",
                     "PostgreSQL app manager requested but not compiled in. Falling back to memory manager."
                 );
-                Ok(Arc::new(MemoryAppManager::new()))
+                Arc::new(MemoryAppManager::new())
             }
             #[cfg(not(feature = "scylladb"))]
             AppManagerDriver::ScyllaDb => {
@@ -150,8 +154,18 @@ impl AppManagerFactory {
                     "{}",
                     "ScyllaDB app manager requested but not compiled in. Falling back to memory manager."
                 );
-                Ok(Arc::new(MemoryAppManager::new()))
+                Arc::new(MemoryAppManager::new())
             }
+        };
+
+        if config.cache.enabled {
+            Ok(Arc::new(CachedAppManager::new(
+                inner,
+                cache_manager,
+                config.cache.clone(),
+            )))
+        } else {
+            Ok(inner)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,39 +300,34 @@ impl SockudoServer {
             debug_enabled
         );
 
-        let app_manager: Arc<dyn AppManager + Send + Sync> = {
-            let inner = AppManagerFactory::create(
-                &config.app_manager,
-                &config.database,
-                &config.database_pooling,
-            )
-            .await?;
-
-            if config.app_manager.cache.enabled {
-                info!(
-                    "Wrapping AppManager with CachedAppManager (ttl: {}s)",
-                    config.app_manager.cache.ttl
+        let cache_manager = CacheManagerFactory::create(&config.cache, &config.database.redis)
+            .await
+            .unwrap_or_else(|e| {
+                warn!(
+                    "CacheManagerFactory creation failed: {}. Using a NoOp (Memory) Cache.",
+                    e
                 );
-                let app_cache = Arc::new(Mutex::new(MemoryCacheManager::new(
-                    "app_cache".to_string(),
-                    crate::options::MemoryCacheOptions {
-                        ttl: config.app_manager.cache.ttl,
-                        cleanup_interval: 60,
-                        max_capacity: 1000,
-                    },
-                )));
-                Arc::new(crate::app::cached_app_manager::CachedAppManager::new(
-                    inner,
-                    app_cache,
-                    config.app_manager.cache.clone(),
-                ))
-            } else {
-                inner
-            }
-        };
+                let fallback_cache_options = config.cache.memory.clone();
+                Arc::new(Mutex::new(MemoryCacheManager::new(
+                    "fallback_cache".to_string(),
+                    fallback_cache_options,
+                )))
+            });
         info!(
-            "AppManager initialized with driver: {:?}",
-            config.app_manager.driver
+            "CacheManager initialized with driver: {:?}",
+            config.cache.driver
+        );
+
+        let app_manager = AppManagerFactory::create(
+            &config.app_manager,
+            &config.database,
+            &config.database_pooling,
+            cache_manager.clone(),
+        )
+        .await?;
+        info!(
+            "AppManager initialized with driver: {:?} (cache: {})",
+            config.app_manager.driver, config.app_manager.cache.enabled
         );
 
         let (connection_manager, typed_adapter) =
@@ -365,24 +360,6 @@ impl SockudoServer {
             info!("Cluster health disabled, skipping dead node cleanup event bus setup");
             None
         };
-
-        let cache_manager = CacheManagerFactory::create(&config.cache, &config.database.redis)
-            .await
-            .unwrap_or_else(|e| {
-                warn!(
-                    "CacheManagerFactory creation failed: {}. Using a NoOp (Memory) Cache.",
-                    e
-                );
-                let fallback_cache_options = config.cache.memory.clone();
-                Arc::new(Mutex::new(MemoryCacheManager::new(
-                    "fallback_cache".to_string(),
-                    fallback_cache_options,
-                )))
-            });
-        info!(
-            "CacheManager initialized with driver: {:?}",
-            config.cache.driver
-        );
 
         let auth_validator = Arc::new(AuthValidator::new(app_manager.clone()));
 


### PR DESCRIPTION
Missed in #174 — moves CachedAppManager wrapping from main.rs into the factory and uses the configured CacheManager instead of a hardcoded MemoryCacheManager.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->