### PR TITLE
fix: bypass sonic_rs::from_value for presence state deserialization

### DIFF
--- a/crates/sockudo-adapter/src/horizontal_adapter.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter.rs
@@ -481,10 +481,12 @@ impl HorizontalAdapter {
             }
             RequestType::PresenceStateSync => {
                 if let Some(presence_data) = request.user_info {
-                    // Deserialize the bulk presence data
-                    match sonic_rs::from_value::<AHashMap<String, AHashMap<String, PresenceEntry>>>(
-                        &presence_data,
-                    ) {
+                    let deser_result = sonic_rs::to_vec(&presence_data).and_then(|bytes| {
+                        sonic_rs::from_slice::<AHashMap<String, AHashMap<String, PresenceEntry>>>(
+                            &bytes,
+                        )
+                    });
+                    match deser_result {
                         Ok(incoming_node_data) => {
                             let mut registry = self.cluster_presence_registry.write().await;
 


### PR DESCRIPTION
sonic_rs::from_value cannot deserialize structs containing sonic_rs::Value fields. The ValueVisitor in sonic_rs 0.5.7 does not implement visit_newtype_struct, so serde falls back to its default which returns: "invalid type: newtype struct, expected a valid json".

This only manifests when PresenceEntry.user_info is Some(...), which happens during PresenceStateSync when nodes with active presence members sync their registry (e.g. during rolling deploys).

Fix: replace from_value with to_vec + from_slice, which bypasses the broken ValueVisitor and uses sonic_rs SIMD-optimized byte parser.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->