### PR TITLE
Fix partial cluster channel counts

### DIFF
--- a/src/adapter/connection_manager.rs
+++ b/src/adapter/connection_manager.rs
@@ -15,6 +15,12 @@ pub type DeadNodeEventBusFlavor = mpsc::List<crate::adapter::horizontal_adapter:
 pub type DeadNodeEventBusSender = crossfire::MTx<DeadNodeEventBusFlavor>;
 pub type DeadNodeEventBusReceiver = crossfire::AsyncRx<DeadNodeEventBusFlavor>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelSocketCount {
+    pub count: usize,
+    pub complete: bool,
+}
+
 /// Parameters for delta compression when sending messages
 pub struct CompressionParams<'a> {
     pub delta_compression: Arc<crate::delta_compression::DeltaCompressionManager>,
@@ -113,6 +119,11 @@ pub trait ConnectionManager: Send + Sync {
     async fn cleanup_connection(&self, app_id: &str, ws: WebSocketRef);
     async fn terminate_connection(&self, app_id: &str, user_id: &str) -> Result<()>;
     async fn add_channel_to_sockets(&self, app_id: &str, channel: &str, socket_id: &SocketId);
+    async fn get_channel_socket_count_info(
+        &self,
+        app_id: &str,
+        channel: &str,
+    ) -> ChannelSocketCount;
     async fn get_channel_socket_count(&self, app_id: &str, channel: &str) -> usize;
     async fn add_to_channel(
         &self,

--- a/src/adapter/horizontal_adapter.rs
+++ b/src/adapter/horizontal_adapter.rs
@@ -82,6 +82,16 @@ pub struct ResponseBody {
     pub exists: bool,
     pub channels: HashSet<String>,
     pub members_count: usize, // New field for ChannelMembersCount
+    #[serde(default)]
+    pub responses_received: usize,
+    #[serde(default)]
+    pub expected_responses: usize,
+    #[serde(default = "default_true")]
+    pub complete: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Message for broadcasting events
@@ -120,6 +130,13 @@ pub struct PendingRequest {
     pub(crate) app_id: String,
     pub(crate) responses: Vec<ResponseBody>,
     pub(crate) notify: Arc<Notify>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AggregationStats {
+    pub responses_received: usize,
+    pub expected_responses: usize,
+    pub complete: bool,
 }
 
 /// Presence entry for cluster-wide presence tracking
@@ -269,6 +286,9 @@ impl HorizontalAdapter {
             exists: false,
             channels: HashSet::new(),
             members_count: 0,
+            responses_received: 0,
+            expected_responses: 0,
+            complete: true,
         };
 
         // Process based on request type
@@ -615,6 +635,9 @@ impl HorizontalAdapter {
                 exists: false,
                 channels: HashSet::new(),
                 members_count: 0,
+                responses_received: 0,
+                expected_responses: 0,
+                complete: true,
             });
         }
 
@@ -671,12 +694,19 @@ impl HorizontalAdapter {
         };
 
         // Use the aggregation method
+        let responses_received = responses.len();
+        let complete = responses_received >= max_expected_responses;
         let combined_response = self.aggregate_responses(
             request_id.clone(),
             self.node_id.clone(),
             app_id.to_string(),
             &request_type,
             responses,
+            AggregationStats {
+                responses_received,
+                expected_responses: max_expected_responses,
+                complete,
+            },
         );
 
         // Validate the aggregated response
@@ -715,6 +745,7 @@ impl HorizontalAdapter {
         app_id: String,
         request_type: &RequestType,
         responses: Vec<ResponseBody>,
+        stats: AggregationStats,
     ) -> ResponseBody {
         let mut combined_response = ResponseBody {
             request_id,
@@ -727,6 +758,9 @@ impl HorizontalAdapter {
             exists: false,
             channels: HashSet::new(),
             members_count: 0,
+            responses_received: stats.responses_received,
+            expected_responses: stats.expected_responses,
+            complete: stats.complete,
         };
 
         if responses.is_empty() {

--- a/src/adapter/horizontal_adapter_base.rs
+++ b/src/adapter/horizontal_adapter_base.rs
@@ -9,8 +9,8 @@ use crate::adapter::connection_manager::{
     ConnectionManager, DeadNodeEventBusReceiver, DeadNodeEventBusSender, HorizontalAdapterInterface,
 };
 use crate::adapter::horizontal_adapter::{
-    BroadcastMessage, DeadNodeEvent, HorizontalAdapter, OrphanedMember, PendingRequest,
-    RequestBody, RequestType, ResponseBody, current_timestamp, generate_request_id,
+    AggregationStats, BroadcastMessage, DeadNodeEvent, HorizontalAdapter, OrphanedMember,
+    PendingRequest, RequestBody, RequestType, ResponseBody, current_timestamp, generate_request_id,
 };
 use crate::adapter::horizontal_transport::{
     HorizontalTransport, TransportConfig, TransportHandlers,
@@ -240,6 +240,9 @@ where
                 exists: false,
                 channels: HashSet::new(),
                 members_count: 0,
+                responses_received: 0,
+                expected_responses: 0,
+                complete: true,
             });
         }
 
@@ -272,7 +275,6 @@ where
         // For presence queries that need member data, use full timeout
         let timeout_duration = match request_type {
             RequestType::SocketExistsInChannel
-            | RequestType::ChannelSocketsCount
             | RequestType::SocketsCount
             | RequestType::Channels
             | RequestType::Sockets => {
@@ -281,7 +283,9 @@ where
                 let adaptive = (50 * node_count as u64).clamp(min_timeout, base_timeout);
                 Duration::from_millis(adaptive)
             }
-            RequestType::ChannelMembers | RequestType::ChannelMembersCount => {
+            RequestType::ChannelMembers
+            | RequestType::ChannelMembersCount
+            | RequestType::ChannelSocketsCount => {
                 // Presence queries need more time for data aggregation
                 Duration::from_millis(base_timeout)
             }
@@ -310,6 +314,9 @@ where
                 exists: false,
                 channels: HashSet::new(),
                 members_count: 0,
+                responses_received: 0,
+                expected_responses: 0,
+                complete: true,
             });
         }
 
@@ -402,6 +409,9 @@ where
             // If result is None, continue waiting (notification came but not enough responses yet)
         };
 
+        let responses_received = responses.len();
+        let complete = responses_received >= max_expected_responses;
+
         // Aggregate responses first, then clean up to prevent race condition
         let combined_response = {
             let horizontal = self.horizontal.read().await;
@@ -411,6 +421,11 @@ where
                 app_id.to_string(),
                 &request_type,
                 responses,
+                AggregationStats {
+                    responses_received,
+                    expected_responses: max_expected_responses,
+                    complete,
+                },
             )
         }; // horizontal lock released here
 
