### PR TITLE
Fix websocket upgrade rate limiting

### DIFF
--- a/crates/sockudo-rate-limiter/src/factory.rs
+++ b/crates/sockudo-rate-limiter/src/factory.rs
@@ -2,6 +2,7 @@
 #![allow(unused_variables)]
 
 use sockudo_core::error::Result;
+use sockudo_core::options::RateLimit;
 use sockudo_core::rate_limiter::RateLimiter;
 use std::sync::Arc;
 use tracing::{info, warn};
@@ -16,35 +17,90 @@ use sockudo_core::options::{CacheDriver, RateLimiterConfig, RedisConnection};
 pub struct RateLimiterFactory;
 
 impl RateLimiterFactory {
+    pub async fn create_api(
+        config: &RateLimiterConfig,
+        global_redis_conn_details: &RedisConnection,
+    ) -> Result<Arc<dyn RateLimiter + Send + Sync>> {
+        Self::create_for_limit(
+            config,
+            &config.api_rate_limit,
+            "HTTP API",
+            "rl_http:",
+            global_redis_conn_details,
+        )
+        .await
+    }
+
+    pub async fn create_websocket(
+        config: &RateLimiterConfig,
+        global_redis_conn_details: &RedisConnection,
+    ) -> Result<Arc<dyn RateLimiter + Send + Sync>> {
+        Self::create_for_limit(
+            config,
+            &config.websocket_rate_limit,
+            "WebSocket",
+            "rl_ws:",
+            global_redis_conn_details,
+        )
+        .await
+    }
+
     pub async fn create(
         config: &RateLimiterConfig,
         global_redis_conn_details: &RedisConnection,
     ) -> Result<Arc<dyn RateLimiter + Send + Sync>> {
+        Self::create_api(config, global_redis_conn_details).await
+    }
+
+    async fn create_for_limit(
+        config: &RateLimiterConfig,
+        limit: &RateLimit,
+        limiter_name: &str,
+        default_prefix_suffix: &str,
+        global_redis_conn_details: &RedisConnection,
+    ) -> Result<Arc<dyn RateLimiter + Send + Sync>> {
         if !config.enabled {
-            info!("HTTP API Rate limiting is globally disabled. Returning a permissive limiter.");
+            info!(
+                "{} rate limiting is globally disabled. Returning a permissive limiter.",
+                limiter_name
+            );
             return Ok(Arc::new(MemoryRateLimiter::new(u32::MAX, 1))); // Allows all
         }
 
         info!(
-            "Initializing HTTP API RateLimiter with driver: {:?}",
-            config.driver
+            "Initializing {} RateLimiter with driver: {:?}",
+            limiter_name, config.driver
         );
 
         match config.driver {
             #[cfg(feature = "redis")]
             CacheDriver::Redis => {
-                Self::create_redis_limiter(config, global_redis_conn_details).await
+                Self::create_redis_limiter(
+                    limit,
+                    limiter_name,
+                    default_prefix_suffix,
+                    config,
+                    global_redis_conn_details,
+                )
+                .await
             }
             #[cfg(feature = "redis-cluster")]
             CacheDriver::RedisCluster => {
-                Self::create_redis_cluster_limiter(config, global_redis_conn_details).await
+                Self::create_redis_cluster_limiter(
+                    limit,
+                    limiter_name,
+                    default_prefix_suffix,
+                    config,
+                    global_redis_conn_details,
+                )
+                .await
             }
-            CacheDriver::Memory => Self::create_memory_limiter(config),
+            CacheDriver::Memory => Self::create_memory_limiter(limit, limiter_name),
             CacheDriver::None => {
                 warn!("Rate limiter driver set to 'None'. Using memory limiter as fallback.");
                 Ok(Arc::new(MemoryRateLimiter::new(
-                    config.api_rate_limit.max_requests,
-                    config.api_rate_limit.window_seconds,
+                    limit.max_requests,
+                    limit.window_seconds,
                 )))
             }
             #[cfg(not(feature = "redis"))]
@@ -52,24 +108,30 @@ impl RateLimiterFactory {
                 warn!(
                     "Redis rate limiter requested but not compiled in. Falling back to memory limiter."
                 );
-                Self::create_memory_limiter(config)
+                Self::create_memory_limiter(limit, limiter_name)
             }
             #[cfg(not(feature = "redis-cluster"))]
             CacheDriver::RedisCluster => {
                 warn!(
                     "Redis Cluster rate limiter requested but not compiled in. Falling back to memory limiter."
                 );
-                Self::create_memory_limiter(config)
+                Self::create_memory_limiter(limit, limiter_name)
             }
         }
     }
 
     #[cfg(feature = "redis")]
     async fn create_redis_limiter(
+        limit: &RateLimit,
+        limiter_name: &str,
+        default_prefix_suffix: &str,
         config: &RateLimiterConfig,
         global_redis_conn_details: &RedisConnection,
     ) -> Result<Arc<dyn RateLimiter + Send + Sync>> {
-        info!("RateLimiter: Using standalone Redis backend.");
+        info!(
+            "RateLimiter: Using standalone Redis backend for {}.",
+            limiter_name
+        );
 
         let redis_url = config
             .redis
@@ -77,11 +139,9 @@ impl RateLimiterFactory {
             .clone()
             .unwrap_or_else(|| global_redis_conn_details.to_url());
 
-        let prefix = config
-            .redis
-            .prefix
-            .clone()
-            .unwrap_or_else(|| global_redis_conn_details.key_prefix.clone() + "rl_http:");
+        let prefix = config.redis.prefix.clone().unwrap_or_else(|| {
+            global_redis_conn_details.key_prefix.clone() + default_prefix_suffix
+        });
 
         let client = redis::Client::open(redis_url.as_str()).map_err(|e| {
             sockudo_core::error::Error::Redis(format!(
@@ -89,23 +149,24 @@ impl RateLimiterFactory {
             ))
         })?;
 
-        let limiter = RedisRateLimiter::new(
-            client,
-            prefix,
-            config.api_rate_limit.max_requests,
-            config.api_rate_limit.window_seconds,
-        )
-        .await?;
+        let limiter =
+            RedisRateLimiter::new(client, prefix, limit.max_requests, limit.window_seconds).await?;
 
         Ok(Arc::new(limiter))
     }
 
     #[cfg(feature = "redis-cluster")]
     async fn create_redis_cluster_limiter(
+        limit: &RateLimit,
+        limiter_name: &str,
+        default_prefix_suffix: &str,
         config: &RateLimiterConfig,
         global_redis_conn_details: &RedisConnection,
     ) -> Result<Arc<dyn RateLimiter + Send + Sync>> {
-        info!("RateLimiter: Using Redis Cluster backend.");
+        info!(
+            "RateLimiter: Using Redis Cluster backend for {}.",
+            limiter_name
+        );
 
         if global_redis_conn_details.cluster_nodes.is_empty() {
             tracing::error!(
@@ -122,11 +183,9 @@ impl RateLimiterFactory {
             .map(|node| node.to_url())
             .collect();
 
-        let prefix = config
-            .redis
-            .prefix
-            .clone()
-            .unwrap_or_else(|| global_redis_conn_details.key_prefix.clone() + "rl_http:");
+        let prefix = config.redis.prefix.clone().unwrap_or_else(|| {
+            global_redis_conn_details.key_prefix.clone() + default_prefix_suffix
+        });
 
         let client = redis::cluster::ClusterClient::new(nodes).map_err(|e| {
             sockudo_core::error::Error::Redis(format!(
@@ -134,25 +193,87 @@ impl RateLimiterFactory {
             ))
         })?;
 
-        let limiter = RedisClusterRateLimiter::new(
-            client,
-            prefix,
-            config.api_rate_limit.max_requests,
-            config.api_rate_limit.window_seconds,
-        )
-        .await?;
+        let limiter =
+            RedisClusterRateLimiter::new(client, prefix, limit.max_requests, limit.window_seconds)
+                .await?;
 
         Ok(Arc::new(limiter))
     }
 
     fn create_memory_limiter(
-        config: &RateLimiterConfig,
+        limit: &RateLimit,
+        limiter_name: &str,
     ) -> Result<Arc<dyn RateLimiter + Send + Sync>> {
-        info!("Using memory rate limiter for HTTP API.");
-        let limiter = MemoryRateLimiter::new(
-            config.api_rate_limit.max_requests,
-            config.api_rate_limit.window_seconds,
-        );
+        info!("Using memory rate limiter for {}.", limiter_name);
+        let limiter = MemoryRateLimiter::new(limit.max_requests, limit.window_seconds);
         Ok(Arc::new(limiter))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sockudo_core::options::{CacheDriver, RateLimiterConfig, RedisConfig};
+
+    fn test_config() -> RateLimiterConfig {
+        RateLimiterConfig {
+            enabled: true,
+            driver: CacheDriver::Memory,
+            api_rate_limit: RateLimit {
+                max_requests: 2,
+                window_seconds: 60,
+                identifier: Some("api".to_string()),
+                trust_hops: Some(0),
+            },
+            websocket_rate_limit: RateLimit {
+                max_requests: 1,
+                window_seconds: 60,
+                identifier: Some("websocket_connect".to_string()),
+                trust_hops: Some(0),
+            },
+            redis: RedisConfig {
+                prefix: Some("sockudo_rate_limiter:".to_string()),
+                url_override: None,
+                cluster_mode: false,
+            },
+        }
+    }
+
+    fn test_redis_connection() -> RedisConnection {
+        RedisConnection {
+            host: "127.0.0.1".to_string(),
+            port: 6379,
+            db: 0,
+            username: None,
+            password: None,
+            key_prefix: "sockudo:".to_string(),
+            sentinels: vec![],
+            sentinel_password: None,
+            name: "mymaster".to_string(),
+            cluster: Default::default(),
+            cluster_nodes: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn create_api_uses_api_rate_limit_settings() {
+        let limiter = RateLimiterFactory::create_api(&test_config(), &test_redis_connection())
+            .await
+            .unwrap();
+
+        assert!(limiter.increment("same-key").await.unwrap().allowed);
+        assert!(limiter.increment("same-key").await.unwrap().allowed);
+        assert!(!limiter.increment("same-key").await.unwrap().allowed);
+    }
+
+    #[tokio::test]
+    async fn create_websocket_uses_websocket_rate_limit_settings() {
+        let limiter =
+            RateLimiterFactory::create_websocket(&test_config(), &test_redis_connection())
+                .await
+                .unwrap();
+
+        assert!(limiter.increment("same-key").await.unwrap().allowed);
+        assert!(!limiter.increment("same-key").await.unwrap().allowed);
     }
 }

--- a/crates/sockudo-server/src/main.rs
+++ b/crates/sockudo-server/src/main.rs
@@ -164,6 +164,7 @@ struct ServerState {
     metrics: Option<Arc<dyn MetricsInterface + Send + Sync>>,
     running: AtomicBool,
     http_api_rate_limiter: Option<Arc<dyn RateLimiter + Send + Sync>>,
+    websocket_rate_limiter: Option<Arc<dyn RateLimiter + Send + Sync>>,
     debug_enabled: bool,
     cleanup_queue: Option<CleanupSender>,
     cleanup_worker_handles: Option<Vec<tokio::task::JoinHandle<()>>>,
@@ -274,6 +275,33 @@ struct Args {
 }
 
 impl SockudoServer {
+    fn build_rate_limit_layer(
+        limiter: Arc<dyn RateLimiter + Send + Sync>,
+        key_prefix: &str,
+        trust_hops: usize,
+        config_name: &str,
+        metrics: Option<&Arc<dyn MetricsInterface + Send + Sync>>,
+    ) -> sockudo_rate_limiter::middleware::RateLimitLayer<IpKeyExtractor> {
+        let options = sockudo_rate_limiter::middleware::RateLimitOptions {
+            include_headers: true,
+            fail_open: false,
+            key_prefix: Some(key_prefix.to_string()),
+        };
+
+        let mut rate_limit_layer = sockudo_rate_limiter::middleware::RateLimitLayer::with_options(
+            limiter,
+            IpKeyExtractor::new(trust_hops),
+            options,
+        )
+        .with_config_name(config_name.to_string());
+
+        if let Some(metrics) = metrics {
+            rate_limit_layer = rate_limit_layer.with_metrics(metrics.clone());
+        }
+
+        rate_limit_layer
+    }
+
     async fn get_http_addr(&self) -> SocketAddr {
         sockudo_core::utils::resolve_socket_addr(&self.config.host, self.config.port, "HTTP server")
             .await
@@ -385,7 +413,7 @@ impl SockudoServer {
         };
 
         let http_api_rate_limiter_instance = if config.rate_limiter.enabled {
-            RateLimiterFactory::create(&config.rate_limiter, &config.database.redis)
+            RateLimiterFactory::create_api(&config.rate_limiter, &config.database.redis)
                 .await
                 .unwrap_or_else(|e| {
                     error!(
@@ -402,6 +430,27 @@ impl SockudoServer {
         };
         info!(
             "HTTP API RateLimiter initialized (enabled: {}) with driver: {:?}",
+            config.rate_limiter.enabled, config.rate_limiter.driver
+        );
+
+        let websocket_rate_limiter_instance = if config.rate_limiter.enabled {
+            RateLimiterFactory::create_websocket(&config.rate_limiter, &config.database.redis)
+                .await
+                .unwrap_or_else(|e| {
+                    error!(
+                        "Failed to initialize WebSocket rate limiter: {}. Using a permissive limiter.",
+                        e
+                    );
+                    Arc::new(sockudo_rate_limiter::memory_limiter::MemoryRateLimiter::new(
+                        u32::MAX, 1,
+                    ))
+                })
+        } else {
+            info!("WebSocket rate limiting is globally disabled. Using a permissive limiter.");
+            Arc::new(sockudo_rate_limiter::memory_limiter::MemoryRateLimiter::new(u32::MAX, 1))
+        };
+        info!(
+            "WebSocket RateLimiter initialized (enabled: {}) with driver: {:?}",
             config.rate_limiter.enabled, config.rate_limiter.driver
         );
 
@@ -703,6 +752,7 @@ impl SockudoServer {
             metrics: metrics.clone(),
             running: AtomicBool::new(true),
             http_api_rate_limiter: Some(http_api_rate_limiter_instance.clone()),
+            websocket_rate_limiter: Some(websocket_rate_limiter_instance.clone()),
             debug_enabled,
             cleanup_queue,
             cleanup_worker_handles,
@@ -914,38 +964,26 @@ impl SockudoServer {
 
         let cors = cors_builder;
 
-        let rate_limiter_middleware_layer = if self.config.rate_limiter.enabled {
+        let api_rate_limiter_middleware_layer = if self.config.rate_limiter.enabled {
             if let Some(rate_limiter_instance) = &self.state.http_api_rate_limiter {
-                let options = sockudo_rate_limiter::middleware::RateLimitOptions {
-                    include_headers: true,
-                    fail_open: false,
-                    key_prefix: Some("api:".to_string()),
-                };
                 let trust_hops = self
                     .config
                     .rate_limiter
                     .api_rate_limit
                     .trust_hops
                     .unwrap_or(0) as usize;
-                let ip_key_extractor = IpKeyExtractor::new(trust_hops);
 
                 info!(
-                    "Applying custom rate limiting middleware with trust_hops: {}",
+                    "Applying HTTP API rate limiting middleware with trust_hops: {}",
                     trust_hops
                 );
-                let mut rate_limit_layer =
-                    sockudo_rate_limiter::middleware::RateLimitLayer::with_options(
-                        rate_limiter_instance.clone(),
-                        ip_key_extractor,
-                        options,
-                    )
-                    .with_config_name("api_rate_limit".to_string());
-
-                if let Some(ref metrics) = self.state.metrics {
-                    rate_limit_layer = rate_limit_layer.with_metrics(metrics.clone());
-                }
-
-                Some(rate_limit_layer)
+                Some(Self::build_rate_limit_layer(
+                    rate_limiter_instance.clone(),
+                    "api",
+                    trust_hops,
+                    "api_rate_limit",
+                    self.state.metrics.as_ref(),
+                ))
             } else {
                 warn!(
                     "Rate limiting is enabled in config, but no RateLimiter instance found in server state for HTTP API. Rate limiting will not be applied."
@@ -957,6 +995,37 @@ impl SockudoServer {
             None
         };
 
+        let websocket_rate_limiter_middleware_layer = if self.config.rate_limiter.enabled {
+            if let Some(rate_limiter_instance) = &self.state.websocket_rate_limiter {
+                let trust_hops = self
+                    .config
+                    .rate_limiter
+                    .websocket_rate_limit
+                    .trust_hops
+                    .unwrap_or(0) as usize;
+
+                info!(
+                    "Applying WebSocket rate limiting middleware with trust_hops: {}",
+                    trust_hops
+                );
+                Some(Self::build_rate_limit_layer(
+                    rate_limiter_instance.clone(),
+                    "websocket_connect",
+                    trust_hops,
+                    "websocket_rate_limit",
+                    self.state.metrics.as_ref(),
+                ))
+            } else {
+                warn!(
+                    "Rate limiting is enabled in config, but no RateLimiter instance found for WebSocket upgrades. WebSocket rate limiting will not be applied."
+                );
+                None
+            }
+        } else {
+            info!("Custom WebSocket rate limiting is disabled in configuration.");
+            None
+        };
+
         let body_limit_bytes =
             (self.config.http_api.request_limit_in_mb as usize).saturating_mul(1024 * 1024);
         debug!(
@@ -964,8 +1033,12 @@ impl SockudoServer {
             self.config.http_api.request_limit_in_mb, body_limit_bytes
         );
 
-        let mut router = Router::new()
-            .route("/app/{appKey}", get(handle_ws_upgrade))
+        let mut websocket_router = Router::new().route("/app/{appKey}", get(handle_ws_upgrade));
+        if let Some(middleware) = websocket_rate_limiter_middleware_layer {
+            websocket_router = websocket_router.layer(middleware);
+        }
+
+        let mut api_router = Router::new()
             .route(
                 "/apps/{appId}/events",
                 post(events).route_layer(axum_middleware::from_fn_with_state(
@@ -1007,7 +1080,15 @@ impl SockudoServer {
                     self.handler.clone(),
                     pusher_api_auth_middleware,
                 )),
-            )
+            );
+
+        if let Some(middleware) = api_rate_limiter_middleware_layer {
+            api_router = api_router.layer(middleware);
+        }
+
+        let mut router = Router::new()
+            .merge(websocket_router)
+            .merge(api_router)
             .route("/up", get(up))
             .route("/up/{appId}", get(up))
             .layer(DefaultBodyLimit::max(body_limit_bytes))
@@ -1015,11 +1096,6 @@ impl SockudoServer {
 
         if self.config.http_api.usage_enabled {
             router = router.route("/usage", get(usage));
-        }
-
-        // Apply rate limiter middleware if it was created
-        if let Some(middleware) = rate_limiter_middleware_layer {
-            router = router.layer(middleware);
         }
 
         router.with_state(self.handler.clone())
@@ -1418,6 +1494,112 @@ impl SockudoServer {
         tokio::time::sleep(Duration::from_secs(self.config.shutdown_grace_period)).await;
         info!("Server stopped");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use sockudo_rate_limiter::memory_limiter::MemoryRateLimiter;
+    use tower::ServiceExt;
+
+    async fn ok_handler() -> StatusCode {
+        StatusCode::OK
+    }
+
+    fn scoped_test_router() -> Router {
+        let api_layer = SockudoServer::build_rate_limit_layer(
+            Arc::new(MemoryRateLimiter::new(1, 60)),
+            "api",
+            0,
+            "api_rate_limit",
+            None,
+        );
+        let websocket_layer = SockudoServer::build_rate_limit_layer(
+            Arc::new(MemoryRateLimiter::new(1, 60)),
+            "websocket_connect",
+            0,
+            "websocket_rate_limit",
+            None,
+        );
+
+        Router::new()
+            .merge(
+                Router::new()
+                    .route("/app/{appKey}", get(ok_handler))
+                    .layer(websocket_layer),
+            )
+            .merge(
+                Router::new()
+                    .route("/apps/{appId}/events", post(ok_handler))
+                    .layer(api_layer),
+            )
+    }
+
+    #[tokio::test]
+    async fn websocket_rate_limit_is_scoped_to_websocket_routes() {
+        let app = scoped_test_router();
+
+        let ws_request = Request::builder()
+            .method("GET")
+            .uri("/app/demo-key")
+            .header("x-real-ip", "127.0.0.1")
+            .body(Body::empty())
+            .unwrap();
+        let ws_response = app.clone().oneshot(ws_request).await.unwrap();
+        assert_eq!(ws_response.status(), StatusCode::OK);
+
+        let api_request = Request::builder()
+            .method("POST")
+            .uri("/apps/demo/events")
+            .header("x-real-ip", "127.0.0.1")
+            .body(Body::empty())
+            .unwrap();
+        let api_response = app.clone().oneshot(api_request).await.unwrap();
+        assert_eq!(api_response.status(), StatusCode::OK);
+
+        let second_ws_request = Request::builder()
+            .method("GET")
+            .uri("/app/demo-key")
+            .header("x-real-ip", "127.0.0.1")
+            .body(Body::empty())
+            .unwrap();
+        let second_ws_response = app.oneshot(second_ws_request).await.unwrap();
+        assert_eq!(second_ws_response.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn api_rate_limit_is_scoped_to_api_routes() {
+        let app = scoped_test_router();
+
+        let api_request = Request::builder()
+            .method("POST")
+            .uri("/apps/demo/events")
+            .header("x-real-ip", "127.0.0.1")
+            .body(Body::empty())
+            .unwrap();
+        let api_response = app.clone().oneshot(api_request).await.unwrap();
+        assert_eq!(api_response.status(), StatusCode::OK);
+
+        let ws_request = Request::builder()
+            .method("GET")
+            .uri("/app/demo-key")
+            .header("x-real-ip", "127.0.0.1")
+            .body(Body::empty())
+            .unwrap();
+        let ws_response = app.clone().oneshot(ws_request).await.unwrap();
+        assert_eq!(ws_response.status(), StatusCode::OK);
+
+        let second_api_request = Request::builder()
+            .method("POST")
+            .uri("/apps/demo/events")
+            .header("x-real-ip", "127.0.0.1")
+            .body(Body::empty())
+            .unwrap();
+        let second_api_response = app.oneshot(second_api_request).await.unwrap();
+        assert_eq!(second_api_response.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 }
 


### PR DESCRIPTION
## Summary
- initialize a dedicated websocket rate limiter from `websocket_rate_limit` instead of reusing `api_rate_limit`
- scope rate limiting so `/app/{appKey}` upgrades and `/apps/...` HTTP API routes use separate middleware layers and key prefixes
- add regression tests for limiter config selection and route scoping

## Testing
- cargo fmt
- cargo test -p sockudo-rate-limiter
- cargo test -p sockudo
- cargo test

Closes #151