### PR TITLE
feat: add production-ready Helm chart

### DIFF
--- a/FEATURE_COMPARISON.md
+++ b/FEATURE_COMPARISON.md
@@ -540,14 +540,15 @@ This document provides a detailed comparison of features available in **Ably**, 
 | **Self-Hosted** | ❌ (Cloud Only) | ✅ | ✅ | - | - |
 | **Docker Support** | N/A | ✅ | ✅ | - | - |
 | **Docker Compose** | N/A | ✅ | ✅ | - | - |
-| **Kubernetes Ready** | N/A | ✅ | ⚠️ Partial | 🟡 Medium | 🟡 Medium |
-| **Helm Charts** | N/A | ✅ | ❌ | 🟡 Medium | 🟡 Medium |
+| **Kubernetes Ready** | N/A | ✅ | ✅ | - | - |
+| **Helm Charts** | N/A | ✅ | ✅ | - | - |
 | **Binary Releases** | N/A | ✅ (Multi-platform) | ✅ | - | - |
 | **Unix Socket Support** | N/A | ❌ | ✅ | - | - |
 
 **Notes:**
 - Ably is cloud-only SaaS.
 - Sockudo and Centrifugo are self-hosted.
+- Sockudo ships production-ready Helm charts (`charts/sockudo/`) with HPA, PDB, ServiceMonitor, NetworkPolicy, and configurable probes.
 - Sockudo's Unix socket support is unique - good for reverse proxy deployments.
 
 ---

--- a/README.md
+++ b/README.md
@@ -171,6 +171,25 @@ make up
 # Metrics on http://localhost:9601/metrics
 ```
 
+### Kubernetes (Helm)
+
+```bash
+# Install with defaults
+helm install sockudo ./charts/sockudo
+
+# Production with Redis adapter and autoscaling
+helm install sockudo ./charts/sockudo \
+  --set config.adapterDriver=redis \
+  --set redis.host=redis-master \
+  --set redis.existingSecret=my-redis-secret \
+  --set autoscaling.enabled=true \
+  --set pdb.enabled=true \
+  --set ingress.enabled=true \
+  --set serviceMonitor.enabled=true
+```
+
+See [`charts/sockudo/values.yaml`](charts/sockudo/values.yaml) for all configurable options.
+
 ### From Source
 
 ```bash
@@ -319,6 +338,8 @@ Behavior:
 | **High Traffic** | 4vCPU/4GB+ | redis | redis | redis | 50K+ |
 | **Multi-Region** | 8vCPU/8GB+ | redis-cluster | redis-cluster | redis-cluster | 100K+ |
 
