### PR TITLE
fix: clean up reader task on ghost connection timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,6 +4086,7 @@ dependencies = [
  "sonic-rs",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "url",
  "urlencoding",

--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -203,6 +203,14 @@ impl ConnectionHandler {
         // Setup rate limiting if needed
         self.setup_rate_limiting(&socket_id, &app_config).await?;
 
+        // Get the cancellation token so the reader loop can be cancelled
+        // when the connection is cleaned up (e.g., ghost connection timeout)
+        let shutdown_token = self
+            .connection_manager
+            .get_connection(&socket_id, &app_config.id)
+            .await
+            .map(|conn| conn.cancellation_token());
+
         // Send connection established
         self.send_connection_established(&app_config.id, &socket_id)
             .await?;
@@ -212,7 +220,7 @@ impl ConnectionHandler {
 
         // Main message loop
         let result = self
-            .run_message_loop(socket_rx, &socket_id, &app_config)
+            .run_message_loop(socket_rx, &socket_id, &app_config, shutdown_token)
             .await;
 
         // Cleanup
@@ -303,8 +311,27 @@ impl ConnectionHandler {
         mut reader: WebSocketReader,
         socket_id: &SocketId,
         app_config: &App,
+        shutdown_token: Option<tokio_util::sync::CancellationToken>,
     ) -> Result<()> {
-        while let Some(next) = reader.next().await {
+        loop {
+            let next = if let Some(ref token) = shutdown_token {
+                tokio::select! {
+                    biased;
+                    _ = token.cancelled() => {
+                        debug!("Reader loop for socket {} cancelled via shutdown token", socket_id);
+                        break;
+                    }
+                    msg = reader.next() => msg,
+                }
+            } else {
+                reader.next().await
+            };
+
+            let next = match next {
+                Some(n) => n,
+                None => break,
+            };
+
             let message = match next {
                 Ok(m) => m,
                 Err(e) => return Err(Error::WebSocket(e)),

--- a/crates/sockudo-core/Cargo.toml
+++ b/crates/sockudo-core/Cargo.toml
@@ -47,6 +47,7 @@ sockudo-ws = { workspace = true }
 sonic-rs = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/sockudo-core/src/namespace.rs
+++ b/crates/sockudo-core/src/namespace.rs
@@ -178,6 +178,9 @@ impl Namespace {
     pub async fn cleanup_connection(&self, ws_ref: WebSocketRef) {
         let socket_id = ws_ref.get_socket_id().await;
 
+        // Signal reader and writer tasks to stop
+        ws_ref.shutdown();
+
         let channels_to_check: Vec<String> = self
             .channels
             .iter()

--- a/crates/sockudo-core/src/websocket.rs
+++ b/crates/sockudo-core/src/websocket.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
 
 /// Buffer limit strategy for WebSocket connections
@@ -503,6 +504,7 @@ impl MessageSender {
         broadcast_rx: SizedMessageReceiverHandle,
         buffer_capacity: usize,
         byte_counter: Option<Arc<ByteCounter>>,
+        shutdown_token: CancellationToken,
     ) -> Self {
         let (sender, receiver) = mpsc::bounded_async::<Message>(buffer_capacity);
 
@@ -516,6 +518,10 @@ impl MessageSender {
                 tokio::select! {
                     biased;
 
+                    _ = shutdown_token.cancelled() => {
+                        debug!("Receiver task shutting down via cancellation token");
+                        break;
+                    }
                     recv_result = broadcast_rx.recv(), if !broadcast_closed => {
                         match recv_result {
                             Ok(sized_msg) => {
@@ -689,6 +695,7 @@ pub struct WebSocket {
     pub broadcast_tx: SizedMessageSenderHandle,
     pub buffer_config: WebSocketBufferConfig,
     pub byte_counter: Option<Arc<ByteCounter>>,
+    pub shutdown_token: CancellationToken,
 }
 
 impl WebSocket {
@@ -709,12 +716,14 @@ impl WebSocket {
 
         let channel_capacity = buffer_config.channel_capacity();
         let (broadcast_tx, broadcast_rx) = mpsc::bounded_async::<SizedMessage>(channel_capacity);
+        let shutdown_token = CancellationToken::new();
 
         let message_sender = MessageSender::new_with_broadcast(
             socket,
             broadcast_rx,
             channel_capacity,
             byte_counter.clone(),
+            shutdown_token.clone(),
         );
 
         WebSocket {
@@ -723,6 +732,7 @@ impl WebSocket {
             broadcast_tx,
             buffer_config,
             byte_counter,
+            shutdown_token,
         }
     }
 
@@ -861,6 +871,7 @@ pub struct WebSocketRef {
     pub socket_id: SocketId,
     pub buffer_config: WebSocketBufferConfig,
     pub byte_counter: Option<Arc<ByteCounter>>,
+    pub shutdown_token: CancellationToken,
     pub inner: Arc<Mutex<WebSocket>>,
 }
 
@@ -870,6 +881,7 @@ impl WebSocketRef {
         let socket_id = *websocket.get_socket_id();
         let buffer_config = websocket.buffer_config;
         let byte_counter = websocket.byte_counter.clone();
+        let shutdown_token = websocket.shutdown_token.clone();
 
         let channel_filters = Arc::new(DashMap::new());
         for (channel, filter) in &websocket.state.subscribed_channels {
@@ -882,6 +894,7 @@ impl WebSocketRef {
             socket_id,
             buffer_config,
             byte_counter,
+            shutdown_token,
             inner: Arc::new(Mutex::new(websocket)),
         }
     }
@@ -958,6 +971,15 @@ impl WebSocketRef {
     pub async fn close(&self, code: u16, reason: String) -> Result<()> {
         let mut ws = self.inner.lock().await;
         ws.close(code, reason).await
+    }
+
+    /// Signal both reader and writer tasks to shut down.
+    pub fn shutdown(&self) {
+        self.shutdown_token.cancel();
+    }
+
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.shutdown_token.clone()
     }
 
     pub fn get_socket_id_sync(&self) -> &SocketId {


### PR DESCRIPTION
Follows up on #193. The previous fix handled the writer task cleanup but I missed the reader task.

`tokio::io::split()` produces independent halves so dropping the write half does not close the read half. When a ghost connection is cleaned up the writer task gets aborted via `MessageSender::Drop` but the reader task stays stuck at `reader.next().await` forever. Each ghost connection leaks one reader task and one FD.

In production with 10+ concurrent connections FD count grew from 34 to 1500+ in 24 hours. After 3-5 minutes of ghost connection churn FD exhaustion caused the `/up` healthcheck to stop responding and Docker killed the container in a restart loop.

**Fix:** Added a `CancellationToken` shared between reader and writer tasks. `cleanup_connection()` cancels the token, both tasks exit via `select!`.

**Test results:**

| Metric | Before | After |
|--------|--------|-------|
| FD count after 50 ghost connections | 1151+ (growing) | 14 (baseline) |
| `/up` response | unresponsive after 3-5 min | always <1ms |

Also note that 3.2.3 is broken because of this. Would be great if you could review and cut a new release once this is merged.