### PR TITLE
fix(metrics): sync active_channels gauge from DashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6630,7 +6630,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-adapter"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-nats",
@@ -6727,7 +6727,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-app"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6754,7 +6754,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-cache"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6767,7 +6767,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-core"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6804,7 +6804,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-delta"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-nats",
@@ -6824,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-filter"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "criterion",
@@ -6836,7 +6836,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-metrics"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6850,7 +6850,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-protocol"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "prost 0.14.3",
@@ -6862,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-queue"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-nats",
@@ -6890,7 +6890,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-rate-limiter"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6911,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-webhook"
-version = "4.1.1"
+version = "4.2.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -98,12 +98,11 @@ impl ConnectionHandler {
 
             // Update active channel count if this was the last connection to the channel
             if current_sub_count == 0 {
-                // Channel became inactive - decrement the count for this channel type
-                // Pass the Arc directly to avoid holding any locks
-                self.decrement_active_channel_count(
+                super::sync_active_channel_count(
+                    &self.connection_manager,
+                    metrics,
                     &app_config.id,
                     channel_type_str,
-                    metrics.clone(),
                 )
                 .await;
             }
@@ -605,16 +604,26 @@ impl ConnectionHandler {
 
         match ChannelManager::batch_unsubscribe(&self.connection_manager, operations).await {
             Ok(results) => {
+                // Collect channel types that became empty so we can sync the gauge once per type
+                let mut types_to_sync: HashSet<String> = HashSet::new();
+
                 // Process webhook events for each successful unsubscribe
-                for (channel_name, result) in results {
+                for (channel_name, result) in &results {
                     match result {
                         Ok((was_removed, remaining_connections)) => {
-                            if was_removed {
+                            if *remaining_connections == 0 {
+                                types_to_sync.insert(
+                                    sockudo_core::channel::ChannelType::from_name(channel_name)
+                                        .as_str()
+                                        .to_string(),
+                                );
+                            }
+                            if *was_removed {
                                 self.handle_post_unsubscribe_webhooks(
                                     app_config,
-                                    &channel_name,
+                                    channel_name,
                                     user_id,
-                                    remaining_connections,
+                                    *remaining_connections,
                                     socket_id,
                                 )
                                 .await?;
@@ -626,6 +635,18 @@ impl ConnectionHandler {
                                 socket_id, channel_name, e
                             );
                         }
+                    }
+                }
+
+                if let Some(ref metrics) = self.metrics {
+                    for channel_type in &types_to_sync {
+                        super::sync_active_channel_count(
+                            &self.connection_manager,
+                            metrics,
+                            &app_config.id,
+                            channel_type,
+                        )
+                        .await;
                     }
                 }
             }

--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -783,88 +783,34 @@ impl ConnectionHandler {
 
         debug!("Socket {} cleanup completed", socket_id);
     }
+}
 
-    /// Increment the active channel count for a specific channel type
-    async fn increment_active_channel_count(
-        &self,
-        app_id: &str,
-        channel_type: &str,
-        metrics: Arc<dyn MetricsInterface + Send + Sync>,
-    ) {
-        // Get current count for this channel type
-        // IMPORTANT: We must get the count BEFORE acquiring the metrics lock to avoid deadlock
-        let current_count = self
-            .get_active_channel_count_for_type(app_id, channel_type)
-            .await;
-
-        // Now acquire the metrics lock and update
-        metrics.update_active_channels(app_id, channel_type, current_count + 1);
-
-        debug!(
-            "Incremented active {} channels for app {} to {}",
-            channel_type,
-            app_id,
-            current_count + 1
-        );
-    }
-
-    /// Decrement the active channel count for a specific channel type
-    async fn decrement_active_channel_count(
-        &self,
-        app_id: &str,
-        channel_type: &str,
-        metrics: Arc<dyn MetricsInterface + Send + Sync>,
-    ) {
-        // Get current count for this channel type
-        // IMPORTANT: We must get the count BEFORE acquiring the metrics lock to avoid deadlock
-        let current_count = self
-            .get_active_channel_count_for_type(app_id, channel_type)
-            .await;
-
-        // Decrement by 1, but never go below 0
-        let new_count = std::cmp::max(0, current_count - 1);
-
-        // Now acquire the metrics lock and update
-        metrics.update_active_channels(app_id, channel_type, new_count);
-
-        debug!(
-            "Decremented active {} channels for app {} to {}",
-            channel_type, app_id, new_count
-        );
-    }
-
-    /// Get the current count of active channels for a specific type
-    async fn get_active_channel_count_for_type(&self, app_id: &str, channel_type: &str) -> i64 {
-        // Get all channels with their socket counts
-        let channels_map = {
-            match self
-                .connection_manager
-                .get_channels_with_socket_count(app_id)
-                .await
-            {
-                Ok(map) => map,
-                Err(e) => {
-                    error!("Failed to get channels for metrics update: {}", e);
-                    return 0;
-                }
-            }
-        };
-
-        // Count active channels of the specified type
-        // This processing happens AFTER the connection_manager lock is released
-        let mut count = 0i64;
-        for (channel_name, socket_count) in &channels_map {
-            // Only count channels that have active connections
-            if *socket_count > 0 {
-                let ch_type = sockudo_core::channel::ChannelType::from_name(channel_name);
-                let ch_type_str = ch_type.as_str();
-
-                if ch_type_str == channel_type {
-                    count += 1;
-                }
-            }
+/// Sync the active channel gauge for a given channel type by recounting live channels
+/// from the DashMap.
+pub async fn sync_active_channel_count(
+    connection_manager: &Arc<dyn ConnectionManager + Send + Sync>,
+    metrics: &Arc<dyn MetricsInterface + Send + Sync>,
+    app_id: &str,
+    channel_type: &str,
+) {
+    let channels_map = match connection_manager
+        .get_channels_with_socket_count(app_id)
+        .await
+    {
+        Ok(map) => map,
+        Err(e) => {
+            error!("Failed to get channels for metrics sync: {}", e);
+            return;
         }
+    };
 
-        count
-    }
+    let count = channels_map
+        .iter()
+        .filter(|(name, cnt)| {
+            **cnt > 0
+                && sockudo_core::channel::ChannelType::from_name(name).as_str() == channel_type
+        })
+        .count() as i64;
+
+    metrics.update_active_channels(app_id, channel_type, count);
 }

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -205,14 +205,13 @@ impl ConnectionHandler {
                 metrics.mark_channel_subscription(&app_config.id, channel_type_str);
             }
 
-            // Update active channel count if this is the first connection to the channel
+            // Sync active channel gauge if this is the first connection to the channel
             if subscription_result.channel_connections == Some(1) {
-                // Channel became active - increment the count for this channel type
-                // Pass the Arc directly to avoid holding any locks
-                self.increment_active_channel_count(
+                super::sync_active_channel_count(
+                    &self.connection_manager,
+                    metrics,
                     &app_config.id,
                     channel_type_str,
-                    metrics.clone(),
                 )
                 .await;
             }

--- a/crates/sockudo-server/src/cleanup/multi_worker.rs
+++ b/crates/sockudo-server/src/cleanup/multi_worker.rs
@@ -2,6 +2,7 @@ use super::{CleanupConfig, CleanupSenderHandle, WorkerThreadsResolve, worker::Cl
 use crossfire::mpsc;
 use sockudo_adapter::connection_manager::ConnectionManager;
 use sockudo_core::app::AppManager;
+use sockudo_core::metrics::MetricsInterface;
 use sockudo_core::options::PresenceHistoryConfig;
 use sockudo_core::presence_history::PresenceHistoryStore;
 use sockudo_webhook::WebhookIntegration;
@@ -23,6 +24,7 @@ impl MultiWorkerCleanupSystem {
         presence_history_store: Arc<dyn PresenceHistoryStore + Send + Sync>,
         presence_history_config: PresenceHistoryConfig,
         config: CleanupConfig,
+        metrics: Option<Arc<dyn MetricsInterface + Send + Sync>>,
     ) -> Self {
         let num_workers = config.worker_threads.resolve();
 
@@ -46,6 +48,7 @@ impl MultiWorkerCleanupSystem {
                 presence_history_store.clone(),
                 presence_history_config.clone(),
                 worker_config.clone(),
+                metrics.clone(),
             );
 
             let handle = tokio::spawn(async move {

--- a/crates/sockudo-server/src/cleanup/worker.rs
+++ b/crates/sockudo-server/src/cleanup/worker.rs
@@ -2,12 +2,16 @@ use super::{CleanupConfig, ConnectionCleanupInfo, DisconnectTask, WebhookEvent};
 use ahash::AHashMap;
 use sockudo_adapter::channel_manager::ChannelManager;
 use sockudo_adapter::connection_manager::ConnectionManager;
+use sockudo_adapter::handler::sync_active_channel_count;
 use sockudo_adapter::presence::global_presence_manager;
 use sockudo_core::app::AppManager;
+use sockudo_core::channel::ChannelType;
+use sockudo_core::metrics::MetricsInterface;
 use sockudo_core::options::PresenceHistoryConfig;
 use sockudo_core::presence_history::{PresenceHistoryEventCause, PresenceHistoryStore};
 use sockudo_core::websocket::SocketId;
 use sockudo_webhook::WebhookIntegration;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::timeout;
@@ -21,6 +25,7 @@ pub struct CleanupWorker {
     presence_history_store: Arc<dyn PresenceHistoryStore + Send + Sync>,
     presence_history_config: PresenceHistoryConfig,
     config: CleanupConfig,
+    metrics: Option<Arc<dyn MetricsInterface + Send + Sync>>,
 }
 
 impl CleanupWorker {
@@ -31,6 +36,7 @@ impl CleanupWorker {
         presence_history_store: Arc<dyn PresenceHistoryStore + Send + Sync>,
         presence_history_config: PresenceHistoryConfig,
         config: CleanupConfig,
+        metrics: Option<Arc<dyn MetricsInterface + Send + Sync>>,
     ) -> Self {
         Self {
             connection_manager,
@@ -39,6 +45,7 @@ impl CleanupWorker {
             presence_history_store,
             presence_history_config,
             config,
+            metrics,
         }
     }
 
@@ -190,9 +197,18 @@ impl CleanupWorker {
 
             match ChannelManager::batch_unsubscribe(&self.connection_manager, operations).await {
                 Ok(results) => {
-                    for (_channel_name, result) in results {
+                    let mut types_to_sync: HashSet<String> = HashSet::new();
+
+                    for (channel_name, result) in &results {
                         match result {
-                            Ok(_) => total_success += 1,
+                            Ok((_, remaining_connections)) => {
+                                total_success += 1;
+                                if *remaining_connections == 0 {
+                                    types_to_sync.insert(
+                                        ChannelType::from_name(channel_name).as_str().to_string(),
+                                    );
+                                }
+                            }
                             Err(e) => {
                                 total_errors += 1;
                                 warn!(
@@ -200,6 +216,18 @@ impl CleanupWorker {
                                     app_id, e
                                 );
                             }
+                        }
+                    }
+
+                    if let Some(ref metrics) = self.metrics {
+                        for channel_type in &types_to_sync {
+                            sync_active_channel_count(
+                                &self.connection_manager,
+                                metrics,
+                                &app_id,
+                                channel_type,
+                            )
+                            .await;
                         }
                     }
                 }

--- a/crates/sockudo-server/src/main.rs
+++ b/crates/sockudo-server/src/main.rs
@@ -754,6 +754,7 @@ impl SockudoServer {
                 presence_history_store.clone(),
                 config.presence_history.clone(),
                 cleanup_config.clone(),
+                metrics.clone(),
             );
 
             let cleanup_sender =


### PR DESCRIPTION
The active_channels Prometheus gauge grew monotonically in production because decrements only fired on explicit `pusher:unsubscribe` events, never on WebSocket drops.
Since connections almost always close without unsubscribing first, the gauge accumulated every channel that was ever subscribed.

A secondary off-by-one existed in both increment and decrement paths: the DashMap was read after mutation, so the count already reflected the change, then ±1 was applied on top, making increment one too high and decrement one too low.

Replace `increment_active_channel_count` / `decrement_active_channel_count` with a single `sync_active_channel_count` free function that re-reads the live channel count from the DashMap and sets the gauge to the exact value. Wire it into all four channel lifecycle paths:

- subscribe (first connection to channel)
- explicit unsubscribe (last connection leaves)
- sync disconnect batch (WebSocket drop, activity timeout, broken pipe)
- async cleanup worker batch (deferred disconnect processing)

Tested in production for 24h+ hours and working fine.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->