+All scenarios above can be deployed via Docker Compose or the included [Helm chart](charts/sockudo/) on Kubernetes with built-in HPA autoscaling.
+
 ## Architecture
 
 ```
@@ -338,6 +359,7 @@ Behavior:
 - **[Full Documentation](docs/)** - Complete setup and configuration guide
 - **[Performance Tuning](docs/QUEUE_CONFIG.md)** - Optimize for your workload
 - **[Docker Deployment](docker-compose.yml)** - Production-ready containers
+- **[Helm Charts](charts/sockudo/)** - Kubernetes deployment with HPA, PDB, ServiceMonitor
 - **[API Reference](docs/API.md)** - WebSocket and HTTP API details
 
 ## Testing

--- a/charts/sockudo/.helmignore
+++ b/charts/sockudo/.helmignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git/
+.gitignore
+.idea/
+*.swp
+*.bak
+*.tmp

--- a/charts/sockudo/Chart.yaml
+++ b/charts/sockudo/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: sockudo
+description: A simple, fast, and secure WebSocket server implementing the Pusher protocol
+type: application
+version: 0.1.0
+appVersion: "3.2.1"
+keywords:
+  - websocket
+  - pusher
+  - realtime
+  - rust
+home: https://github.com/sockudo/sockudo
+sources:
+  - https://github.com/sockudo/sockudo
+maintainers:
+  - name: sockudo

--- a/charts/sockudo/templates/NOTES.txt
+++ b/charts/sockudo/templates/NOTES.txt
@@ -1,0 +1,36 @@
+Sockudo has been deployed successfully!
+
+1. Get the application URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "sockudo.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "sockudo.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "sockudo.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  echo "Visit http://127.0.0.1:{{ .Values.service.port }}/up to check health"
+{{- end }}
+
+2. WebSocket endpoint:
+  ws://{{ include "sockudo.fullname" . }}:{{ .Values.service.port }}/app/{APP_KEY}
+
+{{- if .Values.config.metrics.enabled }}
+
+3. Metrics:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "sockudo.fullname" . }}-metrics {{ .Values.metricsService.port }}:{{ .Values.metricsService.port }}
+  echo "Visit http://127.0.0.1:{{ .Values.metricsService.port }}/metrics"
+{{- end }}
+
+{{- if .Values.defaultApp.enabled }}
+
+4. Default app configured:
+  App ID:  {{ .Values.defaultApp.id }}
+  App Key: {{ .Values.defaultApp.key }}
+{{- end }}

--- a/charts/sockudo/templates/_helpers.tpl
+++ b/charts/sockudo/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sockudo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "sockudo.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sockudo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sockudo.labels" -}}
+helm.sh/chart: {{ include "sockudo.chart" . }}
+{{ include "sockudo.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sockudo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sockudo.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sockudo.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sockudo.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Config map name
+*/}}
+{{- define "sockudo.configMapName" -}}
+{{- printf "%s-config" (include "sockudo.fullname" .) }}
+{{- end }}
+
+{{/*
+Secret name
+*/}}
+{{- define "sockudo.secretName" -}}
+{{- printf "%s-secret" (include "sockudo.fullname" .) }}
+{{- end }}

--- a/charts/sockudo/templates/configmap.yaml
+++ b/charts/sockudo/templates/configmap.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sockudo.configMapName" . }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+data:
+  {{- if .Values.configJson }}
+  config.json: |
+    {{- .Values.configJson | nindent 4 }}
+  {{- else }}
+  config.json: |
+    {
+      "debug": {{ .Values.config.debug }},
+      "host": "0.0.0.0",
+      "port": 6001,
+      "mode": {{ .Values.config.mode | quote }},
+      "shutdown_grace_period": {{ .Values.config.shutdownGracePeriod | int64 }},
+      "adapter": {
+        "driver": {{ .Values.config.adapterDriver | quote }}
+      },
+      "app_manager": {
+        "driver": {{ .Values.config.appManagerDriver | quote }}
+      },
+      "cache": {
+        "driver": {{ .Values.config.cacheDriver | quote }}
+      },
+      "queue": {
+        "driver": {{ .Values.config.queueDriver | quote }}
+      },
+      "rate_limiter": {
+        "enabled": {{ .Values.config.rateLimiter.enabled }},
+        "driver": {{ .Values.config.rateLimiterDriver | quote }}
+      },
+      "metrics": {
+        "enabled": {{ .Values.config.metrics.enabled }},
+        "driver": {{ .Values.config.metrics.driver | quote }},
+        "host": "0.0.0.0",
+        "port": 9601,
+        "prometheus": {
+          "prefix": {{ .Values.config.metrics.prefix | quote }}
+        }
+      },
+      "websocket": {
+        "max_payload_kb": {{ .Values.config.websocket.maxPayloadKb | int64 }},
+        "max_messages": {{ .Values.config.websocket.maxMessages | int64 }},
+        "max_bytes": {{ .Values.config.websocket.maxBytes | int64 }},
+        "ping_interval": {{ .Values.config.websocket.pingInterval | int64 }},
+        "idle_timeout": {{ .Values.config.websocket.idleTimeout | int64 }},
+        "compression": {{ .Values.config.websocket.compression | quote }}
+      },
+      "delta_compression": {
+        "enabled": {{ .Values.config.deltaCompression.enabled }},
+        "algorithm": {{ .Values.config.deltaCompression.algorithm | quote }},
+        "full_message_interval": {{ .Values.config.deltaCompression.fullMessageInterval | int64 }},
+        "min_message_size": {{ .Values.config.deltaCompression.minMessageSize | int64 }},
+        "max_state_age_secs": {{ .Values.config.deltaCompression.maxStateAgeSecs | int64 }}
+      },
+      "ssl": {
+        "enabled": {{ .Values.config.ssl.enabled }}
+      },
+      "cors": {
+        "credentials": {{ .Values.config.cors.credentials }},
+        "origin": {{ .Values.config.cors.origin | toJson }},
+        "methods": {{ .Values.config.cors.methods | toJson }},
+        "allowed_headers": {{ .Values.config.cors.allowedHeaders | toJson }}
+      }
+    }
+  {{- end }}

--- a/charts/sockudo/templates/deployment.yaml
+++ b/charts/sockudo/templates/deployment.yaml
@@ -1,0 +1,350 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sockudo.fullname" . }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "sockudo.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "sockudo.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sockudo.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # Fixed: Explicitly define the binary to run
+          command:
+            - /usr/local/bin/sockudo
+          args:
+            - --config
+            - /app/config/config.json
+          ports:
+            - name: http
+              containerPort: 6001
+              protocol: TCP
+            {{- if .Values.config.metrics.enabled }}
+            - name: metrics
+              containerPort: 9601
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.cluster.enabled }}
+            - name: cluster
+              containerPort: {{ .Values.cluster.port }}
+              protocol: TCP
+            {{- end }}
+          env:
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: "6001"
+            - name: LOG_OUTPUT_FORMAT
+              value: {{ .Values.config.logOutputFormat | quote }}
+            - name: RUST_LOG
+              value: {{ .Values.config.rustLog | quote }}
+            - name: SHUTDOWN_GRACE_PERIOD
+              value: {{ .Values.config.shutdownGracePeriod | quote }}
+            {{- if .Values.config.debug }}
+            - name: DEBUG
+              value: "true"
+            {{- end }}
+            # Driver configuration
+            - name: ADAPTER_DRIVER
+              value: {{ .Values.config.adapterDriver | quote }}
+            - name: APP_MANAGER_DRIVER
+              value: {{ .Values.config.appManagerDriver | quote }}
+            - name: CACHE_DRIVER
+              value: {{ .Values.config.cacheDriver | quote }}
+            - name: QUEUE_DRIVER
+              value: {{ .Values.config.queueDriver | quote }}
+            - name: RATE_LIMITER_DRIVER
+              value: {{ .Values.config.rateLimiterDriver | quote }}
+            # Rate limiter
+            - name: RATE_LIMITER_ENABLED
+              value: {{ .Values.config.rateLimiter.enabled | quote }}
+            - name: RATE_LIMITER_API_MAX_REQUESTS
+              value: {{ .Values.config.rateLimiter.apiMaxRequests | quote }}
+            - name: RATE_LIMITER_API_WINDOW_SECONDS
+              value: {{ .Values.config.rateLimiter.apiWindowSeconds | quote }}
+            - name: RATE_LIMITER_WS_MAX_REQUESTS
+              value: {{ .Values.config.rateLimiter.wsMaxRequests | quote }}
+            - name: RATE_LIMITER_WS_WINDOW_SECONDS
+              value: {{ .Values.config.rateLimiter.wsWindowSeconds | quote }}
+            # Metrics
+            {{- if .Values.config.metrics.enabled }}
+            - name: METRICS_ENABLED
+              value: "true"
+            - name: METRICS_HOST
+              value: "0.0.0.0"
+            - name: METRICS_PORT
+              value: "9601"
+            - name: METRICS_PROMETHEUS_PREFIX
+              value: {{ .Values.config.metrics.prefix | quote }}
+            {{- end }}
+            # Redis
+            {{- if .Values.redis.host }}
+            - name: DATABASE_REDIS_HOST
+              value: {{ .Values.redis.host | quote }}
+            - name: DATABASE_REDIS_PORT
+              value: {{ .Values.redis.port | quote }}
+            - name: DATABASE_REDIS_DB
+              value: {{ .Values.redis.db | quote }}
+            - name: DATABASE_REDIS_KEY_PREFIX
+              value: {{ .Values.redis.keyPrefix | quote }}
+            {{- if or .Values.redis.existingSecret .Values.redis.password }}
+            - name: DATABASE_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: redis-password
+            {{- end }}
+            {{- if or .Values.redis.existingSecret .Values.redis.username }}
+            - name: DATABASE_REDIS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: redis-username
+                  optional: true
+            {{- end }}
+            {{- end }}
+            # Redis Cluster
+            {{- if .Values.redisCluster.nodes }}
+            - name: REDIS_CLUSTER_NODES
+              value: {{ .Values.redisCluster.nodes | quote }}
+            - name: DATABASE_REDIS_CLUSTER_USE_TLS
+              value: {{ .Values.redisCluster.useTls | quote }}
+            {{- if or .Values.redisCluster.existingSecret .Values.redisCluster.password }}
+            - name: DATABASE_REDIS_CLUSTER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redisCluster.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: redis-cluster-password
+            {{- end }}
+            {{- if or .Values.redisCluster.existingSecret .Values.redisCluster.username }}
+            - name: DATABASE_REDIS_CLUSTER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redisCluster.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: redis-cluster-username
+                  optional: true
+            {{- end }}
+            {{- end }}
+            # MySQL
+            {{- if .Values.database.mysql.host }}
+            - name: DATABASE_MYSQL_HOST
+              value: {{ .Values.database.mysql.host | quote }}
+            - name: DATABASE_MYSQL_PORT
+              value: {{ .Values.database.mysql.port | quote }}
+            - name: DATABASE_MYSQL_DATABASE
+              value: {{ .Values.database.mysql.database | quote }}
+            - name: DATABASE_MYSQL_TABLE_NAME
+              value: {{ .Values.database.mysql.tableName | quote }}
+            {{- if or .Values.database.existingSecret .Values.database.mysql.username }}
+            - name: DATABASE_MYSQL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: database-username
+            {{- end }}
+            {{- if or .Values.database.existingSecret .Values.database.mysql.password }}
+            - name: DATABASE_MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: database-password
+            {{- end }}
+            {{- end }}
+            # PostgreSQL
+            {{- if .Values.database.postgres.host }}
+            - name: DATABASE_POSTGRES_HOST
+              value: {{ .Values.database.postgres.host | quote }}
+            - name: DATABASE_POSTGRES_PORT
+              value: {{ .Values.database.postgres.port | quote }}
+            - name: DATABASE_POSTGRES_DATABASE
+              value: {{ .Values.database.postgres.database | quote }}
+            {{- if or .Values.database.existingSecret .Values.database.postgres.username }}
+            - name: DATABASE_POSTGRES_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: database-username
+            {{- end }}
+            {{- if or .Values.database.existingSecret .Values.database.postgres.password }}
+            - name: DATABASE_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: database-password
+            {{- end }}
+            {{- end }}
+            # NATS
+            {{- if .Values.nats.servers }}
+            - name: NATS_SERVERS
+              value: {{ .Values.nats.servers | quote }}
+            - name: NATS_CONNECTION_TIMEOUT_MS
+              value: {{ .Values.nats.connectionTimeoutMs | quote }}
+            - name: NATS_REQUEST_TIMEOUT_MS
+              value: {{ .Values.nats.requestTimeoutMs | quote }}
+            {{- if .Values.nats.username }}
+            - name: NATS_USERNAME
+              value: {{ .Values.nats.username | quote }}
+            {{- end }}
+            {{- if or .Values.nats.existingSecret .Values.nats.password }}
+            - name: NATS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.nats.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: nats-password
+            {{- end }}
+            {{- if or .Values.nats.existingSecret .Values.nats.token }}
+            - name: NATS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.nats.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: nats-token
+                  optional: true
+            {{- end }}
+            {{- end }}
+            # Cluster
+            {{- if .Values.cluster.enabled }}
+            - name: CLUSTER_PORT
+              value: {{ .Values.cluster.port | quote }}
+            - name: CLUSTER_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: INSTANCE_PROCESS_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: CLUSTER_HELLO_INTERVAL
+              value: {{ .Values.cluster.helloInterval | quote }}
+            - name: CLUSTER_CHECK_INTERVAL
+              value: {{ .Values.cluster.checkInterval | quote }}
+            - name: CLUSTER_NODE_TIMEOUT
+              value: {{ .Values.cluster.nodeTimeout | quote }}
+            - name: CLUSTER_MASTER_TIMEOUT
+              value: {{ .Values.cluster.masterTimeout | quote }}
+            {{- end }}
+            # Default app
+            {{- if .Values.defaultApp.enabled }}
+            - name: SOCKUDO_DEFAULT_APP_ENABLED
+              value: "true"
+            - name: SOCKUDO_DEFAULT_APP_ID
+              value: {{ .Values.defaultApp.id | quote }}
+            - name: SOCKUDO_DEFAULT_APP_KEY
+              value: {{ .Values.defaultApp.key | quote }}
+            - name: SOCKUDO_DEFAULT_APP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sockudo.secretName" . }}
+                  key: default-app-secret
+            - name: SOCKUDO_DEFAULT_APP_MAX_CONNECTIONS
+              value: {{ .Values.defaultApp.maxConnections | quote }}
+            - name: SOCKUDO_ENABLE_CLIENT_MESSAGES
+              value: {{ .Values.defaultApp.enableClientMessages | quote }}
+            - name: SOCKUDO_DEFAULT_APP_ENABLE_USER_AUTHENTICATION
+              value: {{ .Values.defaultApp.enableUserAuthentication | quote }}
+            - name: SOCKUDO_DEFAULT_APP_MAX_CLIENT_EVENTS_PER_SECOND
+              value: {{ .Values.defaultApp.maxClientEventsPerSecond | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            - name: logs
+              mountPath: /app/logs
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "sockudo.configMapName" . }}
+        - name: tmp
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/sockudo/templates/hpa.yaml
+++ b/charts/sockudo/templates/hpa.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "sockudo.fullname" . }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "sockudo.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/ingress.yaml
+++ b/charts/sockudo/templates/ingress.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sockudo.fullname" . }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "sockudo.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}
+---
+{{- if .Values.wsIngress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sockudo.fullname" . }}-ws
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+  {{- with .Values.wsIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.wsIngress.className }}
+  ingressClassName: {{ .Values.wsIngress.className }}
+  {{- end }}
+  {{- if .Values.wsIngress.tls }}
+  tls:
+    {{- range .Values.wsIngress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.wsIngress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "sockudo.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/networkpolicy.yaml
+++ b/charts/sockudo/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sockudo.fullname" . }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "sockudo.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- with .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/pdb.yaml
+++ b/charts/sockudo/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "sockudo.fullname" . }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "sockudo.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/sockudo/templates/secret.yaml
+++ b/charts/sockudo/templates/secret.yaml
@@ -1,0 +1,56 @@
+{{- $hasRedis := and (not .Values.redis.existingSecret) (or .Values.redis.password .Values.redis.username) -}}
+{{- $hasRedisCluster := and (not .Values.redisCluster.existingSecret) (or .Values.redisCluster.password .Values.redisCluster.username) -}}
+{{- $hasDatabase := and (not .Values.database.existingSecret) (or .Values.database.mysql.password .Values.database.postgres.password) -}}
+{{- $hasNats := and (not .Values.nats.existingSecret) (or .Values.nats.password .Values.nats.token) -}}
+{{- $hasDefaultApp := and .Values.defaultApp.enabled .Values.defaultApp.secret -}}
+{{- if or $hasRedis $hasRedisCluster $hasDatabase $hasNats $hasDefaultApp }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sockudo.secretName" . }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if $hasRedis }}
+  {{- if .Values.redis.password }}
+  redis-password: {{ .Values.redis.password | quote }}
+  {{- end }}
+  {{- if .Values.redis.username }}
+  redis-username: {{ .Values.redis.username | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if $hasRedisCluster }}
+  {{- if .Values.redisCluster.password }}
+  redis-cluster-password: {{ .Values.redisCluster.password | quote }}
+  {{- end }}
+  {{- if .Values.redisCluster.username }}
+  redis-cluster-username: {{ .Values.redisCluster.username | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if $hasDatabase }}
+  {{- if .Values.database.mysql.password }}
+  database-password: {{ .Values.database.mysql.password | quote }}
+  {{- end }}
+  {{- if .Values.database.mysql.username }}
+  database-username: {{ .Values.database.mysql.username | quote }}
+  {{- end }}
+  {{- if .Values.database.postgres.password }}
+  database-password: {{ .Values.database.postgres.password | quote }}
+  {{- end }}
+  {{- if .Values.database.postgres.username }}
+  database-username: {{ .Values.database.postgres.username | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if $hasNats }}
+  {{- if .Values.nats.password }}
+  nats-password: {{ .Values.nats.password | quote }}
+  {{- end }}
+  {{- if .Values.nats.token }}
+  nats-token: {{ .Values.nats.token | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if $hasDefaultApp }}
+  default-app-secret: {{ .Values.defaultApp.secret | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/service.yaml
+++ b/charts/sockudo/templates/service.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sockudo.fullname" . }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "sockudo.selectorLabels" . | nindent 4 }}
+---
+{{- if .Values.metricsService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sockudo.fullname" . }}-metrics
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+  {{- with .Values.metricsService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.metricsService.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "sockudo.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/sockudo/templates/serviceaccount.yaml
+++ b/charts/sockudo/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sockudo.serviceAccountName" . }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/sockudo/templates/servicemonitor.yaml
+++ b/charts/sockudo/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "sockudo.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "sockudo.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/tests/test-connection.yaml
+++ b/charts/sockudo/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "sockudo.fullname" . }}-test-connection"
+  labels:
+    {{- include "sockudo.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "sockudo.fullname" . }}:{{ .Values.service.port }}/up', '-q', '-O', '-']
+  restartPolicy: Never

--- a/charts/sockudo/values.yaml
+++ b/charts/sockudo/values.yaml
@@ -1,0 +1,354 @@
+replicaCount: 1
+
+image:
+  repository: sockudo/sockudo
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+
+# -- Sockudo server configuration
+config:
+  # -- Server mode: "production" or "development"
+  mode: production
+  # -- Enable debug logging
+  debug: false
+  # -- Log output format: "human" or "json"
+  logOutputFormat: json
+  # -- Rust log level
+  rustLog: "info,sockudo=info"
+  # -- Graceful shutdown period in seconds
+  shutdownGracePeriod: 10
+
+  # -- Adapter driver: local, redis, redis-cluster, nats
+  adapterDriver: local
+  # -- App manager driver: memory, mysql, postgres, dynamodb, scylladb
+  appManagerDriver: memory
+  # -- Cache driver: memory, redis, redis-cluster, none
+  cacheDriver: memory
+  # -- Queue driver: memory, redis, redis-cluster, sqs, sns, none
+  queueDriver: memory
+  # -- Rate limiter driver: memory, redis, redis-cluster
+  rateLimiterDriver: memory
+
+  # -- WebSocket settings
+  websocket:
+    maxPayloadKb: 64
+    maxMessages: 1000
+    maxBytes: 1048576
+    pingInterval: 30
+    idleTimeout: 120
+    compression: disabled
+
+  # -- Rate limiter settings
+  rateLimiter:
+    enabled: true
+    apiMaxRequests: 100
+    apiWindowSeconds: 60
+    wsMaxRequests: 20
+    wsWindowSeconds: 60
+
+  # -- Metrics settings
+  metrics:
+    enabled: true
+    driver: prometheus
+    prefix: "sockudo_"
+
+  # -- SSL/TLS settings (typically terminated at ingress)
+  ssl:
+    enabled: false
+
+  # -- Delta compression settings
+  deltaCompression:
+    enabled: true
+    algorithm: Fossil
+    fullMessageInterval: 10
+    minMessageSize: 100
+    maxStateAgeSecs: 300
+
+  # -- CORS settings
+  cors:
+    credentials: true
+    origin:
+      - "*"
+    methods:
+      - GET
+      - POST
+      - OPTIONS
+    allowedHeaders:
+      - Authorization
+      - Content-Type
+      - X-Requested-With
+      - Accept
+
+# -- Config file content (JSON). If set, mounted as /app/config/config.json.
+# Takes precedence over individual config.* values above.
+# configJson: |
+#   { "debug": false, "port": 6001, ... }
+
+# -- Default app configuration (for development/testing)
+defaultApp:
+  enabled: false
+  id: ""
+  key: ""
+  secret: ""
+  maxConnections: 1000
+  enableClientMessages: true
+  enableUserAuthentication: false
+  maxClientEventsPerSecond: 100
+
+# -- Extra environment variables (name/value pairs)
+extraEnv: []
+  # - name: REDIS_URL
+  #   value: "redis://redis:6379"
+
+# -- Extra environment variables from secrets/configmaps
+extraEnvFrom: []
+  # - secretRef:
+  #     name: sockudo-redis-credentials
+
+# -- Redis configuration (when using redis-based drivers)
+redis:
+  # -- Redis host
+  host: ""
+  # -- Redis port
+  port: 6379
+  # -- Redis database number
+  db: 0
+  # -- Redis key prefix
+  keyPrefix: "sockudo:"
+  # -- Redis username (optional)
+  username: ""
+  # -- Redis password (optional)
+  password: ""
+  # -- Use an existing secret for Redis credentials
+  # Must contain keys: redis-password (and optionally redis-username)
+  existingSecret: ""
+
+# -- Redis Cluster configuration
+redisCluster:
+  # -- Comma-separated Redis cluster node URLs
+  nodes: ""
+  # -- Redis Cluster username (optional)
+  username: ""
+  # -- Redis Cluster password (optional)
+  password: ""
+  # -- Use TLS for Redis Cluster
+  useTls: false
+  # -- Use an existing secret for Redis Cluster credentials
+  existingSecret: ""
+
+# -- Database configuration (MySQL/PostgreSQL for app manager)
+database:
+  mysql:
+    host: ""
+    port: 3306
+    username: ""
+    password: ""
+    database: "sockudo"
+    tableName: "apps"
+  postgres:
+    host: ""
+    port: 5432
+    username: ""
+    password: ""
+    database: "sockudo"
+  # -- Use an existing secret for database credentials
+  # Must contain keys matching: database-username, database-password
+  existingSecret: ""
+
+# -- NATS configuration (when using nats adapter)
+nats:
+  servers: ""
+  username: ""
+  password: ""
+  token: ""
+  connectionTimeoutMs: 5000
+  requestTimeoutMs: 5000
+  existingSecret: ""
+
+# -- Cluster (multi-node) configuration
+cluster:
+  enabled: false
+  port: 6002
+  helloInterval: 5000
+  checkInterval: 10000
+  nodeTimeout: 30000
+  masterTimeout: 60000
+
+service:
+  type: ClusterIP
+  port: 6001
+  # -- Node port (only used when type is NodePort)
+  nodePort: ""
+  annotations: {}
+
+metricsService:
+  # -- Enable a separate service for metrics scraping
+  enabled: true
+  port: 9601
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    # nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    # nginx.ingress.kubernetes.io/upstream-hash-by: "$remote_addr"
+  hosts:
+    - host: sockudo.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: sockudo-tls
+  #    hosts:
+  #      - sockudo.local
+
+# -- WebSocket-specific ingress (if you need separate ingress for WS)
+# Useful when your ingress controller needs different annotations for WebSocket
+wsIngress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+resources:
+  limits:
+    memory: 1Gi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+
+# -- Pod Disruption Budget
+pdb:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+livenessProbe:
+  httpGet:
+    path: /up
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+readinessProbe:
+  httpGet:
+    path: /up
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+startupProbe:
+  httpGet:
+    path: /up
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 30
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# -- Topology spread constraints for pod scheduling
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: topology.kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels: {}
+
+# -- Priority class name for pods
+priorityClassName: ""
+
+# -- Termination grace period (should be >= config.shutdownGracePeriod)
+terminationGracePeriodSeconds: 30
+
+# -- Extra volumes to add to the pod
+extraVolumes: []
+# -- Extra volume mounts to add to the container
+extraVolumeMounts: []
+
+# -- Init containers
+initContainers: []
+
+# -- Sidecar containers
+extraContainers: []
+
+# -- ServiceMonitor for Prometheus Operator
+serviceMonitor:
+  enabled: false
+  namespace: ""
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+  honorLabels: false
+  metricRelabelings: []
+  relabelings: []
+
+# -- Network policy
+networkPolicy:
+  enabled: false
+  ingress: []
+  egress: []

--- a/docs/content/1.getting-started/3.installation.md
+++ b/docs/content/1.getting-started/3.installation.md
@@ -50,7 +50,7 @@ docker run -d \
   --name sockudo \
   -p 6001:6001 \
   -p 9601:9601 \
-  sockudo/sockudo:v1.0.0
+  sockudo/sockudo:latest
 
 # Or GitHub Container Registry
 docker run -d \
@@ -97,7 +97,44 @@ curl http://localhost:9601/metrics
 Official Docker images are available on [Docker Hub](https://hub.docker.com/r/sockudo/sockudo) and [GitHub Container Registry](https://github.com/sockudo/sockudo/pkgs/container/sockudo). Images are tagged with version numbers and `latest` for the most recent release.
 ::
 
-## Option 2: Cargo Binstall (Precompiled Binary)
+## Option 2: Kubernetes (Helm)
+
+Deploy to Kubernetes using the included Helm chart:
+
+```bash [Terminal]
+# Install with defaults
+helm install sockudo ./charts/sockudo
+
+# Install with Redis adapter for horizontal scaling
+helm install sockudo ./charts/sockudo \
+  --set config.adapterDriver=redis \
+  --set redis.host=redis-master \
+  --set redis.existingSecret=my-redis-secret \
+  --set replicaCount=3
+
+# Production with autoscaling, PDB, and monitoring
+helm install sockudo ./charts/sockudo \
+  --set config.adapterDriver=redis \
+  --set redis.host=redis-master \
+  --set redis.existingSecret=my-redis-secret \
+  --set autoscaling.enabled=true \
+  --set pdb.enabled=true \
+  --set ingress.enabled=true \
+  --set serviceMonitor.enabled=true
+```
+
+The Helm chart includes:
+- HPA with configurable CPU/memory targets and scale behavior
+- Pod Disruption Budget for safe rollouts
+- Liveness, readiness, and startup probes
+- Prometheus ServiceMonitor for metrics scraping
+- Non-root container with read-only filesystem
+- Support for `existingSecret` references for all credentials
+- Automatic rolling restart on config changes
+
+See [`charts/sockudo/values.yaml`](https://github.com/sockudo/sockudo/blob/master/charts/sockudo/values.yaml) for all options.
+
+## Option 3: Cargo Binstall (Precompiled Binary)
 
 Install precompiled binaries directly using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall):
 
@@ -126,7 +163,7 @@ cargo binstall sockudo --features redis,mysql
 cargo-binstall downloads precompiled binaries when available, making installation much faster than compiling from source.
 ::
 
-## Option 3: Build From Source
+## Option 4: Build From Source
 
 Requirements:
 

--- a/docs/content/2.server/14.ssl-deployment.md
+++ b/docs/content/2.server/14.ssl-deployment.md
@@ -334,13 +334,80 @@ Available features:
 | `lambda` | AWS Lambda webhook delivery |
 | `full` | All features |
 
+## Kubernetes Deployment
+
+Sockudo ships with production-ready Helm charts in `charts/sockudo/`.
+
+### Quick Install
+
+```bash
+helm install sockudo ./charts/sockudo
+```
+
+### Production Install
+
+```bash
+helm install sockudo ./charts/sockudo \
+  --set config.adapterDriver=redis \
+  --set redis.host=redis-master \
+  --set redis.existingSecret=my-redis-secret \
+  --set replicaCount=3 \
+  --set autoscaling.enabled=true \
+  --set autoscaling.minReplicas=2 \
+  --set autoscaling.maxReplicas=10 \
+  --set pdb.enabled=true \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set serviceMonitor.enabled=true
+```
+
+### Helm Chart Features
+
+| Feature | Description |
+|---|---|
+| **HPA** | Autoscaling based on CPU/memory with configurable scale behavior |
+| **PDB** | Pod Disruption Budget for safe rollouts |
+| **ServiceMonitor** | Prometheus Operator integration for metrics scraping |
+| **NetworkPolicy** | Optional network policy for ingress/egress control |
+| **Probes** | Liveness, readiness, and startup probes on `/up` |
+| **Security** | Non-root, read-only filesystem, all capabilities dropped |
+| **Secrets** | Support for `existingSecret` references (Redis, DB, NATS) |
+| **Config checksum** | Automatic rolling restart on config changes |
+| **Cluster mode** | Pod IP and name injected for multi-node coordination |
+
+### Ingress with WebSocket Support
+
+When using Nginx Ingress Controller, add WebSocket-specific annotations:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+  hosts:
+    - host: ws.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sockudo-tls
+      hosts:
+        - ws.example.com
+```
+
+See [`charts/sockudo/values.yaml`](https://github.com/sockudo/sockudo/blob/master/charts/sockudo/values.yaml) for all configurable options.
+
 ## Health Checks
 
 Sockudo exposes health and metrics endpoints for monitoring:
 
 | Endpoint | Port | Description |
 |---|---|---|
-| `/` | `6001` | Returns `OK` if the server is running |
+| `/up` | `6001` | Returns `OK` if the server is healthy |
+| `/up/{app_id}` | `6001` | Returns `OK` if a specific app is healthy |
 | `/metrics` | `9601` | Prometheus metrics |
 
 Use these for load balancer health checks, Kubernetes liveness probes, or Docker healthchecks:
@@ -348,20 +415,32 @@ Use these for load balancer health checks, Kubernetes liveness probes, or Docker
 ```yaml
 # Docker Compose
 healthcheck:
-  test: ["CMD", "curl", "-f", "http://localhost:6001/"]
+  test: ["CMD", "curl", "-f", "http://localhost:6001/up"]
   interval: 10s
   timeout: 5s
   retries: 3
 ```
 
 ```yaml
-# Kubernetes
+# Kubernetes (included in Helm chart by default)
 livenessProbe:
   httpGet:
-    path: /
+    path: /up
+    port: 6001
+  initialDelaySeconds: 15
+  periodSeconds: 20
+readinessProbe:
+  httpGet:
+    path: /up
     port: 6001
   initialDelaySeconds: 5
   periodSeconds: 10
+startupProbe:
+  httpGet:
+    path: /up
+    port: 6001
+  failureThreshold: 30
+  periodSeconds: 5
 ```
 
 ## Production Checklist
@@ -376,3 +455,5 @@ livenessProbe:
 - [ ] Use TLS - either via Sockudo directly or via a reverse proxy
 - [ ] Configure webhook endpoints if you need server-side event notifications
 - [ ] Set `ENVIRONMENT=production` for production-appropriate defaults
+- [ ] On Kubernetes: enable PDB and HPA in the Helm chart for availability and autoscaling
+- [ ] On Kubernetes: use `existingSecret` references instead of plaintext credentials in values

--- a/docs/content/2.server/4.scaling.md
+++ b/docs/content/2.server/4.scaling.md
@@ -447,3 +447,28 @@ cargo build --release --features full
   }
 }
 ```
+
+## Kubernetes Deployment
+
+For Kubernetes deployments, Sockudo includes production-ready Helm charts in `charts/sockudo/`. The chart supports autoscaling, pod disruption budgets, and Prometheus ServiceMonitor out of the box.
+
+```bash
+# Deploy with Redis adapter and autoscaling
+helm install sockudo ./charts/sockudo \
+  --set config.adapterDriver=redis \
+  --set redis.host=redis-master \
+  --set redis.existingSecret=my-redis-secret \
+  --set autoscaling.enabled=true \
+  --set autoscaling.minReplicas=2 \
+  --set autoscaling.maxReplicas=10 \
+  --set pdb.enabled=true \
+  --set serviceMonitor.enabled=true
+```
+
+The Helm chart automatically configures:
+- `CLUSTER_HOSTNAME` from the pod IP for cluster peer discovery
+- `INSTANCE_PROCESS_ID` from the pod name for unique node identification
+- Rolling restarts when the ConfigMap changes
+- Separate metrics service on port 9601 for Prometheus scraping
+
+See [SSL & Deployment](/server/ssl-deployment) for full Helm chart documentation.


### PR DESCRIPTION
## Summary
- Add complete Helm chart (`charts/sockudo/`) for Kubernetes deployment with HPA, PDB, ServiceMonitor, NetworkPolicy, security-hardened pods, and configurable probes
- Fix integer serialization in configmap template — pipe numeric values through `int64` to prevent Helm/Go from rendering large integers (e.g. `max_bytes: 1048576`) as floats
- Update README, installation docs, scaling docs, and SSL deployment docs with Helm install instructions

## Test plan
- [x] `helm install` succeeds and pod reaches Ready state
- [x] Config parse error (`invalid type: floating point`) no longer appears in logs
- [x] Default app registers correctly via env vars when `defaultApp.enabled=true`
- [x] Health check (`/up`) returns 200 after app is configured
- [ ] `helm template` renders all integer fields without scientific notation
- [ ] Upgrade from revision 1 to revision 2 performs rolling restart correctly