### PR TITLE
fix: avoid DashMap lock contention in channel cleanup

### DIFF
--- a/crates/sockudo-core/src/namespace.rs
+++ b/crates/sockudo-core/src/namespace.rs
@@ -189,13 +189,10 @@ impl Namespace {
             .collect();
 
         for channel_name in channels_to_check {
-            if let Some(socket_set) = self.channels.get(&channel_name) {
-                socket_set.remove(&socket_id);
-                if socket_set.is_empty() {
-                    self.channels
-                        .remove_if(&channel_name, |_, set| set.is_empty());
-                }
-            }
+            self.channels.remove_if(&channel_name, |_, set| {
+                set.remove(&socket_id);
+                set.is_empty()
+            });
         }
 
         let user_id_option = ws_ref.get_user_id().await;


### PR DESCRIPTION
Follows up on #193 and #194. When `cleanup_connection` removes a socket from a channel it calls `self.channels.get()` followed by `remove_if()` on the same DashMap. Under concurrent load with active broadcasts this causes lock contention that blocks the tokio runtime and the `/up` healthcheck stops responding

In production with 500+ concurrent connections and 3000+ connections per hour the healthcheck timed out every 5-8 minutes causing Docker to kill the container. After deploying the fix the service has been running stable for 20+ hours with zero healthcheck failures

**Fix:** Replaced `get()` + `remove()` with a single `remove_if()` call to avoid holding multiple locks on the same DashMap

**Before (3.2.2, FD leak growing over time):**

<img width="559" height="284" alt="Screenshot 2026-03-22 at 23 50 07" src="https://github.com/user-attachments/assets/8583e40f-342d-4258-b633-8dbc9983ecf5" />


**After (with #193, #194 and this fix, stable for 20+ hours, FD follows traffic pattern):**

<img width="565" height="281" alt="Screenshot 2026-03-22 at 23 51 24" src="https://github.com/user-attachments/assets/a921e76d-6584-4ca9-a3aa-bae11e7c29e4" />