@@ -1283,7 +1298,11 @@ where
             .await;
     }
 
-    async fn get_channel_socket_count(&self, app_id: &str, channel: &str) -> usize {
+    async fn get_channel_socket_count_info(
+        &self,
+        app_id: &str,
+        channel: &str,
+    ) -> crate::adapter::connection_manager::ChannelSocketCount {
         // Get local count
         let local_count = self
             .local_adapter
@@ -1301,12 +1320,24 @@ where
             )
             .await
         {
-            Ok(response) => local_count + response.sockets_count,
+            Ok(response) => crate::adapter::connection_manager::ChannelSocketCount {
+                count: local_count + response.sockets_count,
+                complete: response.complete,
+            },
             Err(e) => {
                 error!("Failed to get remote channel socket count: {}", e);
-                local_count
+                crate::adapter::connection_manager::ChannelSocketCount {
+                    count: local_count,
+                    complete: false,
+                }
             }
         }
+    }
+
+    async fn get_channel_socket_count(&self, app_id: &str, channel: &str) -> usize {
+        self.get_channel_socket_count_info(app_id, channel)
+            .await
+            .count
     }
 
     async fn add_to_channel(

--- a/src/adapter/local_adapter.rs
+++ b/src/adapter/local_adapter.rs
@@ -1652,6 +1652,17 @@ impl ConnectionManager for LocalAdapter {
         namespace.add_channel_to_socket(channel, socket_id);
     }
 
+    async fn get_channel_socket_count_info(
+        &self,
+        app_id: &str,
+        channel: &str,
+    ) -> crate::adapter::connection_manager::ChannelSocketCount {
+        crate::adapter::connection_manager::ChannelSocketCount {
+            count: self.get_channel_socket_count(app_id, channel).await,
+            complete: true,
+        }
+    }
+
     async fn get_channel_socket_count(&self, app_id: &str, channel: &str) -> usize {
         let namespace = self.get_or_create_namespace(app_id).await;
         namespace.get_channel_socket_count(channel)

--- a/src/cleanup/worker.rs
+++ b/src/cleanup/worker.rs
@@ -299,12 +299,12 @@ impl CleanupWorker {
         // IMPORTANT: Acquire and release lock for each channel to minimize lock contention
         for channel in &task.subscribed_channels {
             // Acquire lock for minimal duration - just for this single channel check
-            let socket_count = self
+            let socket_count_info = self
                 .connection_manager
-                .get_channel_socket_count(&task.app_id, channel)
+                .get_channel_socket_count_info(&task.app_id, channel)
                 .await;
 
-            if socket_count == 0 {
+            if socket_count_info.complete && socket_count_info.count == 0 {
                 events.push(WebhookEvent {
                     event_type: "channel_vacated".to_string(),
                     app_id: task.app_id.clone(),

--- a/src/http_handler.rs
+++ b/src/http_handler.rs
@@ -777,10 +777,11 @@ pub async fn channel(
     let wants_user_count = info_query_str.wants_user_count();
     let wants_cache_data = info_query_str.wants_cache();
 
-    let socket_count_val = handler
+    let socket_count_info = handler
         .connection_manager
-        .get_channel_socket_count(&app_id, &channel_name)
+        .get_channel_socket_count_info(&app_id, &channel_name)
         .await;
+    let socket_count_val = socket_count_info.count;
 
     let user_count_val = if wants_user_count {
         if channel_name.starts_with("presence-") {
@@ -823,12 +824,15 @@ pub async fn channel(
     } else {
         None
     };
-    let response_payload = PusherMessage::channel_info(
+    let mut response_payload = PusherMessage::channel_info(
         socket_count_val > 0,
         subscription_count_val,
         user_count_val,
         cache_data_tuple,
     );
+    if wants_subscription_count && !socket_count_info.complete {
+        response_payload["subscription_count_complete"] = json!(false);
+    }
     let response_json_bytes = sonic_rs::to_vec(&response_payload)?;
     record_api_metrics(&handler, &app_id, 0, response_json_bytes.len()).await;
     debug!("Channel info for '{}' retrieved successfully", channel_name);

--- a/tests/adapter/cross_node_sync_tests.rs
+++ b/tests/adapter/cross_node_sync_tests.rs
@@ -1,6 +1,6 @@
 use crate::adapter::horizontal_adapter_helpers::{MockConfig, MockNodeState, MockTransport};
 use ahash::AHashMap;
-use sockudo::adapter::horizontal_adapter::{RequestType, ResponseBody};
+use sockudo::adapter::horizontal_adapter::{AggregationStats, RequestType, ResponseBody};
 use sockudo::adapter::horizontal_adapter_base::HorizontalAdapterBase;
 use std::collections::HashSet;
 
@@ -29,6 +29,9 @@ async fn test_request_response_aggregation_logic() {
             exists: true,
             channels: HashSet::new(),
             members_count: 0,
+            responses_received: 0,
+            expected_responses: 0,
+            complete: true,
         },
         // Response 2: Node has 1 socket in channel
         ResponseBody {
@@ -42,6 +45,9 @@ async fn test_request_response_aggregation_logic() {
             exists: true,
             channels: HashSet::new(),
             members_count: 0,
+            responses_received: 0,
+            expected_responses: 0,
+            complete: true,
         },
     ];
 
@@ -54,6 +60,11 @@ async fn test_request_response_aggregation_logic() {
             "test-app".to_string(),
             &RequestType::ChannelSockets,
             responses,
+            AggregationStats {
+                responses_received: 2,
+                expected_responses: 2,
+                complete: true,
+            },
         )
     };
 
@@ -62,6 +73,9 @@ async fn test_request_response_aggregation_logic() {
     assert_eq!(combined_response.app_id, "test-app");
     assert_eq!(combined_response.socket_ids.len(), 3); // Combined from both nodes
     assert_eq!(combined_response.sockets_count, 3); // Sum of both nodes
+    assert!(combined_response.complete);
+    assert_eq!(combined_response.responses_received, 2);
+    assert_eq!(combined_response.expected_responses, 2);
     // Note: exists field is not aggregated for ChannelSockets request type
 
     // Verify all socket IDs are present
@@ -112,6 +126,9 @@ async fn test_channel_members_aggregation_deduplication() {
         exists: false,
         channels: HashSet::new(),
         members_count: 2,
+        responses_received: 0,
+        expected_responses: 0,
+        complete: true,
     });
 
     // Node 2: Has user-1 (duplicate) and user-3 (unique)
@@ -142,6 +159,9 @@ async fn test_channel_members_aggregation_deduplication() {
         exists: false,
         channels: HashSet::new(),
         members_count: 2,
+        responses_received: 0,
+        expected_responses: 0,
+        complete: true,
     });
 
     // Test aggregation
@@ -153,6 +173,11 @@ async fn test_channel_members_aggregation_deduplication() {
             "test-app".to_string(),
             &RequestType::ChannelMembers,
             responses,
+            AggregationStats {
+                responses_received: 2,
+                expected_responses: 2,
+                complete: true,
+            },
         )
     };
 
@@ -197,6 +222,9 @@ async fn test_channels_with_socket_count_aggregation() {
         exists: false,
         channels: HashSet::new(),
         members_count: 0,
+        responses_received: 0,
+        expected_responses: 0,
+        complete: true,
     });
 
     // Node 2: Has channels A(3 sockets), C(1 socket)
@@ -215,6 +243,9 @@ async fn test_channels_with_socket_count_aggregation() {
         exists: false,
         channels: HashSet::new(),
         members_count: 0,
+        responses_received: 0,
+        expected_responses: 0,
+        complete: true,
     });
 
     // Test aggregation
@@ -226,6 +257,11 @@ async fn test_channels_with_socket_count_aggregation() {
             "test-app".to_string(),
             &RequestType::ChannelsWithSocketsCount,
             responses,
+            AggregationStats {
+                responses_received: 2,
+                expected_responses: 2,
+                complete: true,
+            },
         )
     };
 
@@ -269,6 +305,9 @@ async fn test_exists_flag_aggregation_logic() {
             exists: false, // All return false
             channels: HashSet::new(),
             members_count: 0,
+            responses_received: 0,
+            expected_responses: 0,
+            complete: true,
         });
     }
 
@@ -280,6 +319,11 @@ async fn test_exists_flag_aggregation_logic() {
             "test-app".to_string(),
             &RequestType::SocketExistsInChannel,
             responses,
+            AggregationStats {
+                responses_received: 3,
+                expected_responses: 3,
+                complete: true,
+            },
         )
     };
 
@@ -301,6 +345,9 @@ async fn test_exists_flag_aggregation_logic() {
             exists: false,
             channels: HashSet::new(),
             members_count: 0,
+            responses_received: 0,
+            expected_responses: 0,
+            complete: true,
         },
         ResponseBody {
             request_id: request_id.to_string(),
@@ -313,6 +360,9 @@ async fn test_exists_flag_aggregation_logic() {
             exists: true, // One returns true
             channels: HashSet::new(),
             members_count: 0,
+            responses_received: 0,
+            expected_responses: 0,
+            complete: true,
         },
     ];
 
@@ -324,6 +374,11 @@ async fn test_exists_flag_aggregation_logic() {
             "test-app".to_string(),
             &RequestType::SocketExistsInChannel,
             responses,
+            AggregationStats {
+                responses_received: 2,
+                expected_responses: 2,
+                complete: true,
+            },
         )
     };
 
@@ -449,6 +504,11 @@ async fn test_empty_response_aggregation() {
             "test-app".to_string(),
             &RequestType::ChannelSockets,
             responses,
+            AggregationStats {
+                responses_received: 0,
+                expected_responses: 2,
+                complete: false,
+            },
         )
     };
 
@@ -460,4 +520,7 @@ async fn test_empty_response_aggregation() {
     assert!(!combined_response.exists);
     assert!(combined_response.members.is_empty());
     assert!(combined_response.channels_with_sockets_count.is_empty());
+    assert!(!combined_response.complete);
+    assert_eq!(combined_response.responses_received, 0);
+    assert_eq!(combined_response.expected_responses, 2);
 }

--- a/tests/adapter/horizontal_adapter_helpers.rs
+++ b/tests/adapter/horizontal_adapter_helpers.rs
@@ -349,6 +349,9 @@ impl MockTransport {
                 exists: true,
                 channels: HashSet::new(),
                 members_count: 999_999_999,
+                responses_received: 0,
+                expected_responses: 0,
+                complete: true,
             };
         }
 
