### PR TITLE
perf(nats): improve horizontal scaling efficiency

### DIFF
--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -13,7 +13,9 @@ use crate::horizontal_adapter::{
     AggregationStats, BroadcastMessage, DeadNodeEvent, HorizontalAdapter, OrphanedMember,
     PendingRequest, RequestBody, RequestType, ResponseBody, current_timestamp, generate_request_id,
 };
-use crate::horizontal_transport::{HorizontalTransport, TransportConfig, TransportHandlers};
+use crate::horizontal_transport::{
+    HorizontalTransport, ResponseHandler, TransportConfig, TransportHandlers,
+};
 use crate::local_adapter::LocalAdapter;
 use async_trait::async_trait;
 use crossfire::mpsc;
@@ -299,8 +301,34 @@ where
             }
         }
 
-        // Broadcast the request via transport.
-        self.transport.publish_request(&request).await?;
+        // Set up inbox for direct replies (eliminates O(N²) response fan-out).
+        let _inbox_guard = match self.transport.new_inbox() {
+            Some(inbox) => {
+                // Subscribe BEFORE publishing to avoid missing early replies
+                let horizontal = self.horizontal.clone();
+                let handler: ResponseHandler = Arc::new(move |response| {
+                    let horizontal = horizontal.clone();
+                    Box::pin(async move {
+                        let _ = horizontal.process_response(response).await;
+                    })
+                });
+
+                let guard = self
+                    .transport
+                    .subscribe_response_inbox(&inbox, handler)
+                    .await?;
+
+                self.transport
+                    .publish_request_with_reply(&request, &inbox)
+                    .await?;
+
+                guard
+            }
+            None => {
+                self.transport.publish_request(&request).await?;
+                None
+            }
+        };
 
         // Wait for responses with adaptive timeout based on request type and node count
         let base_timeout = self

