### PR TITLE
Fix webhook batching and filter handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -534,6 +534,7 @@ impl SockudoServer {
             batching: BatchingConfig {
                 enabled: config.webhooks.batching.enabled,
                 duration: config.webhooks.batching.duration,
+                size: config.webhooks.batching.size,
             },
             process_id: config.instance.process_id.clone(),
             debug: config.debug,

--- a/src/options.rs
+++ b/src/options.rs
@@ -1616,6 +1616,7 @@ pub struct WebhooksConfig {
 pub struct BatchingConfig {
     pub enabled: bool,
     pub duration: u64, // ms
+    pub size: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2034,6 +2035,7 @@ impl Default for BatchingConfig {
         Self {
             enabled: true,
             duration: 50,
+            size: 100,
         }
     }
 }
@@ -2421,6 +2423,8 @@ impl ServerOptions {
             parse_bool_env("WEBHOOK_BATCHING_ENABLED", self.webhooks.batching.enabled);
         self.webhooks.batching.duration =
             parse_env::<u64>("WEBHOOK_BATCHING_DURATION", self.webhooks.batching.duration);
+        self.webhooks.batching.size =
+            parse_env::<usize>("WEBHOOK_BATCHING_SIZE", self.webhooks.batching.size);
 
         // --- NATS Adapter ---
         if let Ok(servers) = std::env::var("NATS_SERVERS") {

--- a/src/webhook/integration.rs
+++ b/src/webhook/integration.rs
@@ -42,6 +42,7 @@ impl Default for WebhookConfig {
 pub struct BatchingConfig {
     pub enabled: bool,
     pub duration: u64, // in milliseconds
+    pub size: usize,
 }
 
 impl Default for BatchingConfig {
@@ -49,6 +50,7 @@ impl Default for BatchingConfig {
         Self {
             enabled: false,
             duration: 50,
+            size: 100,
         }
     }
 }
@@ -125,6 +127,7 @@ impl WebhookIntegration {
         let queue_manager_clone = self.queue_manager.clone();
         let batched_webhooks_clone = self.batched_webhooks.clone();
         let batch_duration = self.config.batching.duration;
+        let batch_size = self.config.batching.size.max(1);
 
         tokio::spawn(async move {
             let mut interval = interval(Duration::from_millis(batch_duration));
@@ -148,8 +151,8 @@ impl WebhookIntegration {
 
                 if let Some(qm) = &queue_manager_clone {
                     for (queue_name, jobs) in webhooks_to_process {
-                        for job in jobs {
-                            if let Err(e) = qm.add_to_queue(&queue_name, job).await {
+                        for batch in Self::merge_jobs_for_queue(jobs, batch_size) {
+                            if let Err(e) = qm.add_to_queue(&queue_name, batch).await {
                                 error!(
                                     "{}",
                                     format!(
@@ -187,6 +190,85 @@ impl WebhookIntegration {
             ));
         }
         Ok(())
+    }
+
+    fn merge_jobs_for_queue(jobs: Vec<JobData>, batch_size: usize) -> Vec<JobData> {
+        let mut merged = Vec::new();
+        let mut current: Option<JobData> = None;
+        let batch_size = batch_size.max(1);
+
+        for job in jobs {
+            for chunk in Self::split_job_by_size(job, batch_size) {
+                match current.as_mut() {
+                    Some(existing)
+                        if existing.app_id == chunk.app_id
+                            && existing.app_key == chunk.app_key
+                            && existing.app_secret == chunk.app_secret
+                            && existing.payload.events.len() + chunk.payload.events.len()
+                                <= batch_size =>
+                    {
+                        existing.payload.time_ms =
+                            existing.payload.time_ms.min(chunk.payload.time_ms);
+                        existing.payload.events.extend(chunk.payload.events);
+                    }
+                    Some(_) => {
+                        if let Some(finished) = current.take() {
+                            merged.push(finished);
+                        }
+                        current = Some(chunk);
+                    }
+                    None => current = Some(chunk),
+                }
+            }
+        }
+
+        if let Some(finished) = current {
+            merged.push(finished);
+        }
+
+        merged
+    }
+
+    fn split_job_by_size(job: JobData, batch_size: usize) -> Vec<JobData> {
+        let batch_size = batch_size.max(1);
+        let JobData {
+            app_key,
+            app_id,
+            app_secret,
+            payload,
+            original_signature,
+        } = job;
+
+        let JobPayload { time_ms, events } = payload;
+        let mut chunks = Vec::new();
+
+        for event_chunk in events.chunks(batch_size) {
+            chunks.push(JobData {
+                app_key: app_key.clone(),
+                app_id: app_id.clone(),
+                app_secret: app_secret.clone(),
+                payload: JobPayload {
+                    time_ms,
+                    events: event_chunk.to_vec(),
+                },
+                original_signature: original_signature.clone(),
+            });
+        }
+
+        if chunks.is_empty() {
+            chunks.push(JobData {
+                app_key,
+                app_id,
+                app_secret,
+                payload: JobPayload {
+                    time_ms,
+                    events: Vec::new(),
+                },
+                original_signature,
+            });
+        }
+
+        chunks
     }
 
     fn create_job_data(
@@ -454,6 +536,7 @@ mod tests {
             batching: BatchingConfig {
                 enabled: true,
                 duration: 1000,
+                size: 50,
             },
             process_id: "test-process".to_string(),
             debug: false,
@@ -465,6 +548,7 @@ mod tests {
         assert_eq!(config.enabled, deserialized.enabled);
         assert_eq!(config.batching.enabled, deserialized.batching.enabled);
         assert_eq!(config.batching.duration, deserialized.batching.duration);
+        assert_eq!(config.batching.size, deserialized.batching.size);
     }
 
     #[tokio::test]
@@ -678,5 +762,73 @@ mod tests {
             .send_subscription_count_changed(&app, "test_channel", 5)
             .await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_merge_jobs_for_queue_batches_by_app_and_size() {
+        let jobs = vec![
+            JobData {
+                app_key: "key-a".to_string(),
+                app_id: "app-a".to_string(),
+                app_secret: "secret-a".to_string(),
+                payload: JobPayload {
+                    time_ms: 10,
+                    events: vec![json!({"name": "channel_occupied", "channel": "one"})],
+                },
+                original_signature: "sig-1".to_string(),
+            },
+            JobData {
+                app_key: "key-a".to_string(),
+                app_id: "app-a".to_string(),
+                app_secret: "secret-a".to_string(),
+                payload: JobPayload {
+                    time_ms: 20,
+                    events: vec![json!({"name": "channel_vacated", "channel": "two"})],
+                },
+                original_signature: "sig-2".to_string(),
+            },
+            JobData {
+                app_key: "key-b".to_string(),
+                app_id: "app-b".to_string(),
+                app_secret: "secret-b".to_string(),
+                payload: JobPayload {
+                    time_ms: 30,
+                    events: vec![json!({"name": "channel_occupied", "channel": "three"})],
+                },
+                original_signature: "sig-3".to_string(),
+            },
+        ];
+
+        let merged = WebhookIntegration::merge_jobs_for_queue(jobs, 2);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].app_id, "app-a");
+        assert_eq!(merged[0].payload.events.len(), 2);
+        assert_eq!(merged[1].app_id, "app-b");
+        assert_eq!(merged[1].payload.events.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_jobs_for_queue_splits_oversized_jobs() {
+        let job = JobData {
+            app_key: "key-a".to_string(),
+            app_id: "app-a".to_string(),
+            app_secret: "secret-a".to_string(),
+            payload: JobPayload {
+                time_ms: 10,
+                events: vec![
+                    json!({"name": "channel_occupied", "channel": "one"}),
+                    json!({"name": "channel_occupied", "channel": "two"}),
+                    json!({"name": "channel_occupied", "channel": "three"}),
+                ],
+            },
+            original_signature: "sig-1".to_string(),
+        };
+
+        let merged = WebhookIntegration::merge_jobs_for_queue(vec![job], 2);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].payload.events.len(), 2);
+        assert_eq!(merged[1].payload.events.len(), 1);
     }
 }

--- a/src/webhook/sender.rs
+++ b/src/webhook/sender.rs
@@ -9,7 +9,7 @@ use crate::webhook::lambda_sender::LambdaWebhookSender;
 // JobData now contains app_secret and its payload.events is Vec<Value>
 // PusherWebhookPayload is the structure for the final POST body
 use crate::token::Token; // For HMAC SHA256 signing
-use crate::webhook::types::{JobData, PusherWebhookPayload, Webhook};
+use crate::webhook::types::{JobData, JobPayload, PusherWebhookPayload, Webhook, WebhookFilter};
 use ahash::AHashMap;
 use reqwest::{Client, header};
 use sonic_rs::Value;
@@ -94,30 +94,85 @@ impl WebhookSender {
         Ok((pusher_payload, body_json_string))
     }
 
+    fn event_matches_webhook_filter(&self, event: &Value, filter: Option<&WebhookFilter>) -> bool {
+        let Some(filter) = filter else {
+            return true;
+        };
+
+        let channel = event
+            .get("channel")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+
+        if let Some(prefix) = &filter.channel_prefix
+            && !channel.starts_with(prefix)
+        {
+            return false;
+        }
+
+        if let Some(suffix) = &filter.channel_suffix
+            && !channel.ends_with(suffix)
+        {
+            return false;
+        }
+
+        if let Some(pattern) = &filter.channel_pattern {
+            let Ok(regex) = regex::Regex::new(pattern) else {
+                warn!(
+                    "Ignoring invalid webhook channel_pattern regex: {}",
+                    pattern
+                );
+                return false;
+            };
+
+            if !regex.is_match(channel) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn filter_events_for_webhook(&self, events: &[Value], webhook_config: &Webhook) -> Vec<Value> {
+        events
+            .iter()
+            .filter(|event| {
+                event
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|event_name| {
+                        webhook_config.event_types.contains(&event_name.to_string())
+                            && self
+                                .event_matches_webhook_filter(event, webhook_config.filter.as_ref())
+                    })
+            })
+            .cloned()
+            .collect()
+    }
+
     fn find_relevant_webhooks<'a>(
         &self,
         events: &[Value],
         webhook_configs: &'a [Webhook],
-    ) -> AHashMap<String, &'a Webhook> {
+    ) -> AHashMap<String, (&'a Webhook, Vec<Value>)> {
         let mut relevant_configs = AHashMap::new();
 
-        for event_value in events {
-            if let Some(event_name) = event_value.get("name").and_then(Value::as_str) {
-                for wh_config in webhook_configs {
-                    if wh_config.event_types.contains(&event_name.to_string()) {
-                        let key = wh_config
-                            .url
-                            .as_ref()
-                            .map(|u| u.to_string())
-                            .or_else(|| wh_config.lambda_function.clone())
-                            .or_else(|| wh_config.lambda.as_ref().map(|l| l.function_name.clone()))
-                            .unwrap_or_else(String::new);
+        for wh_config in webhook_configs {
+            let filtered_events = self.filter_events_for_webhook(events, wh_config);
+            if filtered_events.is_empty() {
+                continue;
+            }
 
-                        if !key.is_empty() {
-                            relevant_configs.entry(key).or_insert(wh_config);
-                        }
-                    }
-                }
+            let key = wh_config
+                .url
+                .as_ref()
+                .map(|u| u.to_string())
+                .or_else(|| wh_config.lambda_function.clone())
+                .or_else(|| wh_config.lambda.as_ref().map(|l| l.function_name.clone()))
+                .unwrap_or_else(String::new);
+
+            if !key.is_empty() {
+                relevant_configs.insert(key, (wh_config, filtered_events));
             }
         }
         relevant_configs
@@ -145,9 +200,7 @@ impl WebhookSender {
             .await?;
 
         // Create payload and signature
-        let (pusher_payload, body_json_string) = self.create_pusher_payload(&job)?;
-        let signature =
-            Token::new(job.app_key.clone(), job.app_secret.clone()).sign(&body_json_string);
+        let (pusher_payload, _body_json_string) = self.create_pusher_payload(&job)?;
 
         // Find relevant webhooks
         let relevant_webhooks = self.find_relevant_webhooks(&job.payload.events, webhook_configs);
@@ -163,7 +216,7 @@ impl WebhookSender {
 
         // Process webhooks
         let mut tasks = Vec::new();
-        for (_endpoint_key, webhook_config) in relevant_webhooks {
+        for (_endpoint_key, (webhook_config, filtered_events)) in relevant_webhooks {
             let permit = self
                 .webhook_semaphore
                 .clone()
@@ -173,13 +226,24 @@ impl WebhookSender {
                     Error::Other(format!("Failed to acquire webhook semaphore permit: {e}"))
                 })?;
 
+            let filtered_job = JobData {
+                payload: JobPayload {
+                    time_ms: job.payload.time_ms,
+                    events: filtered_events,
+                },
+                ..job.clone()
+            };
+            let (_, filtered_body_json_string) = self.create_pusher_payload(&filtered_job)?;
+            let filtered_signature = Token::new(job.app_key.clone(), job.app_secret.clone())
+                .sign(&filtered_body_json_string);
+
             let task = self.create_webhook_task(
                 webhook_config,
                 permit,
                 app_id.clone(),
                 app_key.clone(),
-                signature.clone(),
-                body_json_string.clone(),
+                filtered_signature,
+                filtered_body_json_string,
             );
             tasks.push(task);
         }
@@ -515,5 +579,86 @@ mod tests {
         for result in results {
             assert!(result.unwrap().is_ok());
         }
+    }
+
+    #[test]
+    fn test_filter_events_for_webhook_respects_channel_prefix() {
+        let webhook_sender = WebhookSender::new(Arc::new(MemoryAppManager::new()));
+        let webhook = Webhook {
+            url: Some(url::Url::parse("http://localhost/webhook").unwrap()),
+            lambda_function: None,
+            lambda: None,
+            event_types: vec!["channel_occupied".to_string()],
+            filter: Some(WebhookFilter {
+                channel_prefix: Some("#server-to-user".to_string()),
+                channel_suffix: None,
+                channel_pattern: None,
+            }),
+            headers: None,
+        };
+
+        let filtered = webhook_sender.filter_events_for_webhook(
+            &[
+                sonic_rs::json!({
+                    "name": "channel_occupied",
+                    "channel": "#server-to-user-123"
+                }),
+                sonic_rs::json!({
+                    "name": "channel_occupied",
+                    "channel": "private-conversation.123"
+                }),
+            ],
+            &webhook,
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(
+            filtered[0].get("channel").and_then(Value::as_str),
+            Some("#server-to-user-123")
+        );
+    }
+
+    #[test]
+    fn test_find_relevant_webhooks_splits_events_per_endpoint() {
+        let webhook_sender = WebhookSender::new(Arc::new(MemoryAppManager::new()));
+        let prefixed = Webhook {
+            url: Some(url::Url::parse("http://localhost/prefix").unwrap()),
+            lambda_function: None,
+            lambda: None,
+            event_types: vec!["channel_occupied".to_string()],
+            filter: Some(WebhookFilter {
+                channel_prefix: Some("#server-to-user".to_string()),
+                channel_suffix: None,
+                channel_pattern: None,
+            }),
+            headers: None,
+        };
+        let catch_all = Webhook {
+            url: Some(url::Url::parse("http://localhost/all").unwrap()),
+            lambda_function: None,
+            lambda: None,
+            event_types: vec!["channel_occupied".to_string()],
+            filter: None,
+            headers: None,
+        };
+
+        let webhooks = [prefixed.clone(), catch_all.clone()];
+        let relevant = webhook_sender.find_relevant_webhooks(
+            &[
+                sonic_rs::json!({
+                    "name": "channel_occupied",
+                    "channel": "#server-to-user-1"
+                }),
+                sonic_rs::json!({
+                    "name": "channel_occupied",
+                    "channel": "private-conversation.1"
+                }),
+            ],
+            &webhooks,
+        );
+
+        assert_eq!(relevant.len(), 2);
+        assert_eq!(relevant.get("http://localhost/prefix").unwrap().1.len(), 1);
+        assert_eq!(relevant.get("http://localhost/all").unwrap().1.len(), 2);
     }
 }


### PR DESCRIPTION
## Summary
- enforce webhook channel filters when routing events to endpoints
- batch queued webhook events by app and honor 
- add regression coverage for filtering and batching behavior

## Verification
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test webhook --lib