### PR TITLE
fix: resolve DashMap deadlocks in namespace cleanup

### DIFF
--- a/crates/sockudo-core/src/namespace.rs
+++ b/crates/sockudo-core/src/namespace.rs
@@ -191,7 +191,9 @@ impl Namespace {
         for channel_name in channels_to_check {
             if let Some(socket_set) = self.channels.get(&channel_name) {
                 socket_set.remove(&socket_id);
-                if socket_set.is_empty() {
+                let is_empty = socket_set.is_empty();
+                drop(socket_set); // Release read lock before acquiring write lock
+                if is_empty {
                     self.channels
                         .remove_if(&channel_name, |_, set| set.is_empty());
                 }
@@ -368,36 +370,40 @@ impl Namespace {
     }
 
     pub async fn remove_user_socket(&self, user_id: &str, socket_id: &SocketId) -> Result<()> {
-        if let Some(user_sockets_ref) = self.users.get_mut(user_id) {
-            let mut found_socket = None;
+        // Collect socket refs without holding the lock across await points
+        let sockets_snapshot: Vec<WebSocketRef> =
+            if let Some(user_sockets_ref) = self.users.get(user_id) {
+                user_sockets_ref.iter().map(|r| r.clone()).collect()
+            } else {
+                debug!(
+                    "User {} not found when removing socket {}",
+                    user_id, socket_id
+                );
+                return Ok(());
+            };
 
-            for ws_ref in user_sockets_ref.iter() {
-                let ws_socket_id = ws_ref.get_socket_id().await;
-                if ws_socket_id == *socket_id {
-                    found_socket = Some(ws_ref.clone());
-                    break;
-                }
+        let mut found_socket = None;
+        for ws_ref in &sockets_snapshot {
+            let ws_socket_id = ws_ref.get_socket_id().await;
+            if ws_socket_id == *socket_id {
+                found_socket = Some(ws_ref.clone());
+                break;
             }
+        }
 
-            if let Some(ws_ref) = found_socket {
-                user_sockets_ref.remove(&ws_ref);
-            }
-
+        if let Some(ref ws_ref) = found_socket
+            && let Some(user_sockets_ref) = self.users.get_mut(user_id)
+        {
+            user_sockets_ref.remove(ws_ref);
             let is_empty = user_sockets_ref.is_empty();
             drop(user_sockets_ref);
-
             if is_empty {
                 self.users.remove(user_id);
                 debug!("Removed empty user entry for: {}", user_id);
             }
-
-            debug!("Removed socket {} from user {}", socket_id, user_id);
-        } else {
-            debug!(
-                "User {} not found when removing socket {}",
-                user_id, socket_id
-            );
         }
+
+        debug!("Removed socket {} from user {}", socket_id, user_id);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- **Fix critical deadlock** in `cleanup_connection`: held a DashMap read lock (`.get()`) while calling `.remove_if()` on the same map, which requires a write lock. When both hit the same shard, the tokio worker thread deadlocks permanently — Sockudo stays "up" but stops processing connections.
- **Fix async deadlock risk** in `remove_user_socket`: held a mutable DashMap reference across `.await` points (`get_socket_id`), blocking other tasks needing that shard. Now snapshots refs first, releases the lock, does async work, then re-acquires to mutate.

## Context
Reported in prod: Sockudo becomes unresponsive ~5 minutes after start. Last log line before hang:
```
WARN sockudo_adapter::handler::timeout_management: No pong received from socket ... after ping, forcing cleanup
```
The timeout triggers `cleanup_connection` → DashMap deadlock → no new connections accepted.

## Test plan
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features` (no warnings)
- [x] `cargo fmt --all`
- [x] `cargo test -p sockudo-core` (18 passed)
- [ ] Deploy to staging and verify connections survive past 5 minutes under presence channel load

🤖 Generated with [Claude Code](https://claude.com/claude-code)