### PR TITLE
Bind HTTP API auth to route app

### DIFF
--- a/crates/sockudo-adapter/tests/adapter/auth_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/auth_test.rs
@@ -17,10 +17,16 @@ use crate::mocks::connection_handler_mock::{
 
 async fn create_test_app_manager() -> Arc<dyn AppManager> {
     let manager = MemoryAppManager::new();
-    let app = App {
-        id: "test-app-id".to_string(),
-        key: "test-app-key".to_string(),
-        secret: "test-app-secret".to_string(),
+    let app = test_app("test-app-id", "test-app-key", "test-app-secret");
+    manager.create_app(app).await.unwrap();
+    Arc::new(manager)
+}
+
+fn test_app(id: &str, key: &str, secret: &str) -> App {
+    App {
+        id: id.to_string(),
+        key: key.to_string(),
+        secret: secret.to_string(),
         max_connections: 1000,
         enable_client_messages: true,
         enabled: true,
@@ -39,8 +45,23 @@ async fn create_test_app_manager() -> Arc<dyn AppManager> {
         enable_watchlist_events: None,
         allowed_origins: None,
         channel_delta_compression: None,
-    };
-    manager.create_app(app).await.unwrap();
+    }
+}
+
+async fn create_multi_app_manager() -> Arc<dyn AppManager> {
+    let manager = MemoryAppManager::new();
+    manager
+        .create_app(test_app("test-app-id", "test-app-key", "test-app-secret"))
+        .await
+        .unwrap();
+    manager
+        .create_app(test_app(
+            "other-app-id",
+            "other-app-key",
+            "other-app-secret",
+        ))
+        .await
+        .unwrap();
     Arc::new(manager)
 }
 
@@ -399,6 +420,47 @@ async fn test_api_auth_invalid_signature() {
 }
 
 #[tokio::test]
+async fn test_api_auth_rejects_route_app_id_mismatch() {
+    let app_manager = create_multi_app_manager().await;
+    let auth_validator = AuthValidator::new(app_manager);
+
+    let current_timestamp = Utc::now().timestamp().to_string();
+    let mut query_params = BTreeMap::new();
+    query_params.insert("auth_key".to_string(), "test-app-key".to_string());
+    query_params.insert("auth_timestamp".to_string(), current_timestamp.clone());
+    query_params.insert("auth_version".to_string(), "1.0".to_string());
+
+    let request_path = "/apps/other-app-id/events";
+    let signature = generate_valid_signature(
+        "test-app-key",
+        "test-app-secret",
+        "GET",
+        request_path,
+        &query_params,
+    );
+
+    let auth_query = EventQuery {
+        auth_key: "test-app-key".to_string(),
+        auth_timestamp: current_timestamp,
+        auth_version: "1.0".to_string(),
+        body_md5: "".to_string(),
+        auth_signature: signature,
+    };
+
+    let result = auth_validator
+        .validate_pusher_api_request(&auth_query, "GET", request_path, &query_params, None)
+        .await;
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        Error::Auth(msg) => {
+            assert!(msg.contains("does not match route app_id"));
+        }
+        _ => panic!("Expected Auth error for mismatched route app_id"),
+    }
+}
+
+#[tokio::test]
 async fn test_api_auth_post_with_body_md5() {
     let app_manager = create_test_app_manager().await;
     let auth_validator = AuthValidator::new(app_manager);
@@ -490,29 +552,7 @@ async fn test_sign_in_token_generation() {
 
     let socket_id = "12345.67890";
     let user_data = "test-user-data";
-    let app_config = App {
-        id: "test-app-id".to_string(),
-        key: "test-key".to_string(),
-        secret: "test-secret".to_string(),
-        max_connections: 1000,
-        enable_client_messages: true,
-        enabled: true,
-        max_backend_events_per_second: Some(1000),
-        max_client_events_per_second: 100,
-        max_read_requests_per_second: Some(1000),
-        max_presence_members_per_channel: None,
-        max_presence_member_size_in_kb: None,
-        max_channel_name_length: None,
-        max_event_channels_at_once: None,
-        max_event_name_length: None,
-        max_event_payload_in_kb: None,
-        max_event_batch_size: None,
-        enable_user_authentication: None,
-        webhooks: Some(vec![]),
-        enable_watchlist_events: None,
-        allowed_origins: None,
-        channel_delta_compression: None,
-    };
+    let app_config = test_app("test-app-id", "test-key", "test-secret");
 
     let signature =
         auth_validator.sign_in_token_for_user_data(socket_id, user_data, app_config.clone());

--- a/crates/sockudo-core/src/auth.rs
+++ b/crates/sockudo-core/src/auth.rs
@@ -47,6 +47,16 @@ impl AuthValidator {
         AuthValidator { app_manager }
     }
 
+    fn route_app_id_from_path(request_path: &str) -> Option<&str> {
+        let mut segments = request_path
+            .split('/')
+            .filter(|segment| !segment.is_empty());
+        match (segments.next(), segments.next()) {
+            (Some("apps"), Some(app_id)) if !app_id.is_empty() => Some(app_id),
+            _ => None,
+        }
+    }
+
     pub async fn validate_channel_auth(
         &self,
         socket_id: SocketId,
@@ -63,22 +73,14 @@ impl AuthValidator {
         Ok(is_valid)
     }
 
-    /// Validates a Pusher-compatible API request signature.
-    ///
-    /// - `auth_params_from_query_struct`: Parsed essential authentication query parameters (auth_key, auth_timestamp, auth_signature).
-    /// - `http_method`: The HTTP method (e.g., "GET", "POST").
-    /// - `request_path`: The full request path (e.g., "/apps/your_app_id/events").
-    /// - `all_query_params_from_url`: A map of ALL query parameters from the request URL, excluding `auth_signature`.
-    /// - `request_body_bytes_for_md5_check`: Raw body bytes for POST MD5 check. For GET, this is None.
-    pub async fn validate_pusher_api_request(
+    pub async fn authenticate_pusher_api_request(
         &self,
         auth_params_from_query_struct: &EventQuery,
         http_method: &str,
         request_path: &str,
         all_query_params_from_url: &BTreeMap<String, String>,
         request_body_bytes_for_md5_check: Option<&[u8]>,
-    ) -> Result<bool, Error> {
-        // Fetch app using auth_key from the parsed EventQuery struct
+    ) -> Result<App, Error> {
         let app = self
             .app_manager
             .find_by_key(&auth_params_from_query_struct.auth_key)
@@ -92,6 +94,19 @@ impl AuthValidator {
             return Err(Error::InvalidAppKey);
         }
         let app_config = app.unwrap();
+
+        if let Some(route_app_id) = Self::route_app_id_from_path(request_path)
+            && route_app_id != app_config.id
+        {
+            debug!(
+                authenticated_app_id = %app_config.id,
+                route_app_id = %route_app_id,
+                "Authenticated app did not match route app id"
+            );
+            return Err(Error::Auth(
+                "Authenticated app does not match route app_id".to_string(),
+            ));
+        }
 
         // --- Timestamp Validation ---
         let auth_ts_str = &auth_params_from_query_struct.auth_timestamp;
@@ -109,7 +124,6 @@ impl AuthValidator {
 
         let current_ts = Utc::now().timestamp();
         if (current_ts - auth_ts).abs() > 600 {
-            // 600 seconds = 10 minutes
             debug!(
                 "Timestamp validation failed. Server time: {}, Provided timestamp: {}, Difference: {}s",
                 current_ts,
@@ -121,19 +135,14 @@ impl AuthValidator {
             ));
         }
 
-        // --- Prepare parameters for signing string construction ---
-        // Start with all query parameters received in the URL (excluding auth_signature)
-        // Convert keys to lowercase before sorting to ensure case-insensitive alphabetical order
         let mut params_for_signing_string: BTreeMap<String, String> = BTreeMap::new();
         for (key, value) in all_query_params_from_url {
             params_for_signing_string.insert(key.to_lowercase(), value.clone());
         }
 
-        // --- body_md5 validation and inclusion in signature params ---
         let uppercased_http_method = http_method.to_uppercase();
         if uppercased_http_method == "POST" {
             if let Some(body_bytes) = request_body_bytes_for_md5_check {
-                // POST with a non-empty body
                 match params_for_signing_string.get("body_md5") {
                     Some(body_md5_from_query) if !body_md5_from_query.is_empty() => {
                         let actual_body_md5 = format!("{:x}", md5::compute(body_bytes));
@@ -144,10 +153,8 @@ impl AuthValidator {
                             );
                             return Err(Error::Auth("body_md5 mismatch".to_string()));
                         }
-                        // body_md5 is valid and already in params_for_signing_string
                     }
                     _ => {
-                        // body_md5 is missing or empty in query, but POST body is non-empty
                         debug!(
                             "POST request has a non-empty body, but 'body_md5' is missing or empty in query parameters."
                         );
@@ -156,36 +163,25 @@ impl AuthValidator {
                         ));
                     }
                 }
-            } else {
-                // POST with an empty body
-                if params_for_signing_string.contains_key("body_md5") {
-                    debug!(
-                        "POST request has an empty body, but 'body_md5' was found in query parameters."
-                    );
-                    return Err(Error::Auth(
-                        "body_md5 must not be present in query parameters for POST requests with an empty body"
-                            .to_string(),
-                    ));
-                }
-                // No body_md5 to include for empty body POST
-            }
-        } else {
-            // For GET requests (or other methods that are not POST)
-            if params_for_signing_string.contains_key("body_md5") {
+            } else if params_for_signing_string.contains_key("body_md5") {
                 debug!(
-                    "{} request should not contain 'body_md5' in query parameters.",
-                    uppercased_http_method
+                    "POST request has an empty body, but 'body_md5' was found in query parameters."
                 );
-                return Err(Error::Auth(format!(
-                    "body_md5 must not be present in query parameters for {uppercased_http_method} requests"
-                )));
+                return Err(Error::Auth(
+                    "body_md5 must not be present in query parameters for POST requests with an empty body"
+                        .to_string(),
+                ));
             }
-            // No body_md5 to include for GET
+        } else if params_for_signing_string.contains_key("body_md5") {
+            debug!(
+                "{} request should not contain 'body_md5' in query parameters.",
+                uppercased_http_method
+            );
+            return Err(Error::Auth(format!(
+                "body_md5 must not be present in query parameters for {uppercased_http_method} requests"
+            )));
         }
 
-        // --- Construct the string to sign ---
-        // BTreeMap iterates in key-sorted order.
-        // Keys are already lowercased when inserted into the map.
         let mut sorted_params_kv_pairs: Vec<String> = Vec::new();
         for (key, value) in &params_for_signing_string {
             sorted_params_kv_pairs.push(format!("{}={}", key, value));
@@ -209,10 +205,36 @@ impl AuthValidator {
             &generated_signature,
             &auth_params_from_query_struct.auth_signature,
         ) {
-            Ok(true)
+            Ok(app_config)
         } else {
             Err(Error::Auth("Invalid API signature".to_string()))
         }
+    }
+
+    /// Validates a Pusher-compatible API request signature.
+    ///
+    /// - `auth_params_from_query_struct`: Parsed essential authentication query parameters (auth_key, auth_timestamp, auth_signature).
+    /// - `http_method`: The HTTP method (e.g., "GET", "POST").
+    /// - `request_path`: The full request path (e.g., "/apps/your_app_id/events").
+    /// - `all_query_params_from_url`: A map of ALL query parameters from the request URL, excluding `auth_signature`.
+    /// - `request_body_bytes_for_md5_check`: Raw body bytes for POST MD5 check. For GET, this is None.
+    pub async fn validate_pusher_api_request(
+        &self,
+        auth_params_from_query_struct: &EventQuery,
+        http_method: &str,
+        request_path: &str,
+        all_query_params_from_url: &BTreeMap<String, String>,
+        request_body_bytes_for_md5_check: Option<&[u8]>,
+    ) -> Result<bool, Error> {
+        self.authenticate_pusher_api_request(
+            auth_params_from_query_struct,
+            http_method,
+            request_path,
+            all_query_params_from_url,
+            request_body_bytes_for_md5_check,
+        )
+        .await
+        .map(|_| true)
     }
 
     pub fn sign_in_token_is_valid(

--- a/crates/sockudo-server/src/http_handler.rs
+++ b/crates/sockudo-server/src/http_handler.rs
@@ -1,7 +1,7 @@
 use ahash::AHashMap;
 use axum::{
     Json,
-    extract::{Path, Query, RawQuery, State},
+    extract::{Extension, Path, Query, RawQuery, State},
     http::{HeaderMap, HeaderValue, StatusCode, Uri, header},
     response::{IntoResponse, Response as AxumResponse},
 };
@@ -506,10 +506,11 @@ async fn process_single_event_parallel(
 #[instrument(skip(handler, event_payload), fields(app_id = %app_id))]
 pub async fn events(
     Path(app_id): Path<String>,
-    Query(auth_q_params_struct): Query<EventQuery>,
+    Query(_auth_q_params_struct): Query<EventQuery>,
+    Extension(app): Extension<App>,
     State(handler): State<Arc<ConnectionHandler>>,
-    uri: Uri,
-    RawQuery(raw_query_str_option): RawQuery,
+    _uri: Uri,
+    RawQuery(_raw_query_str_option): RawQuery,
     Json(event_payload): Json<PusherApiMessage>,
 ) -> Result<impl IntoResponse, AppError> {
     let start_time_ms = std::time::SystemTime::now()
@@ -519,12 +520,6 @@ pub async fn events(
         / 1_000_000.0;
 
     let incoming_request_size_bytes = sonic_rs::to_vec(&event_payload)?.len();
-
-    let app = handler
-        .app_manager()
-        .find_by_id(app_id.as_str())
-        .await?
-        .ok_or_else(|| AppError::AppNotFound(app_id.clone()))?;
 
     let need_channel_info = event_payload.info.is_some();
 
@@ -562,6 +557,7 @@ pub async fn events(
 pub async fn batch_events(
     Path(app_id): Path<String>,
     Query(_auth_q_params_struct): Query<EventQuery>,
+    Extension(app_config): Extension<App>,
     State(handler): State<Arc<ConnectionHandler>>,
     _uri: Uri,
     RawQuery(_raw_query_str_option): RawQuery,
@@ -582,12 +578,6 @@ pub async fn batch_events(
     for (i, event) in batch_events_vec.iter().enumerate().take(3) {
         debug!("Batch event #{}: tags={:?}", i, event.tags);
     }
-
-    let app_config = handler
-        .app_manager()
-        .find_by_id(app_id.as_str())
-        .await?
-        .ok_or_else(|| AppError::AppNotFound(app_id.clone()))?;
 
     if let Some(max_batch) = app_config.max_event_batch_size
         && batch_len > max_batch as usize
@@ -666,17 +656,12 @@ pub async fn batch_events(
 pub async fn channel(
     Path((app_id, channel_name)): Path<(String, String)>,
     Query(query_params_specific): Query<ChannelQuery>,
+    Extension(app): Extension<App>,
     State(handler): State<Arc<ConnectionHandler>>,
-    uri: Uri,
-    RawQuery(raw_query_str_option): RawQuery,
+    _uri: Uri,
+    RawQuery(_raw_query_str_option): RawQuery,
 ) -> Result<impl IntoResponse, AppError> {
     debug!("Request for channel info for channel: {}", channel_name);
-    let app = handler
-        .app_manager()
-        .find_by_id(&app_id)
-        .await?
-        .ok_or_else(|| AppError::AppNotFound(app_id.clone()))?;
-
     validate_channel_name(&app, &channel_name).await?;
 
     let info_query_str = query_params_specific.info.as_ref();
@@ -751,9 +736,10 @@ pub async fn channel(
 pub async fn channels(
     Path(app_id): Path<String>,
     Query(query_params_specific): Query<ChannelsQuery>,
+    Extension(app): Extension<App>,
     State(handler): State<Arc<ConnectionHandler>>,
-    uri: Uri,
-    RawQuery(raw_query_str_option): RawQuery,
+    _uri: Uri,
+    RawQuery(_raw_query_str_option): RawQuery,
 ) -> Result<impl IntoResponse, AppError> {
     debug!("Request for channels list for app_id: {}", app_id);
 
@@ -762,11 +748,6 @@ pub async fn channels(
         .as_deref()
         .unwrap_or("");
     let wants_user_count = query_params_specific.info.as_ref().wants_user_count();
-    let app = handler
-        .app_manager()
-        .find_by_id(&app_id)
-        .await?
-        .ok_or_else(|| AppError::AppNotFound(app_id.clone()))?;
 
     let channels_map = handler
         .connection_manager()
@@ -816,14 +797,10 @@ pub async fn channels(
 #[instrument(skip(handler), fields(app_id = %app_id, channel = %channel_name))]
 pub async fn channel_users(
     Path((app_id, channel_name)): Path<(String, String)>,
-    Query(auth_q_params_struct): Query<EventQuery>,
+    Query(_auth_q_params_struct): Query<EventQuery>,
+    Extension(app): Extension<App>,
     State(handler): State<Arc<ConnectionHandler>>,
 ) -> Result<impl IntoResponse, AppError> {
-    let app = handler
-        .app_manager()
-        .find_by_id(&app_id)
-        .await?
-        .ok_or_else(|| AppError::AppNotFound(app_id.clone()))?;
     debug!("Request for users in channel: {}", channel_name);
     validate_channel_name(&app, &channel_name).await?;
 
@@ -854,10 +831,11 @@ pub async fn channel_users(
 #[instrument(skip(handler), fields(app_id = %app_id, user_id = %user_id))]
 pub async fn terminate_user_connections(
     Path((app_id, user_id)): Path<(String, String)>,
-    Query(auth_q_params_struct): Query<EventQuery>,
+    Query(_auth_q_params_struct): Query<EventQuery>,
+    Extension(app): Extension<App>,
     State(handler): State<Arc<ConnectionHandler>>,
-    uri: Uri,
-    RawQuery(raw_query_str_option): RawQuery,
+    _uri: Uri,
+    RawQuery(_raw_query_str_option): RawQuery,
 ) -> Result<impl IntoResponse, AppError> {
     info!(
         "Received request to terminate user connections for user_id: {}",
@@ -866,7 +844,7 @@ pub async fn terminate_user_connections(
 
     handler
         .connection_manager()
-        .terminate_connection(&app_id, &user_id)
+        .terminate_connection(&app.id, &user_id)
         .await?;
 
     info!(
@@ -876,7 +854,7 @@ pub async fn terminate_user_connections(
 
     let response_payload = json!({ "ok": true });
     let response_size = sonic_rs::to_vec(&response_payload)?.len();
-    record_api_metrics(&handler, &app_id, 0, response_size).await;
+    record_api_metrics(&handler, &app.id, 0, response_size).await;
 
     Ok((StatusCode::OK, Json(response_payload)))
 }

--- a/crates/sockudo-server/src/middleware.rs
+++ b/crates/sockudo-server/src/middleware.rs
@@ -89,7 +89,7 @@ pub async fn pusher_api_auth_middleware(
     let auth_validator = AuthValidator::new(handler_state.app_manager().clone());
 
     match auth_validator
-        .validate_pusher_api_request(
+        .authenticate_pusher_api_request(
             &auth_q_params_struct,
             method.as_str(),
             &path,
@@ -98,17 +98,11 @@ pub async fn pusher_api_auth_middleware(
         )
         .await
     {
-        Ok(true) => {
+        Ok(app) => {
             tracing::debug!("Pusher API authentication successful for path: {}", path);
-            let request = HttpRequest::from_parts(parts, Body::from(body_bytes.clone()));
+            let mut request = HttpRequest::from_parts(parts, Body::from(body_bytes.clone()));
+            request.extensions_mut().insert(app);
             Ok(next.run(request).await)
-        }
-        Ok(false) => {
-            tracing::warn!(
-                "Pusher API authentication failed (validator returned false) for path: {}",
-                path
-            );
-            Err(AppError::ApiAuthFailed("Invalid API signature".to_string()))
         }
         Err(e) => {
             tracing::warn!(


### PR DESCRIPTION
## Summary
- bind authenticated HTTP API requests to the route app id derived from the request path
- pass the authenticated app through request extensions so handlers cannot rebind to a different tenant
- add a regression test covering cross-app signature reuse

## Testing
- cargo fmt
- cargo test -p sockudo-adapter auth_test
- cargo test -p sockudo

Closes #195