### PR TITLE
fix: cancel shutdown token on writer death and reject sends on dead connections

### DIFF
--- a/crates/sockudo-core/src/websocket.rs
+++ b/crates/sockudo-core/src/websocket.rs
@@ -653,6 +653,10 @@ impl MessageSender {
                 }
             }
 
+            // Signal the reader loop that the writer is dead.
+            // cancel() is idempotent, safe if already cancelled by normal shutdown.
+            shutdown_token.cancel();
+
             if let Err(e) = socket.close(1000, "Normal closure").await {
                 Self::log_connection_error(&e, SocketOperation::SendCloseFrame, msg_count, true);
             }
@@ -818,7 +822,7 @@ impl WebSocket {
     }
 
     fn ensure_can_send(&self) -> Result<()> {
-        if self.is_connected() {
+        if self.is_connected() && !self.shutdown_token.is_cancelled() {
             Ok(())
         } else {
             Err(Error::ConnectionClosed(
@@ -873,6 +877,7 @@ impl WebSocket {
     }
 
     pub fn send_frame(&self, message: Message) -> Result<()> {
+        self.ensure_can_send()?;
         self.message_sender.send(message)
     }
 
@@ -1463,5 +1468,59 @@ mod tests {
         let config = WebSocketBufferConfig::new(500, false);
         assert_eq!(config.channel_capacity(), 500);
         assert!(!config.disconnect_on_full);
+    }
+
+    fn create_test_message_sender() -> MessageSender {
+        let (sender, _receiver) = mpsc::bounded_async::<Message>(1);
+        MessageSender {
+            sender,
+            receiver_handle: None,
+        }
+    }
+
+    fn create_test_websocket(shutdown_token: CancellationToken) -> WebSocket {
+        let (broadcast_tx, _broadcast_rx) = mpsc::bounded_async::<SizedMessage>(1);
+        WebSocket {
+            state: ConnectionState::with_socket_id(SocketId::new()),
+            message_sender: create_test_message_sender(),
+            broadcast_tx,
+            buffer_config: WebSocketBufferConfig::default(),
+            byte_counter: None,
+            shutdown_token,
+        }
+    }
+
+    #[test]
+    fn test_send_rejected_on_cancelled_token() {
+        let shutdown_token = CancellationToken::new();
+        let ws = create_test_websocket(shutdown_token.clone());
+
+        assert!(ws.is_connected());
+
+        shutdown_token.cancel();
+
+        let result = ws.send_text("hello".to_string());
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            Error::ConnectionClosed(_) => {}
+            other => panic!("expected ConnectionClosed, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_normal_close_still_rejects() {
+        let shutdown_token = CancellationToken::new();
+        let mut ws = create_test_websocket(shutdown_token);
+
+        assert!(ws.is_connected());
+
+        ws.state.status = ConnectionStatus::Closed;
+
+        let result = ws.send_text("hello".to_string());
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            Error::ConnectionClosed(_) => {}
+            other => panic!("expected ConnectionClosed, got: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
When the WebSocket writer task exits (write error, channel closure, etc.), the shutdown_token was never cancelled. This left the reader loop alive on a dead connection — a resource leak that silently accumulated under load.

Additionally, `send_text()` and `send_message()` would return Ok(()) on a connection whose writer was dead, because `ensure_can_send()` only checked `is_connected()` (connection status), not whether the writer was still alive. Messages are queued into the dead channel buffer until it is filled.

Root cause: the writer loop in `MessageSender::new_with_broadcast` broke out of its `select!` loop on errors but never signalled anyone. The `shutdown_token` existed for coordinated shutdown but was only cancelled by external callers, never by the writer itself.

Fix:
- Call `shutdown_token.cancel()` after the writer loop exits. `cancel()` is idempotent, so the normal-shutdown path (token already cancelled) is unaffected.
- Add `!self.shutdown_token.is_cancelled()` to `ensure_can_send()`, so send_message/send_text/send_frame all reject immediately when the writer is dead, returning `ConnectionClosed` instead of silently buffering.
- Guard `send_frame()` through `ensure_can_send()` (previously it bypassed the check entirely, going straight to `message_sender.send()`).

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->