--- a/crates/sockudo-adapter/src/horizontal_transport.rs
+++ b/crates/sockudo-adapter/src/horizontal_transport.rs
@@ -8,6 +8,12 @@ use sockudo_core::error::Result;
 use sockudo_core::metrics::MetricsInterface;
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+pub type ResponseHandler = Arc<dyn Fn(ResponseBody) -> BoxFuture<'static, ()> + Send + Sync>;
+
+/// Guard that keeps an inbox subscription alive. Drop to unsubscribe.
+pub struct InboxGuard {
+    pub(crate) _cancel: tokio::sync::oneshot::Sender<()>,
+}
 
 /// Handlers for transport events
 pub struct TransportHandlers {
@@ -45,6 +51,31 @@ pub trait HorizontalTransport: Send + Sync + Clone {
 
     /// Attach metrics for transport-level instrumentation.
     fn set_metrics(&self, _metrics: Arc<dyn MetricsInterface + Send + Sync>) {}
+
+    /// Generate a unique inbox subject. Returns None if transport doesn't support direct reply.
+    fn new_inbox(&self) -> Option<String> {
+        None
+    }
+
+    /// Publish a request with a reply-to subject so responders reply directly to the requester.
+    /// Default: ignores reply_to and publishes normally.
+    async fn publish_request_with_reply(
+        &self,
+        request: &RequestBody,
+        _reply_to: &str,
+    ) -> Result<()> {
+        self.publish_request(request).await
+    }
+
+    /// Subscribe to an inbox and forward responses to the handler.
+    /// Returns a guard — drop it to unsubscribe.
+    async fn subscribe_response_inbox(
+        &self,
+        _inbox: &str,
+        _handler: ResponseHandler,
+    ) -> Result<Option<InboxGuard>> {
+        Ok(None)
+    }
 }
 
 /// Common configuration traits for transport implementations

--- a/crates/sockudo-adapter/src/transports/nats_transport.rs
+++ b/crates/sockudo-adapter/src/transports/nats_transport.rs
@@ -1,5 +1,7 @@
 use crate::horizontal_adapter::{BroadcastMessage, RequestBody, ResponseBody};
-use crate::horizontal_transport::{HorizontalTransport, TransportConfig, TransportHandlers};
+use crate::horizontal_transport::{
+    HorizontalTransport, InboxGuard, ResponseHandler, TransportConfig, TransportHandlers,
+};
 use async_nats::{Client as NatsClient, ConnectOptions as NatsOptions, Subject};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -73,6 +75,10 @@ impl NatsTransport {
     /// Get transport metrics for monitoring
     pub fn get_metrics(&self) -> Arc<TransportMetrics> {
         self.metrics.clone()
+    }
+
+    pub fn client(&self) -> &NatsClient {
+        &self.client
     }
 
     async fn discover_node_count_via_system_ping(&self) -> Result<Option<usize>> {
@@ -309,24 +315,29 @@ impl HorizontalTransport for NatsTransport {
                     break;
                 };
                 metrics_broadcast.record_received();
-                match sonic_rs::from_slice::<BroadcastMessage>(&msg.payload) {
-                    Ok(broadcast) => {
-                        broadcast_handler(broadcast).await;
-                        metrics_broadcast.record_processed();
-                    }
-                    Err(e) => {
-                        metrics_broadcast.record_parse_error();
-                        if let Some(metrics) = metrics_driver_broadcast.get() {
-                            metrics.mark_horizontal_transport_message_dropped("nats");
+                let handler = broadcast_handler.clone();
+                let metrics = metrics_broadcast.clone();
+                let metrics_driver = metrics_driver_broadcast.clone();
+                tokio::spawn(async move {
+                    match sonic_rs::from_slice::<BroadcastMessage>(&msg.payload) {
+                        Ok(broadcast) => {
+                            handler(broadcast).await;
+                            metrics.record_processed();
                         }
-                        let payload_preview =
-                            String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
-                        error!(
-                            "Failed to parse broadcast message: {} - payload preview: {}",
-                            e, payload_preview
-                        );
+                        Err(e) => {
+                            metrics.record_parse_error();
+                            if let Some(m) = metrics_driver.get() {
+                                m.mark_horizontal_transport_message_dropped("nats");
+                            }
+                            let payload_preview =
+                                String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
+                            error!(
+                                "Failed to parse broadcast message: {} - payload preview: {}",
+                                e, payload_preview
+                            );
+                        }
                     }
-                }
+                });
             }
             warn!("Broadcast subscription ended unexpectedly");
         });
@@ -346,36 +357,43 @@ impl HorizontalTransport for NatsTransport {
                     break;
                 };
                 metrics_request.record_received();
-                match sonic_rs::from_slice::<RequestBody>(&msg.payload) {
-                    Ok(request) => {
-                        let response_result = request_handler(request).await;
+                let handler = request_handler.clone();
+                let metrics = metrics_request.clone();
+                let metrics_driver = metrics_driver_request.clone();
+                let client = response_client.clone();
+                let subject = response_subject.clone();
+                tokio::spawn(async move {
+                    match sonic_rs::from_slice::<RequestBody>(&msg.payload) {
+                        Ok(request) => {
+                            let response_result = handler(request).await;
 
-                        if let Ok(response) = response_result
-                            && let Ok(response_data) = sonic_rs::to_vec(&response)
-                            && let Err(e) = response_client
-                                .publish(
-                                    Subject::from(response_subject.clone()),
-                                    response_data.into(),
-                                )
-                                .await
-                        {
-                            warn!("Failed to publish response: {}", e);
+                            if let Ok(response) = response_result
+                                && let Ok(response_data) = sonic_rs::to_vec(&response)
+                            {
+                                // Reply to requester's inbox if available,
+                                // otherwise fall back to global subject
+                                let target = msg.reply.unwrap_or_else(|| Subject::from(subject));
+
+                                if let Err(e) = client.publish(target, response_data.into()).await {
+                                    warn!("Failed to publish response: {}", e);
+                                }
+                            }
+                            metrics.record_processed();
                         }
-                        metrics_request.record_processed();
-                    }
-                    Err(e) => {
-                        metrics_request.record_parse_error();
-                        if let Some(metrics) = metrics_driver_request.get() {
-                            metrics.mark_horizontal_transport_message_dropped("nats");
+                        Err(e) => {
+                            metrics.record_parse_error();
+                            if let Some(m) = metrics_driver.get() {
+                                m.mark_horizontal_transport_message_dropped("nats");
+                            }
+                            let payload_preview =
+                                String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
+                            error!(
+                                "Failed to parse request message: {} - payload preview: {}",
+                                e, payload_preview
+                            );
                         }
-                        let payload_preview =
-                            String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
-                        error!(
-                            "Failed to parse request message: {} - payload preview: {}",
-                            e, payload_preview
-                        );
                     }
-                }
+                });
             }
             warn!("Request subscription ended unexpectedly");
         });
@@ -395,24 +413,29 @@ impl HorizontalTransport for NatsTransport {
                     break;
                 };
                 metrics_response.record_received();
-                match sonic_rs::from_slice::<ResponseBody>(&msg.payload) {
-                    Ok(response) => {
-                        response_handler(response).await;
-                        metrics_response.record_processed();
-                    }
-                    Err(e) => {
-                        metrics_response.record_parse_error();
-                        if let Some(metrics) = metrics_driver_response.get() {
-                            metrics.mark_horizontal_transport_message_dropped("nats");
+                let handler = response_handler.clone();
+                let metrics = metrics_response.clone();
+                let metrics_driver = metrics_driver_response.clone();
+                tokio::spawn(async move {
+                    match sonic_rs::from_slice::<ResponseBody>(&msg.payload) {
+                        Ok(response) => {
+                            handler(response).await;
+                            metrics.record_processed();
                         }
-                        let payload_preview =
-                            String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
-                        error!(
-                            "Failed to parse response message: {} - payload preview: {}",
-                            e, payload_preview
-                        );
+                        Err(e) => {
+                            metrics.record_parse_error();
+                            if let Some(m) = metrics_driver.get() {
+                                m.mark_horizontal_transport_message_dropped("nats");
+                            }
+                            let payload_preview =
+                                String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
+                            error!(
+                                "Failed to parse response message: {} - payload preview: {}",
+                                e, payload_preview
+                            );
+                        }
                     }
-                }
+                });
             }
             warn!("Response subscription ended unexpectedly");
         });
@@ -456,6 +479,65 @@ impl HorizontalTransport for NatsTransport {
 
     fn set_metrics(&self, metrics: Arc<dyn MetricsInterface + Send + Sync>) {
         let _ = self.metrics_driver.set(metrics);
+    }
+
+    fn new_inbox(&self) -> Option<String> {
+        Some(self.client.new_inbox())
+    }
+
+    async fn publish_request_with_reply(
+        &self,
+        request: &RequestBody,
+        reply_to: &str,
+    ) -> Result<()> {
+        let request_data = sonic_rs::to_vec(request)
+            .map_err(|e| Error::Other(format!("Failed to serialize request: {e}")))?;
+
+        self.client
+            .publish_with_reply(
+                Subject::from(self.request_subject.clone()),
+                Subject::from(reply_to.to_string()),
+                request_data.into(),
+            )
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to publish request: {e}")))?;
+
+        debug!(
+            "Published request {} with reply_to via NATS",
+            request.request_id
+        );
+        Ok(())
+    }
+
+    async fn subscribe_response_inbox(
+        &self,
+        inbox: &str,
+        handler: ResponseHandler,
+    ) -> Result<Option<InboxGuard>> {
+        let mut sub = self
+            .client
+            .subscribe(Subject::from(inbox.to_string()))
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to subscribe to inbox: {e}")))?;
+
+        let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = &mut cancel_rx => break,
+                    msg = sub.next() => {
+                        let Some(msg) = msg else { break };
+                        if let Ok(response) = sonic_rs::from_slice::<ResponseBody>(&msg.payload) {
+                            handler(response).await;
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Some(InboxGuard { _cancel: cancel_tx }))
     }
 }
 

--- a/crates/sockudo-adapter/tests/adapter/transports/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/mod.rs
@@ -9,3 +9,6 @@ mod redis_cluster_transport_test;
 
 #[cfg(all(test, feature = "nats"))]
 mod nats_transport_test;
+
+#[cfg(all(test, feature = "nats"))]
+mod nats_inbox_test;

--- a/crates/sockudo-adapter/tests/adapter/transports/nats_inbox_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/nats_inbox_test.rs
@@ -1,0 +1,183 @@
+use sockudo_adapter::horizontal_adapter::ResponseBody;
+use sockudo_adapter::horizontal_transport::{BoxFuture, HorizontalTransport, ResponseHandler};
+use sockudo_adapter::transports::NatsTransport;
+use sockudo_core::error::Result;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use super::test_helpers::*;
+
+#[tokio::test]
+async fn test_inbox_request_reply_flow() -> Result<()> {
+    let config = get_nats_config();
+    let transport = NatsTransport::new(config.clone()).await?;
+
+    // Start listeners (responder side)
+    let collector = MessageCollector::new();
+    let handlers = create_test_handlers(collector.clone());
+    transport.start_listeners(handlers).await?;
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Set up inbox subscription (requester side)
+    let inbox = transport.new_inbox().unwrap();
+    let inbox_responses = Arc::new(Mutex::new(Vec::new()));
+    let inbox_responses_clone = inbox_responses.clone();
+    let handler: ResponseHandler = Arc::new(move |response| {
+        let responses = inbox_responses_clone.clone();
+        Box::pin(async move {
+            responses.lock().await.push(response);
+        }) as BoxFuture<'static, ()>
+    });
+    let _guard = transport.subscribe_response_inbox(&inbox, handler).await?;
+
+    // Publish request with reply-to
+    let request = create_test_request();
+    let request_id = request.request_id.clone();
+    transport
+        .publish_request_with_reply(&request, &inbox)
+        .await?;
+
+    // Response should arrive at the inbox
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(500);
+    loop {
+        let responses = inbox_responses.lock().await;
+        if !responses.is_empty() {
+            assert_eq!(responses[0].request_id, request_id);
+            break;
+        }
+        drop(responses);
+        if tokio::time::Instant::now() >= deadline {
+            panic!("Timed out waiting for inbox response");
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_no_reply_to_falls_back_to_global_subject() -> Result<()> {
+    let config = get_nats_config();
+    let transport = NatsTransport::new(config.clone()).await?;
+
+    // Start listeners
+    let collector = MessageCollector::new();
+    let handlers = create_test_handlers(collector.clone());
+    transport.start_listeners(handlers).await?;
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Publish request WITHOUT reply_to (simulates old pod)
+    let request = create_test_request();
+    let request_id = request.request_id.clone();
+    transport.publish_request(&request).await?;
+
+    // Response should arrive via global subject
+    let received = collector.wait_for_response(500).await;
+    assert!(
+        received.is_some(),
+        "Response should arrive via global subject when no reply_to"
+    );
+    assert_eq!(received.unwrap().request_id, request_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_inbox_guard_drop_stops_receiving() -> Result<()> {
+    let config = get_nats_config();
+    let transport = NatsTransport::new(config.clone()).await?;
+
+    let inbox = transport.new_inbox().unwrap();
+    let received = Arc::new(Mutex::new(Vec::<ResponseBody>::new()));
+    let received_clone = received.clone();
+    let handler: ResponseHandler = Arc::new(move |response| {
+        let received = received_clone.clone();
+        Box::pin(async move {
+            received.lock().await.push(response);
+        }) as BoxFuture<'static, ()>
+    });
+
+    let guard = transport
+        .subscribe_response_inbox(&inbox, handler)
+        .await?
+        .unwrap();
+
+    // Drop the guard
+    drop(guard);
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Publish after drop — should not be received
+    let response = create_test_response("should-not-arrive");
+    let response_data = sonic_rs::to_vec(&response).unwrap();
+    transport
+        .client()
+        .publish(async_nats::Subject::from(inbox), response_data.into())
+        .await
+        .map_err(|e| sockudo_core::error::Error::Internal(e.to_string()))?;
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    assert!(
+        received.lock().await.is_empty(),
+        "Should not receive messages after guard dropped"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_two_transports_inbox_isolation() -> Result<()> {
+    let config = get_nats_config();
+    let transport_a = NatsTransport::new(config.clone()).await?;
+    let transport_b = NatsTransport::new(config.clone()).await?;
+
+    // Both start listeners (both are responders)
+    let collector_a = MessageCollector::new();
+    transport_a
+        .start_listeners(create_test_handlers(collector_a.clone()))
+        .await?;
+    let collector_b = MessageCollector::new();
+    transport_b
+        .start_listeners(create_test_handlers(collector_b.clone()))
+        .await?;
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Transport A sends a request with inbox
+    let inbox_a = transport_a.new_inbox().unwrap();
+    let responses_a = Arc::new(Mutex::new(Vec::new()));
+    let responses_a_clone = responses_a.clone();
+    let handler_a: ResponseHandler = Arc::new(move |response| {
+        let responses = responses_a_clone.clone();
+        Box::pin(async move {
+            responses.lock().await.push(response);
+        }) as BoxFuture<'static, ()>
+    });
+    let _guard_a = transport_a
+        .subscribe_response_inbox(&inbox_a, handler_a)
+        .await?;
+
+    let request = create_test_request();
+    let request_id = request.request_id.clone();
+    transport_a
+        .publish_request_with_reply(&request, &inbox_a)
+        .await?;
+
+    // Wait for responses
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
+    loop {
+        let resps = responses_a.lock().await;
+        // Both transport_a and transport_b receive the request and respond to inbox_a.
+        // transport_a's own listener also responds. So we expect 2 responses.
+        if resps.len() >= 2 {
+            assert!(resps.iter().all(|r| r.request_id == request_id));
+            break;
+        }
+        drop(resps);
+        if tokio::time::Instant::now() >= deadline {
+            let count = responses_a.lock().await.len();
+            panic!("Timed out: expected 2 inbox responses, got {}", count);
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+
+    Ok(())
+}

--- a/crates/sockudo-server/src/cleanup/mod.rs
+++ b/crates/sockudo-server/src/cleanup/mod.rs
@@ -9,6 +9,7 @@ pub use sockudo_adapter::cleanup::{
 
 // Re-export CleanupConfig and WorkerThreadsConfig from sockudo-core options
 pub use sockudo_core::options::{CleanupConfig, WorkerThreadsConfig};
+use sockudo_core::websocket::SocketId;
 
 // Re-export CancellationToken for use by callers who want graceful shutdown
 pub use tokio_util::sync::CancellationToken;
@@ -103,5 +104,6 @@ pub struct WebhookEvent {
     pub app_id: String,
     pub channel: String,
     pub user_id: Option<String>,
+    pub socket_id: Option<SocketId>,
     pub data: sonic_rs::Value,
 }

--- a/crates/sockudo-server/src/cleanup/worker.rs
+++ b/crates/sockudo-server/src/cleanup/worker.rs
@@ -267,6 +267,7 @@ impl CleanupWorker {
                     app_id: task.app_id.clone(),
                     channel: channel.clone(),
                     user_id: Some(user_id.clone()),
+                    socket_id: Some(task.socket_id),
                     data: sonic_rs::json!({
                         "user_id": user_id,
                         "socket_id": task.socket_id.to_string()
@@ -287,6 +288,7 @@ impl CleanupWorker {
                     app_id: task.app_id.clone(),
                     channel: channel.clone(),
                     user_id: None,
+                    socket_id: None,
                     data: sonic_rs::json!({
                         "channel": channel
                     }),
@@ -385,7 +387,7 @@ impl CleanupWorker {
                             app_config,
                             &event.channel,
                             user_id,
-                            None,
+                            event.socket_id.as_ref(),
                             PresenceHistoryEventCause::Disconnect,
                             None,
                             Some(


### PR DESCRIPTION
Use NATS request-reply inboxes so responses route directly to the requesting node instead of broadcasting on the global response subject, reducing cross-node response traffic from O(N²) to O(N). This breaks the crash-loop spiral where NATS overload + fallback_to_local: false causes pods to fail startup, scaling adds more pods, which adds more NATS pressure.

Spawn message handlers concurrently via tokio::spawn to match the Redis adapter concurrency model.

Also pass socket_id through webhook events for correct attribution.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->