@@ -363,6 +366,9 @@ impl MockTransport {
             exists: false,
             channels: HashSet::new(),
             members_count: 0,
+            responses_received: 0,
+            expected_responses: 0,
+            complete: true,
         };
 
         match request.request_type {

--- a/tests/adapter/transports/test_helpers.rs
+++ b/tests/adapter/transports/test_helpers.rs
@@ -105,6 +105,9 @@ pub fn create_test_response(request_id: &str) -> ResponseBody {
         exists: false,
         channels: HashSet::new(),
         members_count: 0,
+        responses_received: 0,
+        expected_responses: 0,
+        complete: true,
     }
 }
 
@@ -259,6 +262,9 @@ pub fn create_test_handlers(
                     exists: false,
                     channels: HashSet::new(),
                     members_count: 0,
+                    responses_received: 0,
+                    expected_responses: 0,
+                    complete: true,
                 })
             }) as BoxFuture<'static, sockudo::error::Result<ResponseBody>>
         }),

--- a/tests/http_handler/up_endpoint_test.rs
+++ b/tests/http_handler/up_endpoint_test.rs
@@ -460,6 +460,16 @@ impl sockudo::adapter::ConnectionManager for FailingAdapter {
         _socket_id: &sockudo::websocket::SocketId,
     ) {
     }
