### PR TITLE
fix: fd leak from ghost connections on pong timeout

### DIFF
--- a/crates/sockudo-adapter/src/handler/timeout_management.rs
+++ b/crates/sockudo-adapter/src/handler/timeout_management.rs
@@ -80,7 +80,12 @@ impl ConnectionHandler {
                 // Truly inactive for activity timeout duration, send ping
                 let ping_result = {
                     let mut ws = conn.inner.lock().await;
-                    // Update connection status to indicate ping sent
+                    if !ws.is_connected() {
+                        debug!("Connection {} already closed, cleaning up", socket_id_clone);
+                        drop(ws);
+                        conn_manager.cleanup_connection(&app_id_clone, conn).await;
+                        break;
+                    }
                     ws.state.status = sockudo_core::websocket::ConnectionStatus::PingSent(
                         std::time::Instant::now(),
                     );
@@ -113,14 +118,16 @@ impl ConnectionHandler {
                                 ws.state.status
                                 && ping_time.elapsed() > Duration::from_secs(PONG_TIMEOUT)
                             {
-                                // No pong received, close connection gracefully
                                 warn!(
-                                    "No pong received from socket {} after ping, closing connection",
+                                    "No pong received from socket {} after ping, forcing cleanup",
                                     socket_id_clone
                                 );
                                 let _ = ws
                                     .close(4201, "Pong reply not received in time".to_string())
                                     .await;
+                                drop(ws);
+                                conn_manager.cleanup_connection(&app_id_clone, conn).await;
+                                break;
                             }
                         }
                         // After handling ping/pong, wait full activity timeout before next check

--- a/crates/sockudo-core/src/websocket.rs
+++ b/crates/sockudo-core/src/websocket.rs
@@ -465,7 +465,15 @@ impl PartialEq for ConnectionState {
 #[derive(Debug)]
 pub struct MessageSender {
     sender: MessageSenderHandle,
-    _receiver_handle: JoinHandle<()>,
+    receiver_handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for MessageSender {
+    fn drop(&mut self) {
+        if let Some(handle) = self.receiver_handle.take() {
+            handle.abort();
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -569,7 +577,7 @@ impl MessageSender {
 
         Self {
             sender,
-            _receiver_handle: receiver_handle,
+            receiver_handle: Some(receiver_handle),
         }
     }
 
@@ -642,7 +650,7 @@ impl MessageSender {
 
         Self {
             sender,
-            _receiver_handle: receiver_handle,
+            receiver_handle: Some(receiver_handle),
         }
     }
 


### PR DESCRIPTION
When a client silently disappears (half-open tcp), the activity timeout detects inactivity and sends a ping. if no pong comes back we call ws.close() but never actually remove the connection from the namespace. the timeout loop keeps going, overwrites Closed status with PingSent on the next iteration and the whole cycle repeats forever. these ghost connections hold socket fds that never get released

We caught this in production running ~3k concurrent connections. after a few days of uptime:
- 7800+ open fds, only ~3k reported as connected
- after restart only ~450 clients reconnected, the rest were ghosts
- fd/connection ratio went from 2.4x (leaked) to 1.3x (healthy) after restart
- soft ulimit was exceeded causing healthcheck failures and periodic crashes

Three things were broken:
1. MessageSender has no Drop impl, the spawned writer task is never aborted so the socket fd stays alive even after cleanup
2. pong timeout path only sends a close frame but doesnt call cleanup_connection or break the loop
3. timeout loop overwrites Closed status with PingSent before checking so dead connections get revived every cycle

This patch adds Drop for MessageSender to abort the writer task, calls cleanup_connection + break on pong timeout and checks is_connected() before setting PingSent