+    async fn get_channel_socket_count_info(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+    ) -> sockudo::adapter::connection_manager::ChannelSocketCount {
+        sockudo::adapter::connection_manager::ChannelSocketCount {
+            count: 0,
+            complete: true,
+        }
+    }
     async fn get_channel_socket_count(&self, _app_id: &str, _channel: &str) -> usize {
         0
     }

--- a/tests/mocks/connection_handler_mock.rs
+++ b/tests/mocks/connection_handler_mock.rs
@@ -1,6 +1,8 @@
 use ahash::AHashMap;
 use async_trait::async_trait;
-use sockudo::adapter::connection_manager::{ConnectionManager, HorizontalAdapterInterface};
+use sockudo::adapter::connection_manager::{
+    ChannelSocketCount, ConnectionManager, HorizontalAdapterInterface,
+};
 use sockudo::adapter::handler::ConnectionHandler;
 use sockudo::app::config::App;
 use sockudo::app::manager::AppManager;
@@ -100,6 +102,16 @@ impl ConnectionManager for MockAdapter {
         Ok(())
     }
     async fn add_channel_to_sockets(&self, _app_id: &str, _channel: &str, _socket_id: &SocketId) {}
+    async fn get_channel_socket_count_info(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+    ) -> ChannelSocketCount {
+        ChannelSocketCount {
+            count: 0,
+            complete: true,
+        }
+    }
     async fn get_channel_socket_count(&self, _app_id: &str, _channel: &str) -> usize {
         0
     }


### PR DESCRIPTION
## Summary
- track whether horizontal channel socket counts are complete or partial
- use the full request timeout for cluster channel count aggregation to reduce false negatives
- suppress `channel_vacated` when cluster counts are incomplete

## Verification
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --lib
- cargo test --test mod cross_node_sync
