### PR TITLE
Use native WebSocket heartbeats for V2 while preserving V1 ping/pong

### DIFF
--- a/benches/sender/Cargo.toml
+++ b/benches/sender/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[workspace]
+
 [dependencies]
 clap = { version = "4.5.51", features = ["derive"] }
 pushers = "1.5.0"

--- a/config/config.redis-cluster-delta-e2e.json
+++ b/config/config.redis-cluster-delta-e2e.json
@@ -1,0 +1,89 @@
+{
+  "app_manager": {
+    "driver": "memory",
+    "array": {
+      "apps": [
+        {
+          "id": "test-app",
+          "key": "test-key",
+          "secret": "test-secret",
+          "enabled": true,
+          "policy": {
+            "limits": {
+              "max_connections": 100,
+              "max_backend_events_per_second": 100,
+              "max_client_events_per_second": 100,
+              "max_read_requests_per_second": 100,
+              "max_presence_members_per_channel": 100,
+              "max_presence_member_size_in_kb": 100,
+              "max_channel_name_length": 100,
+              "max_event_channels_at_once": 100,
+              "max_event_name_length": 100,
+              "max_event_payload_in_kb": 100,
+              "max_event_batch_size": 100
+            },
+            "features": {
+              "enable_client_messages": true
+            },
+            "channels": {
+              "channel_namespaces": [
+                {
+                  "name": "ticker",
+                  "channel_name_pattern": "^ticker:[A-Z]+$",
+                  "allow_subscribe_for_client": true,
+                  "allow_publish_for_client": true
+                },
+                {
+                  "name": "presence-delta-cluster",
+                  "channel_name_pattern": "^presence-delta-cluster-[0-9]+$",
+                  "allow_subscribe_for_client": true,
+                  "allow_presence_for_client": true
+                }
+              ],
+              "channel_delta_compression": {
+                "ticker:*": {
+                  "enabled": true,
+                  "algorithm": "Fossil",
+                  "conflation_key": "symbol",
+                  "max_messages_per_key": 10,
+                  "max_conflation_keys": 100
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "delta_compression": {
+    "enabled": true,
+    "algorithm": "fossil",
+    "full_message_interval": 4,
+    "min_message_size": 64,
+    "max_state_age_secs": 300,
+    "max_channel_states_per_socket": 100,
+    "max_conflation_states_per_channel": 100,
+    "conflation_key_path": "symbol",
+    "cluster_coordination": true,
+    "coordination_backend": "redis_cluster",
+    "omit_delta_algorithm": false
+  },
+  "tag_filtering": {
+    "enabled": true,
+    "enable_tags": true
+  },
+  "history": {
+    "enabled": true,
+    "rewind_enabled": true,
+    "backend": "memory",
+    "retention_window_seconds": 300,
+    "max_page_size": 50,
+    "max_messages_per_channel": 50
+  },
+  "presence_history": {
+    "enabled": true,
+    "retention_window_seconds": 300,
+    "max_page_size": 50,
+    "max_events_per_channel": 50
+  }
+}

--- a/crates/sockudo-adapter/src/handler/timeout_management.rs
+++ b/crates/sockudo-adapter/src/handler/timeout_management.rs
@@ -2,6 +2,7 @@ use super::ConnectionHandler;
 use bytes::Bytes;
 use sockudo_core::error::Result;
 use sockudo_core::websocket::SocketId;
+use sockudo_protocol::ProtocolVersion;
 use sockudo_protocol::constants::PONG_TIMEOUT;
 use sockudo_protocol::messages::PusherMessage;
 use sockudo_ws::Message;
@@ -30,14 +31,30 @@ impl ConnectionHandler {
     }
 
     pub async fn set_activity_timeout(&self, app_id: &str, socket_id: &SocketId) -> Result<()> {
+        // Clear any existing timeout
+        self.clear_activity_timeout(app_id, socket_id).await?;
+
+        let Some(connection) = self
+            .connection_manager
+            .get_connection(socket_id, app_id)
+            .await
+        else {
+            return Ok(());
+        };
+
+        if connection.protocol_version == ProtocolVersion::V2 {
+            debug!(
+                "Skipping app-level activity timeout loop for V2 socket {} (native WebSocket ping/pong handles heartbeats)",
+                socket_id
+            );
+            return Ok(());
+        }
+
         let socket_id_clone = *socket_id;
         let app_id_clone = app_id.to_string();
         let connection_manager = self.connection_manager.clone();
         let handler = self.clone();
         let activity_timeout = self.server_options.activity_timeout;
-
-        // Clear any existing timeout
-        self.clear_activity_timeout(app_id, socket_id).await?;
 
         let timeout_handle = tokio::spawn(async move {
             // Initial sleep before first check

--- a/crates/sockudo-adapter/src/handler/types.rs
+++ b/crates/sockudo-adapter/src/handler/types.rs
@@ -329,7 +329,8 @@ impl SubscriptionRequest {
 
         #[cfg(feature = "tag-filtering")]
         let tags_filter = effective_tags_filter_raw
-            .and_then(|v| sonic_rs::from_value::<FilterNode>(&v).ok())
+            .and_then(|v| sonic_rs::to_vec(&v).ok())
+            .and_then(|bytes| sonic_rs::from_slice::<FilterNode>(&bytes).ok())
             .map(|mut filter| {
                 // PERFORMANCE: Pre-build HashSet caches for large IN/NIN operators
                 filter.optimize();
@@ -503,12 +504,18 @@ mod tests {
     fn test_extract_event_name_filter_compound_with_events() {
         let filter = json!({
             "events": ["price-update", "trade-executed"],
-            "tags": "headers.asset == \"BTC\""
+            "tags": {
+                "cmp": "eq",
+                "key": "headers.asset",
+                "val": "BTC"
+            }
         });
         let (events, tags) = SubscriptionRequest::extract_event_name_filter(Some(filter));
         assert_eq!(events.unwrap(), vec!["price-update", "trade-executed"]);
-        assert!(tags.is_some());
-        assert_eq!(tags.unwrap().as_str().unwrap(), "headers.asset == \"BTC\"");
+        let tags = tags.unwrap();
+        assert_eq!(tags["cmp"].as_str(), Some("eq"));
+        assert_eq!(tags["key"].as_str(), Some("headers.asset"));
+        assert_eq!(tags["val"].as_str(), Some("BTC"));
     }
 
     #[test]
@@ -543,6 +550,38 @@ mod tests {
         let (events, tags) = SubscriptionRequest::extract_event_name_filter(Some(filter.clone()));
         assert!(events.is_none());
         assert_eq!(tags.unwrap(), filter);
+    }
+
+    #[test]
+    fn test_compound_filter_parses_tags_filter_node() {
+        let filter = json!({
+            "events": ["price-update"],
+            "tags": {
+                "cmp": "eq",
+                "key": "symbol",
+                "val": "BTC"
+            }
+        });
+
+        let request = SubscriptionRequest::build(
+            "ticker:*".to_string(),
+            None,
+            None,
+            Some(filter),
+            None,
+            None,
+            &event_name_filtering_config(),
+        )
+        .unwrap();
+
+        assert_eq!(request.event_name_filter.unwrap(), vec!["price-update"]);
+        #[cfg(feature = "tag-filtering")]
+        {
+            let tags_filter = request.tags_filter.expect("expected tags filter");
+            assert_eq!(tags_filter.cmp.as_deref(), Some("eq"));
+            assert_eq!(tags_filter.key.as_deref(), Some("symbol"));
+            assert_eq!(tags_filter.val.as_deref(), Some("BTC"));
+        }
     }
 
     #[test]

--- a/crates/sockudo-adapter/src/horizontal_adapter.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter.rs
@@ -189,7 +189,7 @@ pub struct HorizontalAdapter {
     pub local_adapter: Arc<LocalAdapter>,
 
     /// Pending requests map - Use DashMap for thread-safe access
-    pub pending_requests: DashMap<String, PendingRequest>,
+    pub pending_requests: Arc<DashMap<String, PendingRequest>>,
 
     /// Timeout for requests in milliseconds
     pub requests_timeout: AtomicU64,
@@ -219,7 +219,7 @@ impl HorizontalAdapter {
         Self {
             node_id: Uuid::new_v4().to_string(),
             local_adapter: Arc::new(LocalAdapter::new()),
-            pending_requests: DashMap::new(),
+            pending_requests: Arc::new(DashMap::new()),
             requests_timeout: AtomicU64::new(5000),
             metrics: OnceLock::new(),
             cluster_presence_registry: Arc::new(RwLock::new(AHashMap::new())),
@@ -234,10 +234,8 @@ impl HorizontalAdapter {
 
     /// Start the request cleanup task
     pub fn start_request_cleanup(&self) {
-        // Clone data needed for the task
-        // let node_id = self.node_id.clone();
         let timeout = self.requests_timeout.load(Ordering::Relaxed);
-        let pending_requests_clone = self.pending_requests.clone();
+        let pending_requests = Arc::clone(&self.pending_requests);
 
         // Spawn a background task to clean up stale requests
         tokio::spawn(async move {
@@ -249,7 +247,7 @@ impl HorizontalAdapter {
                 let mut expired_requests = Vec::new();
 
                 // We can't modify pending_requests while iterating
-                for entry in &pending_requests_clone {
+                for entry in pending_requests.iter() {
                     let request_id = entry.key();
                     let request = entry.value();
                     if now.duration_since(request.start_time).as_millis() > timeout as u128 {
@@ -260,7 +258,9 @@ impl HorizontalAdapter {
                 // Process expired requests
                 for request_id in expired_requests {
                     warn!("{}", format!("Request {} expired", request_id));
-                    pending_requests_clone.remove(&request_id);
+                    if let Some((_, request)) = pending_requests.remove(&request_id) {
+                        request.notify.notify_waiters();
+                    }
                 }
             }
         });
@@ -372,10 +372,7 @@ impl HorizontalAdapter {
                     .local_adapter
                     .get_all_connections(&request.app_id)
                     .await;
-                response.socket_ids = connections
-                    .iter()
-                    .map(|entry| entry.key().to_string())
-                    .collect();
+                response.socket_ids = connections.iter().map(ToString::to_string).collect();
                 response.sockets_count = connections.len();
             }
             RequestType::Channels => {
@@ -571,6 +568,97 @@ impl HorizontalAdapter {
         Ok(())
     }
 
+    async fn wait_for_request_responses(
+        &self,
+        request_id: &str,
+        start: Instant,
+        timeout_duration: Duration,
+        max_expected_responses: usize,
+    ) -> Vec<ResponseBody> {
+        let deadline = start + timeout_duration;
+
+        loop {
+            let Some(notify) = self
+                .pending_requests
+                .get(request_id)
+                .map(|request| Arc::clone(&request.notify))
+            else {
+                return Vec::new();
+            };
+            let notified = notify.notified();
+            tokio::pin!(notified);
+
+            let response_count = self
+                .pending_requests
+                .get(request_id)
+                .map(|pending_request| pending_request.responses.len());
+
+            match response_count {
+                Some(count) if count >= max_expected_responses => {
+                    debug!(
+                        "Request {} completed successfully with {}/{} responses in {}ms",
+                        request_id,
+                        count,
+                        max_expected_responses,
+                        start.elapsed().as_millis()
+                    );
+                    return self
+                        .pending_requests
+                        .remove(request_id)
+                        .map(|(_, req)| req.responses)
+                        .unwrap_or_default();
+                }
+                Some(_) => {}
+                None => return Vec::new(),
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                let current_responses = self
+                    .pending_requests
+                    .get(request_id)
+                    .map(|r| r.responses.len())
+                    .unwrap_or(0);
+                warn!(
+                    "Request {} timed out after {}ms, got {} responses out of {} expected",
+                    request_id,
+                    start.elapsed().as_millis(),
+                    current_responses,
+                    max_expected_responses
+                );
+                return self
+                    .pending_requests
+                    .remove(request_id)
+                    .map(|(_, req)| req.responses)
+                    .unwrap_or_default();
+            }
+
+            let remaining = deadline.saturating_duration_since(now);
+            if tokio::time::timeout(remaining, &mut notified)
+                .await
+                .is_err()
+            {
+                let current_responses = self
+                    .pending_requests
+                    .get(request_id)
+                    .map(|r| r.responses.len())
+                    .unwrap_or(0);
+                warn!(
+                    "Request {} timed out after {}ms, got {} responses out of {} expected",
+                    request_id,
+                    start.elapsed().as_millis(),
+                    current_responses,
+                    max_expected_responses
+                );
+                return self
+                    .pending_requests
+                    .remove(request_id)
+                    .map(|(_, req)| req.responses)
+                    .unwrap_or_default();
+            }
+        }
+    }
+
     /// Send a request to other nodes and wait for responses
     pub async fn send_request(
         &mut self,
@@ -653,57 +741,14 @@ impl HorizontalAdapter {
             });
         }
 
-        // Improved waiting logic
-        let check_interval = Duration::from_millis(50);
-        let mut checks = 0;
-        let max_checks = (timeout_duration.as_millis() / check_interval.as_millis()) as usize;
-
-        let responses = loop {
-            if checks >= max_checks {
-                let current_responses = self
-                    .pending_requests
-                    .get(&request_id)
-                    .map(|r| r.responses.len())
-                    .unwrap_or(0);
-
-                warn!(
-                    "Request {} timed out after {}ms, got {} responses out of {} expected",
-                    request_id,
-                    start.elapsed().as_millis(),
-                    current_responses,
-                    max_expected_responses
-                );
-                break self
-                    .pending_requests
-                    .remove(&request_id)
-                    .map(|(_, req)| req.responses)
-                    .unwrap_or_default();
-            }
-
-            if let Some(pending_request) = self.pending_requests.get(&request_id) {
-                if pending_request.responses.len() >= max_expected_responses {
-                    debug!(
-                        "Request {} completed successfully with {}/{} responses in {}ms",
-                        request_id,
-                        pending_request.responses.len(),
-                        max_expected_responses,
-                        start.elapsed().as_millis()
-                    );
-                    break self
-                        .pending_requests
-                        .remove(&request_id)
-                        .map(|(_, req)| req.responses)
-                        .unwrap_or_default();
-                }
-            } else {
-                return Err(Error::Other(format!(
-                    "Request {request_id} was removed unexpectedly (possibly by cleanup task)"
-                )));
-            }
-
-            tokio::time::sleep(check_interval).await;
-            checks += 1;
-        };
+        let responses = self
+            .wait_for_request_responses(
+                &request_id,
+                start,
+                timeout_duration,
+                max_expected_responses,
+            )
+            .await;
 
         // Use the aggregation method
         let responses_received = responses.len();
@@ -1149,4 +1194,83 @@ pub fn current_timestamp() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{Duration, sleep, timeout};
+
+    #[tokio::test]
+    async fn request_cleanup_operates_on_live_pending_requests() {
+        let adapter = HorizontalAdapter::new();
+        adapter.requests_timeout.store(1, Ordering::Relaxed);
+        adapter.start_request_cleanup();
+        adapter.pending_requests.insert(
+            "expired".to_string(),
+            PendingRequest {
+                start_time: Instant::now() - Duration::from_secs(1),
+                app_id: "app".to_string(),
+                responses: Vec::new(),
+                notify: Arc::new(Notify::new()),
+            },
+        );
+
+        timeout(Duration::from_secs(2), async {
+            loop {
+                if !adapter.pending_requests.contains_key("expired") {
+                    break;
+                }
+                sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("cleanup should remove expired live requests");
+    }
+
+    #[tokio::test]
+    async fn send_request_wakes_on_notify_without_polling_delay() {
+        let adapter = Arc::new(HorizontalAdapter::new());
+        adapter.pending_requests.insert(
+            "req-1".to_string(),
+            PendingRequest {
+                start_time: Instant::now(),
+                app_id: "app".to_string(),
+                responses: Vec::new(),
+                notify: Arc::new(Notify::new()),
+            },
+        );
+
+        let wait_adapter = Arc::clone(&adapter);
+        let waiter = tokio::spawn(async move {
+            wait_adapter
+                .wait_for_request_responses("req-1", Instant::now(), Duration::from_millis(40), 1)
+                .await
+        });
+
+        sleep(Duration::from_millis(10)).await;
+        adapter
+            .process_response(ResponseBody {
+                request_id: "req-1".to_string(),
+                node_id: "node-2".to_string(),
+                app_id: "app".to_string(),
+                members: AHashMap::new(),
+                channels_with_sockets_count: AHashMap::new(),
+                socket_ids: vec!["socket-1".to_string()],
+                sockets_count: 1,
+                exists: true,
+                channels: HashSet::new(),
+                members_count: 0,
+                responses_received: 0,
+                expected_responses: 0,
+                complete: true,
+            })
+            .await
+            .unwrap();
+
+        let responses = timeout(Duration::from_millis(20), waiter)
+            .await
+            .expect("notify should wake waiter before timeout");
+        assert_eq!(responses.unwrap().len(), 1);
+    }
 }

--- a/crates/sockudo-adapter/src/local_adapter.rs
+++ b/crates/sockudo-adapter/src/local_adapter.rs
@@ -1146,6 +1146,10 @@ impl LocalAdapter {
             .partition(|s| s.protocol_version == sockudo_protocol::ProtocolVersion::V1)
     }
 
+    fn should_assign_v2_message_id(message: &PusherMessage) -> bool {
+        message.message_id.is_none() && !message.is_protocol_ping_or_pong()
+    }
+
     fn v1_compatible_message(message: &PusherMessage) -> Option<PusherMessage> {
         if extract_runtime_action(message).is_some() {
             return None;
@@ -1456,7 +1460,7 @@ impl ConnectionManager for LocalAdapter {
         match connection.protocol_version {
             sockudo_protocol::ProtocolVersion::V2 => {
                 let mut rewritten = message;
-                if rewritten.message_id.is_none() {
+                if Self::should_assign_v2_message_id(&rewritten) {
                     rewritten.message_id = Some(generate_message_id());
                 }
                 rewritten.rewrite_prefix(sockudo_protocol::ProtocolVersion::V2);
@@ -1968,5 +1972,26 @@ mod tests {
         message.stream_id = Some("stream-1".to_string());
 
         assert!(LocalAdapter::v1_compatible_message(&message).is_none());
+    }
+
+    #[test]
+    fn v2_runtime_message_id_skips_protocol_heartbeats() {
+        assert!(!LocalAdapter::should_assign_v2_message_id(
+            &PusherMessage::ping()
+        ));
+        assert!(!LocalAdapter::should_assign_v2_message_id(
+            &PusherMessage::pong()
+        ));
+    }
+
+    #[test]
+    fn v2_runtime_message_id_still_assigns_regular_messages() {
+        let message = PusherMessage::channel_event(
+            "chat.message",
+            "room",
+            sonic_rs::json!({"text": "hello"}),
+        );
+
+        assert!(LocalAdapter::should_assign_v2_message_id(&message));
     }
 }

--- a/crates/sockudo-adapter/src/local_adapter.rs
+++ b/crates/sockudo-adapter/src/local_adapter.rs
@@ -341,8 +341,8 @@ impl LocalAdapter {
         for socket_ref in target_socket_refs {
             let socket_id = socket_ref.get_socket_id_sync();
 
-            // Check if socket has delta enabled
-            if delta_compression.is_enabled_for_socket(socket_id) {
+            // Check if socket has delta enabled for this specific channel
+            if delta_compression.is_enabled_for_socket_channel(socket_id, channel) {
                 debug!(
                     "Socket {} has delta compression enabled for channel {}",
                     socket_id, channel
@@ -699,7 +699,7 @@ impl LocalAdapter {
 
         // Only process delta compression if it's enabled for this socket
         let (compression_result, message_with_sequence) = if !delta_compression
-            .is_enabled_for_socket(socket_id)
+            .is_enabled_for_socket_channel(socket_id, channel)
         {
             (CompressionResult::Uncompressed, base_message_bytes.clone())
         } else {
@@ -1139,11 +1139,10 @@ impl LocalAdapter {
             .clone()
     }
 
-    /// Partition socket refs into V1 (strict Pusher) and V2 (Sockudo-native) groups.
-    fn partition_by_protocol(sockets: Vec<WebSocketRef>) -> (Vec<WebSocketRef>, Vec<WebSocketRef>) {
-        sockets
-            .into_iter()
-            .partition(|s| s.protocol_version == sockudo_protocol::ProtocolVersion::V1)
+    fn existing_namespace(&self, app_id: &str) -> Option<Arc<Namespace>> {
+        self.namespaces
+            .get(app_id)
+            .map(|namespace| namespace.value().clone())
     }
 
     fn should_assign_v2_message_id(message: &PusherMessage) -> bool {
@@ -1199,17 +1198,17 @@ impl LocalAdapter {
 
     /// Apply tag filtering to V2 sockets. When the `tag-filtering` feature is
     /// disabled this is a no-op that returns the input unchanged.
-    fn filter_v2_sockets(
+    fn filter_v2_sockets_in_place(
         &self,
         channel: &str,
         message: &PusherMessage,
-        v2_sockets: Vec<WebSocketRef>,
+        v2_sockets: &mut Vec<WebSocketRef>,
         except: Option<&SocketId>,
         namespace: &Namespace,
-    ) -> Vec<WebSocketRef> {
+    ) {
         #[cfg(feature = "tag-filtering")]
         {
-            crate::v2_broadcast::apply_tag_filter(
+            crate::v2_broadcast::apply_tag_filter_in_place(
                 &self.filter_index,
                 self.tag_filtering_enabled.load(Ordering::Acquire),
                 channel,
@@ -1221,8 +1220,7 @@ impl LocalAdapter {
         }
         #[cfg(not(feature = "tag-filtering"))]
         {
-            let _ = (channel, message, except, namespace);
-            v2_sockets
+            let _ = (channel, message, v2_sockets, except, namespace);
         }
     }
 
@@ -1230,17 +1228,17 @@ impl LocalAdapter {
     /// matched sockets (used by `send_with_compression` where the filter index
     /// may contain both V1 and V2 socket IDs).
     #[cfg(feature = "delta")]
-    fn filter_v2_sockets_strict(
+    fn filter_v2_sockets_strict_in_place(
         &self,
         channel: &str,
         message: &PusherMessage,
-        v2_sockets: Vec<WebSocketRef>,
+        v2_sockets: &mut Vec<WebSocketRef>,
         except: Option<&SocketId>,
         namespace: &Namespace,
-    ) -> Vec<WebSocketRef> {
+    ) {
         #[cfg(feature = "tag-filtering")]
         {
-            crate::v2_broadcast::apply_tag_filter_v2_only(
+            crate::v2_broadcast::apply_tag_filter_v2_only_in_place(
                 &self.filter_index,
                 self.tag_filtering_enabled.load(Ordering::Acquire),
                 channel,
@@ -1252,8 +1250,7 @@ impl LocalAdapter {
         }
         #[cfg(not(feature = "tag-filtering"))]
         {
-            let _ = (channel, message, except, namespace);
-            v2_sockets
+            let _ = (channel, message, v2_sockets, except, namespace);
         }
     }
 
@@ -1278,26 +1275,27 @@ impl LocalAdapter {
         }
     }
 
-    async fn split_rewind_gated_sockets(
+    async fn split_rewind_gated_sockets_in_place(
         &self,
         channel: &str,
         message: &PusherMessage,
-        sockets: Vec<WebSocketRef>,
-    ) -> Vec<WebSocketRef> {
-        let mut ungated = Vec::with_capacity(sockets.len());
-        for socket in sockets {
-            if socket.buffer_rewind_message(channel, message).await {
-                continue;
+        sockets: &mut Vec<WebSocketRef>,
+    ) {
+        let mut index = 0;
+        while index < sockets.len() {
+            if sockets[index].buffer_rewind_message(channel, message).await {
+                sockets.swap_remove(index);
+            } else {
+                index += 1;
             }
-            ungated.push(socket);
         }
-        ungated
     }
 
     // Updated to return WebSocketRef instead of Arc<Mutex<WebSocket>>
-    pub async fn get_all_connections(&self, app_id: &str) -> DashMap<SocketId, WebSocketRef> {
-        let namespace = self.get_or_create_namespace(app_id).await;
-        namespace.sockets.clone()
+    pub async fn get_all_connections(&self, app_id: &str) -> Vec<SocketId> {
+        self.existing_namespace(app_id)
+            .map(|namespace| namespace.sockets.iter().map(|entry| *entry.key()).collect())
+            .unwrap_or_default()
     }
 
     /// Fast-path channel join for LocalAdapter - atomic operation without locks
@@ -1380,7 +1378,7 @@ impl ConnectionManager for LocalAdapter {
     }
 
     async fn get_namespace(&self, app_id: &str) -> Option<Arc<Namespace>> {
-        Some(self.get_or_create_namespace(app_id).await)
+        self.existing_namespace(app_id)
     }
 
     async fn add_socket(
@@ -1426,8 +1424,9 @@ impl ConnectionManager for LocalAdapter {
             "LocalAdapter::get_connection: looking for socket {} in app {}",
             socket_id, app_id
         );
-        let namespace = self.get_or_create_namespace(app_id).await;
-        let result = namespace.get_connection(socket_id);
+        let result = self
+            .existing_namespace(app_id)
+            .and_then(|namespace| namespace.get_connection(socket_id));
         debug!(
             "LocalAdapter::get_connection: socket {} in app {} found: {}",
             socket_id,
@@ -1530,10 +1529,12 @@ impl ConnectionManager for LocalAdapter {
         }
 
         // Fall back to regular sending without delta compression
-        let namespace = self.get_namespace(app_id).await.unwrap();
+        let Some(namespace) = self.get_namespace(app_id).await else {
+            return Ok(());
+        };
 
         // Get target socket references based on channel type
-        let target_socket_refs = if channel.starts_with("#server-to-user-") {
+        let (v1_all_sockets, v2_target_sockets) = if channel.starts_with("#server-to-user-") {
             let user_id = channel.trim_start_matches("#server-to-user-");
             let socket_refs = namespace.get_user_sockets(user_id).await?;
 
@@ -1545,23 +1546,28 @@ impl ConnectionManager for LocalAdapter {
                 }
             }
             target_refs
+                .into_iter()
+                .partition(|s| s.protocol_version == sockudo_protocol::ProtocolVersion::V1)
         } else {
-            namespace.get_matching_channel_socket_refs_except(channel, except)
+            namespace.get_matching_channel_socket_refs_partitioned_except(channel, except)
         };
-
-        let (v1_all_sockets, v2_target_sockets) = Self::partition_by_protocol(target_socket_refs);
 
         self.send_to_v1_sockets(v1_all_sockets, &message).await?;
 
-        let filtered_socket_refs =
-            self.filter_v2_sockets(channel, &message, v2_target_sockets, except, &namespace);
-
-        // Apply event name filtering (V2 only)
-        let filtered_socket_refs =
-            crate::v2_broadcast::apply_event_name_filter(channel, &message, filtered_socket_refs);
-
-        let filtered_socket_refs = self
-            .split_rewind_gated_sockets(channel, &message, filtered_socket_refs)
+        let mut filtered_socket_refs = v2_target_sockets;
+        self.filter_v2_sockets_in_place(
+            channel,
+            &message,
+            &mut filtered_socket_refs,
+            except,
+            &namespace,
+        );
+        crate::v2_broadcast::apply_event_name_filter_in_place(
+            channel,
+            &message,
+            &mut filtered_socket_refs,
+        );
+        self.split_rewind_gated_sockets_in_place(channel, &message, &mut filtered_socket_refs)
             .await;
 
         // Send to filtered V2 sockets (Sockudo-native: sockudo: prefix, serial + message_id)
@@ -1594,10 +1600,12 @@ impl ConnectionManager for LocalAdapter {
         );
         debug!("Message: {:?}", message);
 
-        let namespace = self.get_namespace(app_id).await.unwrap();
+        let Some(namespace) = self.get_namespace(app_id).await else {
+            return Ok(());
+        };
 
         // Get target socket references based on channel type
-        let target_socket_refs = if channel.starts_with("#server-to-user-") {
+        let (v1_all_sockets, v2_target_sockets) = if channel.starts_with("#server-to-user-") {
             let user_id = channel.trim_start_matches("#server-to-user-");
             let socket_refs = namespace.get_user_sockets(user_id).await?;
 
@@ -1609,23 +1617,28 @@ impl ConnectionManager for LocalAdapter {
                 }
             }
             target_refs
+                .into_iter()
+                .partition(|s| s.protocol_version == sockudo_protocol::ProtocolVersion::V1)
         } else {
-            namespace.get_matching_channel_socket_refs_except(channel, except)
+            namespace.get_matching_channel_socket_refs_partitioned_except(channel, except)
         };
-
-        let (v1_all_sockets, v2_target_sockets) = Self::partition_by_protocol(target_socket_refs);
 
         self.send_to_v1_sockets(v1_all_sockets, &message).await?;
 
-        let filtered_socket_refs =
-            self.filter_v2_sockets_strict(channel, &message, v2_target_sockets, except, &namespace);
-
-        // Apply event name filtering (V2 only)
-        let filtered_socket_refs =
-            crate::v2_broadcast::apply_event_name_filter(channel, &message, filtered_socket_refs);
-
-        let filtered_socket_refs = self
-            .split_rewind_gated_sockets(channel, &message, filtered_socket_refs)
+        let mut filtered_socket_refs = v2_target_sockets;
+        self.filter_v2_sockets_strict_in_place(
+            channel,
+            &message,
+            &mut filtered_socket_refs,
+            except,
+            &namespace,
+        );
+        crate::v2_broadcast::apply_event_name_filter_in_place(
+            channel,
+            &message,
+            &mut filtered_socket_refs,
+        );
+        self.split_rewind_gated_sockets_in_place(channel, &message, &mut filtered_socket_refs)
             .await;
 
         let message = self.maybe_strip_tags(message, channel_settings);
@@ -1662,13 +1675,17 @@ impl ConnectionManager for LocalAdapter {
         app_id: &str,
         channel: &str,
     ) -> Result<HashMap<String, PresenceMemberInfo>> {
-        let namespace = self.get_or_create_namespace(app_id).await;
-        namespace.get_channel_members(channel).await
+        match self.existing_namespace(app_id) {
+            Some(namespace) => namespace.get_channel_members(channel).await,
+            None => Ok(HashMap::new()),
+        }
     }
 
     async fn get_channel_sockets(&self, app_id: &str, channel: &str) -> Result<Vec<SocketId>> {
-        let namespace = self.get_or_create_namespace(app_id).await;
-        Ok(namespace.get_channel_sockets(channel))
+        Ok(self
+            .existing_namespace(app_id)
+            .map(|namespace| namespace.get_channel_sockets(channel))
+            .unwrap_or_default())
     }
 
     async fn remove_channel(&self, app_id: &str, channel: &str) {
@@ -1698,13 +1715,16 @@ impl ConnectionManager for LocalAdapter {
         channel: &str,
         socket_id: &SocketId,
     ) -> Result<bool> {
-        let namespace = self.get_or_create_namespace(app_id).await;
-        Ok(namespace.is_in_channel(channel, socket_id))
+        Ok(self
+            .existing_namespace(app_id)
+            .is_some_and(|namespace| namespace.is_in_channel(channel, socket_id)))
     }
 
     async fn get_user_sockets(&self, user_id: &str, app_id: &str) -> Result<Vec<WebSocketRef>> {
-        let namespace = self.get_or_create_namespace(app_id).await;
-        namespace.get_user_sockets(user_id).await
+        match self.existing_namespace(app_id) {
+            Some(namespace) => namespace.get_user_sockets(user_id).await,
+            None => Ok(Vec::new()),
+        }
     }
 
     async fn cleanup_connection(&self, app_id: &str, ws: WebSocketRef) {
@@ -1745,8 +1765,9 @@ impl ConnectionManager for LocalAdapter {
     }
 
     async fn get_channel_socket_count(&self, app_id: &str, channel: &str) -> usize {
-        let namespace = self.get_or_create_namespace(app_id).await;
-        namespace.get_channel_socket_count(channel)
+        self.existing_namespace(app_id)
+            .map(|namespace| namespace.get_channel_socket_count(channel))
+            .unwrap_or(0)
     }
 
     async fn add_to_channel(
@@ -1823,7 +1844,7 @@ impl ConnectionManager for LocalAdapter {
             let ws_guard = ws_ref.inner.lock().await;
             ws_guard.state.get_app_id()
         };
-        let namespace = self.get_namespace(&app_id).await.unwrap();
+        let namespace = self.get_or_create_namespace(&app_id).await;
         namespace.add_user(ws_ref).await
     }
 
@@ -1834,8 +1855,10 @@ impl ConnectionManager for LocalAdapter {
             let ws_guard = ws_ref.inner.lock().await;
             ws_guard.state.get_app_id()
         };
-        let namespace = self.get_namespace(&app_id).await.unwrap();
-        namespace.remove_user(ws_ref).await
+        match self.existing_namespace(&app_id) {
+            Some(namespace) => namespace.remove_user(ws_ref).await,
+            None => Ok(()),
+        }
     }
 
     async fn remove_user_socket(
@@ -1844,8 +1867,10 @@ impl ConnectionManager for LocalAdapter {
         socket_id: &SocketId,
         app_id: &str,
     ) -> Result<()> {
-        let namespace = self.get_namespace(app_id).await.unwrap();
-        namespace.remove_user_socket(user_id, socket_id).await
+        match self.existing_namespace(app_id) {
+            Some(namespace) => namespace.remove_user_socket(user_id, socket_id).await,
+            None => Ok(()),
+        }
     }
 
     async fn count_user_connections_in_channel(
@@ -1855,15 +1880,21 @@ impl ConnectionManager for LocalAdapter {
         channel: &str,
         excluding_socket: Option<&SocketId>,
     ) -> Result<usize> {
-        let namespace = self.get_namespace(app_id).await.unwrap();
-        namespace
-            .count_user_connections_in_channel(user_id, channel, excluding_socket)
-            .await
+        match self.existing_namespace(app_id) {
+            Some(namespace) => {
+                namespace
+                    .count_user_connections_in_channel(user_id, channel, excluding_socket)
+                    .await
+            }
+            None => Ok(0),
+        }
     }
 
     async fn get_channels_with_socket_count(&self, app_id: &str) -> Result<HashMap<String, usize>> {
-        let namespace = self.get_or_create_namespace(app_id).await;
-        namespace.get_channels_with_socket_count().await
+        match self.existing_namespace(app_id) {
+            Some(namespace) => namespace.get_channels_with_socket_count().await,
+            None => Ok(HashMap::new()),
+        }
     }
 
     async fn get_sockets_count(&self, app_id: &str) -> Result<usize> {
@@ -1908,6 +1939,7 @@ impl ConnectionManager for LocalAdapter {
 #[cfg(test)]
 mod tests {
     use super::LocalAdapter;
+    use crate::ConnectionManager;
     use sockudo_protocol::messages::{ExtrasValue, MessageData, MessageExtras, PusherMessage};
     use std::collections::HashMap;
 
@@ -1993,5 +2025,22 @@ mod tests {
         );
 
         assert!(LocalAdapter::should_assign_v2_message_id(&message));
+    }
+
+    #[tokio::test]
+    async fn read_only_queries_do_not_create_empty_namespaces() {
+        let adapter = LocalAdapter::new();
+
+        assert_eq!(
+            ConnectionManager::get_channel_socket_count(&adapter, "missing-app", "room").await,
+            0
+        );
+        assert!(
+            ConnectionManager::get_channel_sockets(&adapter, "missing-app", "room")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(adapter.namespaces.len(), 0);
     }
 }

--- a/crates/sockudo-adapter/src/memory_rate_limiter.rs
+++ b/crates/sockudo-adapter/src/memory_rate_limiter.rs
@@ -2,10 +2,8 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use sockudo_core::error::Result;
 use sockudo_core::rate_limiter::{RateLimitConfig, RateLimitResult, RateLimiter};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
-use tokio::time::interval;
 
 /// Entry in the rate limiter map
 #[derive(Clone)]
@@ -21,12 +19,80 @@ struct RateLimitEntry {
 /// In-memory rate limiter implementation
 pub struct MemoryRateLimiter {
     /// Storage for rate limit counters
-    limits: Arc<DashMap<String, RateLimitEntry, ahash::RandomState>>,
+    limits: Arc<RateLimitMap>,
     /// Configuration for rate limiting
     config: RateLimitConfig,
-    /// Cleanup task handle
-    #[allow(dead_code)]
-    cleanup_task: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+}
+
+type RateLimitMap = DashMap<String, RateLimitEntry, ahash::RandomState>;
+
+struct SharedLimiterCleanup {
+    tracked_maps: Arc<Mutex<Vec<Weak<RateLimitMap>>>>,
+}
+
+impl SharedLimiterCleanup {
+    fn global() -> &'static Self {
+        static REGISTRY: OnceLock<SharedLimiterCleanup> = OnceLock::new();
+
+        REGISTRY.get_or_init(|| {
+            let cleanup = SharedLimiterCleanup {
+                tracked_maps: Arc::new(Mutex::new(Vec::new())),
+            };
+            cleanup.spawn_worker();
+            cleanup
+        })
+    }
+
+    fn register(&self, limits: &Arc<RateLimitMap>) {
+        let mut tracked_maps = self.tracked_maps.lock().unwrap();
+        tracked_maps.push(Arc::downgrade(limits));
+    }
+
+    fn spawn_worker(&self) {
+        let tracked_maps = Arc::clone(&self.tracked_maps);
+
+        std::thread::Builder::new()
+            .name("sockudo-adapter-rate-limit-sweeper".to_string())
+            .spawn(move || {
+                loop {
+                    std::thread::sleep(shared_cleanup_interval());
+                    let now = Instant::now();
+                    let live_maps = {
+                        let mut tracked = tracked_maps.lock().unwrap();
+                        let mut live_maps = Vec::with_capacity(tracked.len());
+                        tracked.retain(|weak_map| match weak_map.upgrade() {
+                            Some(map) => {
+                                live_maps.push(map);
+                                true
+                            }
+                            None => false,
+                        });
+                        live_maps
+                    };
+
+                    for limits in live_maps {
+                        sweep_expired_entries(&limits, now);
+                    }
+                }
+            })
+            .expect("failed to spawn shared rate limiter cleanup worker");
+    }
+}
+
+fn sweep_expired_entries(limits: &RateLimitMap, now: Instant) {
+    limits.retain(|_, value| value.expiry > now);
+}
+
+fn shared_cleanup_interval() -> Duration {
+    #[cfg(test)]
+    {
+        Duration::from_millis(25)
+    }
+
+    #[cfg(not(test))]
+    {
+        Duration::from_secs(10)
+    }
 }
 
 impl MemoryRateLimiter {
@@ -41,25 +107,10 @@ impl MemoryRateLimiter {
 
     /// Create a new memory-based rate limiter with a specific configuration
     pub fn with_config(config: RateLimitConfig) -> Self {
-        let limits: Arc<DashMap<String, RateLimitEntry, ahash::RandomState>> =
-            Arc::new(DashMap::with_hasher(ahash::RandomState::new()));
-        let limits_clone = Arc::clone(&limits);
+        let limits = Arc::new(DashMap::with_hasher(ahash::RandomState::new()));
+        SharedLimiterCleanup::global().register(&limits);
 
-        // Start cleanup task
-        let cleanup_task = tokio::spawn(async move {
-            let mut interval = interval(Duration::from_secs(10));
-            loop {
-                interval.tick().await;
-                let now = Instant::now();
-                limits_clone.retain(|_, value| value.expiry > now);
-            }
-        });
-
-        Self {
-            limits,
-            config,
-            cleanup_task: Arc::new(Mutex::new(Some(cleanup_task))),
-        }
+        Self { limits, config }
     }
 }
 
@@ -70,6 +121,8 @@ impl RateLimiter for MemoryRateLimiter {
 
         if let Some(entry) = self.limits.get(key) {
             if entry.expiry <= now {
+                drop(entry);
+                self.limits.remove(key);
                 return Ok(RateLimitResult {
                     allowed: true,
                     remaining: self.config.max_requests,
@@ -141,6 +194,8 @@ impl RateLimiter for MemoryRateLimiter {
 
         if let Some(entry) = self.limits.get(key) {
             if entry.expiry <= now {
+                drop(entry);
+                self.limits.remove(key);
                 return Ok(self.config.max_requests);
             }
 
@@ -152,12 +207,46 @@ impl RateLimiter for MemoryRateLimiter {
     }
 }
 
-impl Drop for MemoryRateLimiter {
-    fn drop(&mut self) {
-        if let Ok(mut task_guard) = self.cleanup_task.try_lock()
-            && let Some(task) = task_guard.take()
-        {
-            task.abort();
-        }
+#[cfg(test)]
+mod tests {
+    use super::MemoryRateLimiter;
+    use sockudo_core::rate_limiter::RateLimiter;
+    use tokio::time::{sleep, timeout};
+
+    #[tokio::test]
+    async fn expired_entries_reset_without_background_cleanup_tasks() {
+        let limiter = MemoryRateLimiter::new(1, 1);
+
+        let first = limiter.increment("socket-1").await.unwrap();
+        assert!(first.allowed);
+
+        let second = limiter.increment("socket-1").await.unwrap();
+        assert!(!second.allowed);
+
+        sleep(std::time::Duration::from_secs(2)).await;
+
+        let reset = limiter.increment("socket-1").await.unwrap();
+        assert!(reset.allowed);
+    }
+
+    #[tokio::test]
+    async fn shared_cleanup_reaps_idle_expired_entries() {
+        let limiter = MemoryRateLimiter::new(1, 1);
+
+        limiter.increment("socket-1").await.unwrap();
+        assert_eq!(limiter.limits.len(), 1);
+
+        sleep(std::time::Duration::from_secs(2)).await;
+
+        timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if limiter.limits.is_empty() {
+                    break;
+                }
+                sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("shared sweeper should reap expired idle limiter entries");
     }
 }

--- a/crates/sockudo-adapter/src/v2_broadcast.rs
+++ b/crates/sockudo-adapter/src/v2_broadcast.rs
@@ -94,17 +94,17 @@ fn event_name_filter_allows(socket: &WebSocketRef, channel: &str, event_name: &s
 }
 
 #[cfg(feature = "tag-filtering")]
-pub(crate) fn apply_tag_filter(
+pub(crate) fn apply_tag_filter_in_place(
     filter_index: &crate::filter_index::FilterIndex,
     tag_filtering_enabled: bool,
     channel: &str,
     message: &PusherMessage,
-    v2_sockets: Vec<WebSocketRef>,
+    v2_sockets: &mut Vec<WebSocketRef>,
     except: Option<&SocketId>,
     namespace: &Namespace,
-) -> Vec<WebSocketRef> {
+) {
     if !tag_filtering_enabled {
-        return v2_sockets;
+        return;
     }
 
     let _ = (filter_index, except, namespace);
@@ -114,28 +114,21 @@ pub(crate) fn apply_tag_filter(
             .collect::<std::collections::BTreeMap<String, String>>()
     });
 
-    v2_sockets
-        .into_iter()
-        .filter(|socket| should_deliver_for_tags(socket, channel, tags_btree.as_ref()))
-        .collect()
+    v2_sockets.retain(|socket| should_deliver_for_tags(socket, channel, tags_btree.as_ref()));
 }
 
-/// Same as `apply_tag_filter` but also verifies matched sockets are V2.
-///
-/// Used by `send_with_compression` where the filter index may contain both V1
-/// and V2 socket IDs (V1 sockets are sent to separately without compression).
 #[cfg(feature = "tag-filtering")]
-pub(crate) fn apply_tag_filter_v2_only(
+pub(crate) fn apply_tag_filter_v2_only_in_place(
     filter_index: &crate::filter_index::FilterIndex,
     tag_filtering_enabled: bool,
     channel: &str,
     message: &PusherMessage,
-    v2_sockets: Vec<WebSocketRef>,
+    v2_sockets: &mut Vec<WebSocketRef>,
     except: Option<&SocketId>,
     namespace: &Namespace,
-) -> Vec<WebSocketRef> {
+) {
     if !tag_filtering_enabled {
-        return v2_sockets;
+        return;
     }
 
     let _ = (filter_index, except, namespace);
@@ -145,30 +138,23 @@ pub(crate) fn apply_tag_filter_v2_only(
             .collect::<std::collections::BTreeMap<String, String>>()
     });
 
-    v2_sockets
-        .into_iter()
-        .filter(|socket| socket.protocol_version == sockudo_protocol::ProtocolVersion::V2)
-        .filter(|socket| should_deliver_for_tags(socket, channel, tags_btree.as_ref()))
-        .collect()
+    v2_sockets.retain(|socket| {
+        socket.protocol_version == sockudo_protocol::ProtocolVersion::V2
+            && should_deliver_for_tags(socket, channel, tags_btree.as_ref())
+    });
 }
 
-/// Apply event name filtering to a list of V2 sockets.
-/// Sockets whose subscription has an event name filter that does not include
-/// the message's event name are removed from the list.
-pub(crate) fn apply_event_name_filter(
+pub(crate) fn apply_event_name_filter_in_place(
     channel: &str,
     message: &PusherMessage,
-    sockets: Vec<sockudo_core::websocket::WebSocketRef>,
-) -> Vec<sockudo_core::websocket::WebSocketRef> {
+    sockets: &mut Vec<sockudo_core::websocket::WebSocketRef>,
+) {
     let event_name = match message.event.as_deref() {
         Some(name) => name,
-        None => return sockets, // no event name = deliver to all
+        None => return,
     };
 
-    sockets
-        .into_iter()
-        .filter(|socket| event_name_filter_allows(socket, channel, event_name))
-        .collect()
+    sockets.retain(|socket| event_name_filter_allows(socket, channel, event_name));
 }
 
 /// Strip tags from a message if tag inclusion is disabled for the channel.

--- a/crates/sockudo-adapter/src/watchlist.rs
+++ b/crates/sockudo-adapter/src/watchlist.rs
@@ -45,6 +45,36 @@ impl WatchlistManager {
             .clone()
     }
 
+    fn is_user_online(state: &AppWatchlistState, user_id: &str) -> bool {
+        state
+            .online_users
+            .get(user_id)
+            .is_some_and(|sockets| !sockets.is_empty())
+    }
+
+    fn prune_watchlist_entry_if_empty(state: &mut AppWatchlistState, user_id: &str) {
+        let should_remove = state.watchlists.get(user_id).is_some_and(|entry| {
+            entry.watchers.is_empty()
+                && entry.watching.is_empty()
+                && !Self::is_user_online(state, user_id)
+        });
+
+        if should_remove {
+            state.watchlists.remove(user_id);
+        }
+    }
+
+    fn remove_watching_edge(
+        state: &mut AppWatchlistState,
+        watcher_id: &str,
+        watched_user_id: &str,
+    ) {
+        if let Some(watched_entry) = state.watchlists.get_mut(watched_user_id) {
+            watched_entry.watchers.remove(watcher_id);
+        }
+        Self::prune_watchlist_entry_if_empty(state, watched_user_id);
+    }
+
     /// Add a user with their watchlist
     pub async fn add_user_with_watchlist(
         &self,
@@ -73,9 +103,7 @@ impl WatchlistManager {
                 .unwrap_or_default();
 
             for removed_user_id in previous_watching.difference(&watching_set) {
-                if let Some(removed_entry) = state.watchlists.get_mut(removed_user_id) {
-                    removed_entry.watchers.remove(user_id);
-                }
+                Self::remove_watching_edge(&mut state, user_id, removed_user_id);
             }
 
             let user_watchers = {
@@ -170,13 +198,21 @@ impl WatchlistManager {
         if should_cleanup_user {
             state.online_users.remove(user_id);
 
-            if let Some(user_entry) = state.watchlists.remove(user_id) {
-                for watched_user_id in &user_entry.watching {
-                    if let Some(watched_entry) = state.watchlists.get_mut(watched_user_id) {
-                        watched_entry.watchers.remove(user_id);
-                    }
+            if let Some(previous_watching) = state
+                .watchlists
+                .get(user_id)
+                .map(|entry| entry.watching.iter().cloned().collect::<Vec<_>>())
+            {
+                if let Some(user_entry) = state.watchlists.get_mut(user_id) {
+                    user_entry.watching.clear();
+                }
+
+                for watched_user_id in previous_watching {
+                    Self::remove_watching_edge(&mut state, user_id, &watched_user_id);
                 }
             }
+
+            Self::prune_watchlist_entry_if_empty(&mut state, user_id);
         }
 
         Ok(events_to_send)
@@ -227,5 +263,74 @@ impl WatchlistManager {
         }
 
         Ok(watchers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sockudo_core::websocket::SocketId;
+
+    #[tokio::test]
+    async fn removes_empty_placeholder_entries_when_watchlist_changes() {
+        let manager = WatchlistManager::new();
+        let socket_id = SocketId::new();
+
+        manager
+            .add_user_with_watchlist(
+                "app",
+                "alice",
+                socket_id,
+                Some(vec!["bob".to_string(), "carol".to_string()]),
+            )
+            .await
+            .unwrap();
+        manager
+            .add_user_with_watchlist("app", "alice", socket_id, Some(vec!["bob".to_string()]))
+            .await
+            .unwrap();
+
+        let app_state = manager.apps.get("app").unwrap().value().clone();
+        let state = app_state.lock().unwrap();
+        assert!(state.watchlists.contains_key("bob"));
+        assert!(!state.watchlists.contains_key("carol"));
+    }
+
+    #[tokio::test]
+    async fn preserves_watcher_placeholders_when_user_goes_offline() {
+        let manager = WatchlistManager::new();
+        let watcher_socket = SocketId::new();
+        let watched_socket = SocketId::new();
+
+        manager
+            .add_user_with_watchlist(
+                "app",
+                "watcher",
+                watcher_socket,
+                Some(vec!["watched".to_string()]),
+            )
+            .await
+            .unwrap();
+        manager
+            .add_user_with_watchlist("app", "watched", watched_socket, Some(Vec::new()))
+            .await
+            .unwrap();
+
+        manager
+            .remove_user_connection("app", "watched", &watched_socket)
+            .await
+            .unwrap();
+
+        let watchers = manager
+            .get_watchers_for_user("app", "watched")
+            .await
+            .unwrap();
+        assert_eq!(watchers, vec!["watcher".to_string()]);
+
+        let app_state = manager.apps.get("app").unwrap().value().clone();
+        let state = app_state.lock().unwrap();
+        let watched_entry = state.watchlists.get("watched").unwrap();
+        assert!(watched_entry.watching.is_empty());
+        assert_eq!(watched_entry.watchers.len(), 1);
     }
 }

--- a/crates/sockudo-core/Cargo.toml
+++ b/crates/sockudo-core/Cargo.toml
@@ -83,3 +83,8 @@ criterion = { workspace = true }
 name = "history_bench"
 path = "benches/history_bench.rs"
 harness = false
+
+[[bench]]
+name = "namespace_bench"
+path = "benches/namespace_bench.rs"
+harness = false

--- a/crates/sockudo-core/benches/namespace_bench.rs
+++ b/crates/sockudo-core/benches/namespace_bench.rs
@@ -1,0 +1,232 @@
+use async_trait::async_trait;
+use criterion::{Criterion, criterion_group, criterion_main};
+use sockudo_core::app::{App, AppManager, AppPolicy};
+use sockudo_core::namespace::Namespace;
+use sockudo_core::websocket::{SocketId, WebSocketBufferConfig};
+use sockudo_protocol::{ProtocolVersion, WireFormat};
+use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, WebSocketStream};
+use std::hint::black_box;
+use std::sync::Arc;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::runtime::Runtime;
+
+struct BenchAppManager {
+    app: App,
+}
+
+#[async_trait]
+impl AppManager for BenchAppManager {
+    async fn init(&self) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn create_app(&self, _config: App) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn update_app(&self, _config: App) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn delete_app(&self, _app_id: &str) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn get_apps(&self) -> sockudo_core::error::Result<Vec<App>> {
+        Ok(vec![self.app.clone()])
+    }
+
+    async fn find_by_id(&self, app_id: &str) -> sockudo_core::error::Result<Option<App>> {
+        Ok((app_id == self.app.id).then(|| self.app.clone()))
+    }
+
+    async fn find_by_key(&self, key: &str) -> sockudo_core::error::Result<Option<App>> {
+        Ok((key == self.app.key).then(|| self.app.clone()))
+    }
+
+    async fn check_health(&self) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+}
+
+fn seed_namespace(
+    exact_channel_count: usize,
+    wildcard_channel_count: usize,
+    sockets_per_channel: usize,
+) -> Namespace {
+    let namespace = Namespace::new("bench-app".to_string());
+
+    for channel_idx in 0..exact_channel_count {
+        let channel = format!("room-{channel_idx}");
+        for _ in 0..sockets_per_channel {
+            namespace.add_channel_to_socket(&channel, &SocketId::new());
+        }
+    }
+
+    for channel_idx in 0..wildcard_channel_count {
+        let channel = format!("room-{channel_idx}-*");
+        for _ in 0..sockets_per_channel {
+            namespace.add_channel_to_socket(&channel, &SocketId::new());
+        }
+    }
+
+    namespace
+}
+
+async fn create_server_writer(addr: std::net::SocketAddr) -> WebSocketWriter {
+    let listener = TcpListener::bind(addr).await.unwrap();
+    let local_addr = listener.local_addr().unwrap();
+
+    let server_task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let _ = sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(local_addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+        .connect(client_stream, &local_addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    server_task.await.unwrap()
+}
+
+async fn seed_namespace_with_refs(
+    exact_channel_count: usize,
+    wildcard_channel_count: usize,
+    sockets_per_channel: usize,
+) -> Namespace {
+    let namespace = Namespace::new("bench-app".to_string());
+    let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(BenchAppManager {
+        app: App::from_policy(
+            "bench-app".to_string(),
+            "bench-key".to_string(),
+            "bench-secret".to_string(),
+            true,
+            AppPolicy::default(),
+        ),
+    });
+
+    for channel_idx in 0..exact_channel_count {
+        let channel = format!("room-{channel_idx}");
+        for socket_idx in 0..sockets_per_channel {
+            let writer =
+                create_server_writer("127.0.0.1:0".parse().unwrap_or_else(|_| unreachable!()))
+                    .await;
+            let socket_id = SocketId::new();
+            namespace
+                .add_socket(
+                    socket_id,
+                    writer,
+                    Arc::clone(&app_manager),
+                    sockudo_core::namespace::SocketInitOptions {
+                        buffer_config: WebSocketBufferConfig::default(),
+                        protocol_version: ProtocolVersion::V2,
+                        wire_format: WireFormat::Json,
+                        echo_messages: true,
+                    },
+                )
+                .await
+                .unwrap();
+            namespace.add_channel_to_socket(&channel, &socket_id);
+
+            black_box(socket_idx);
+        }
+    }
+
+    for channel_idx in 0..wildcard_channel_count {
+        let channel = format!("room-{channel_idx}-*");
+        for socket_idx in 0..sockets_per_channel {
+            let writer =
+                create_server_writer("127.0.0.1:0".parse().unwrap_or_else(|_| unreachable!()))
+                    .await;
+            let socket_id = SocketId::new();
+            namespace
+                .add_socket(
+                    socket_id,
+                    writer,
+                    Arc::clone(&app_manager),
+                    sockudo_core::namespace::SocketInitOptions {
+                        buffer_config: WebSocketBufferConfig::default(),
+                        protocol_version: ProtocolVersion::V2,
+                        wire_format: WireFormat::Json,
+                        echo_messages: true,
+                    },
+                )
+                .await
+                .unwrap();
+            namespace.add_channel_to_socket(&channel, &socket_id);
+
+            black_box(socket_idx);
+        }
+    }
+
+    namespace
+}
+
+fn bench_namespace_matching(c: &mut Criterion) {
+    let namespace = seed_namespace(20_000, 500, 4);
+    let rt = Runtime::new().expect("runtime");
+    let namespace_refs = rt.block_on(seed_namespace_with_refs(1_000, 100, 1));
+    let namespace_refs_no_wildcards = rt.block_on(seed_namespace_with_refs(1_000, 0, 1));
+
+    let mut group = c.benchmark_group("namespace_matching");
+
+    group.bench_function("exact_match_many_channels", |b| {
+        b.iter(|| {
+            let matches = namespace.get_matching_channel_socket_ids_except("room-42", None);
+            black_box(matches.len());
+        });
+    });
+
+    group.bench_function("wildcard_match_many_channels", |b| {
+        b.iter(|| {
+            let matches = namespace.get_matching_channel_socket_ids_except("room-42-suffix", None);
+            black_box(matches.len());
+        });
+    });
+
+    group.bench_function("exact_match_socket_refs_many_channels", |b| {
+        b.iter(|| {
+            let matches = namespace_refs.get_matching_channel_socket_refs_except("room-42", None);
+            black_box(matches.len());
+        });
+    });
+
+    group.bench_function("exact_match_socket_refs_no_wildcards", |b| {
+        b.iter(|| {
+            let matches = namespace_refs_no_wildcards
+                .get_matching_channel_socket_refs_except("room-42", None);
+            black_box(matches.len());
+        });
+    });
+
+    group.bench_function("exact_match_socket_refs_partitioned_no_wildcards", |b| {
+        b.iter(|| {
+            let (v1, v2) = namespace_refs_no_wildcards
+                .get_matching_channel_socket_refs_partitioned_except("room-42", None);
+            black_box((v1.len(), v2.len()));
+        });
+    });
+
+    group.bench_function("exact_match_socket_refs_partitioned_many_channels", |b| {
+        b.iter(|| {
+            let (v1, v2) =
+                namespace_refs.get_matching_channel_socket_refs_partitioned_except("room-42", None);
+            black_box((v1.len(), v2.len()));
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_namespace_matching);
+criterion_main!(benches);

--- a/crates/sockudo-core/examples/profile_namespace_exact.rs
+++ b/crates/sockudo-core/examples/profile_namespace_exact.rs
@@ -1,0 +1,36 @@
+use sockudo_core::namespace::Namespace;
+use sockudo_core::websocket::SocketId;
+use std::hint::black_box;
+
+fn seed_namespace(
+    exact_channel_count: usize,
+    wildcard_channel_count: usize,
+    sockets_per_channel: usize,
+) -> Namespace {
+    let namespace = Namespace::new("profile-app".to_string());
+
+    for channel_idx in 0..exact_channel_count {
+        let channel = format!("room-{channel_idx}");
+        for _ in 0..sockets_per_channel {
+            namespace.add_channel_to_socket(&channel, &SocketId::new());
+        }
+    }
+
+    for channel_idx in 0..wildcard_channel_count {
+        let channel = format!("room-{channel_idx}-*");
+        for _ in 0..sockets_per_channel {
+            namespace.add_channel_to_socket(&channel, &SocketId::new());
+        }
+    }
+
+    namespace
+}
+
+fn main() {
+    let namespace = seed_namespace(20_000, 500, 4);
+
+    for _ in 0..2_000_000 {
+        let matches = namespace.get_matching_channel_socket_ids_except("room-42", None);
+        black_box(matches.len());
+    }
+}

--- a/crates/sockudo-core/examples/profile_namespace_ref_allocs.rs
+++ b/crates/sockudo-core/examples/profile_namespace_ref_allocs.rs
@@ -1,0 +1,186 @@
+use async_trait::async_trait;
+use sockudo_core::app::{App, AppManager, AppPolicy};
+use sockudo_core::namespace::Namespace;
+use sockudo_core::websocket::{SocketId, WebSocketBufferConfig};
+use sockudo_protocol::{ProtocolVersion, WireFormat};
+use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, WebSocketStream};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::runtime::Runtime;
+
+struct CountingAlloc;
+
+static ALLOC_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DEALLOC_CALLS: AtomicUsize = AtomicUsize::new(0);
+static ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static DEALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAlloc = CountingAlloc;
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        ALLOC_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        DEALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        DEALLOC_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+struct BenchAppManager {
+    app: App,
+}
+
+#[async_trait]
+impl AppManager for BenchAppManager {
+    async fn init(&self) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn create_app(&self, _config: App) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn update_app(&self, _config: App) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn delete_app(&self, _app_id: &str) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+
+    async fn get_apps(&self) -> sockudo_core::error::Result<Vec<App>> {
+        Ok(vec![self.app.clone()])
+    }
+
+    async fn find_by_id(&self, app_id: &str) -> sockudo_core::error::Result<Option<App>> {
+        Ok((app_id == self.app.id).then(|| self.app.clone()))
+    }
+
+    async fn find_by_key(&self, key: &str) -> sockudo_core::error::Result<Option<App>> {
+        Ok((key == self.app.key).then(|| self.app.clone()))
+    }
+
+    async fn check_health(&self) -> sockudo_core::error::Result<()> {
+        Ok(())
+    }
+}
+
+async fn create_server_writer() -> WebSocketWriter {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_addr = listener.local_addr().unwrap();
+
+    let server_task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let _ = sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(local_addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+        .connect(client_stream, &local_addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    server_task.await.unwrap()
+}
+
+async fn seed_namespace_with_refs() -> Namespace {
+    let namespace = Namespace::new("profile-app".to_string());
+    let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(BenchAppManager {
+        app: App::from_policy(
+            "profile-app".to_string(),
+            "profile-key".to_string(),
+            "profile-secret".to_string(),
+            true,
+            AppPolicy::default(),
+        ),
+    });
+
+    for channel_idx in 0..1_000 {
+        let channel = format!("room-{channel_idx}");
+        let writer = create_server_writer().await;
+        let socket_id = SocketId::new();
+        namespace
+            .add_socket(
+                socket_id,
+                writer,
+                Arc::clone(&app_manager),
+                sockudo_core::namespace::SocketInitOptions {
+                    buffer_config: WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+        namespace.add_channel_to_socket(&channel, &socket_id);
+    }
+
+    for channel_idx in 0..100 {
+        let channel = format!("room-{channel_idx}-*");
+        let writer = create_server_writer().await;
+        let socket_id = SocketId::new();
+        namespace
+            .add_socket(
+                socket_id,
+                writer,
+                Arc::clone(&app_manager),
+                sockudo_core::namespace::SocketInitOptions {
+                    buffer_config: WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+        namespace.add_channel_to_socket(&channel, &socket_id);
+    }
+
+    namespace
+}
+
+fn reset_alloc_stats() {
+    ALLOC_CALLS.store(0, Ordering::Relaxed);
+    DEALLOC_CALLS.store(0, Ordering::Relaxed);
+    ALLOC_BYTES.store(0, Ordering::Relaxed);
+    DEALLOC_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn main() {
+    let rt = Runtime::new().unwrap();
+    let namespace = rt.block_on(seed_namespace_with_refs());
+
+    reset_alloc_stats();
+
+    for _ in 0..100_000 {
+        let (v1, v2) =
+            namespace.get_matching_channel_socket_refs_partitioned_except("room-42", None);
+        black_box((v1.len(), v2.len()));
+    }
+
+    println!(
+        "alloc_calls={} dealloc_calls={} alloc_bytes={} dealloc_bytes={}",
+        ALLOC_CALLS.load(Ordering::Relaxed),
+        DEALLOC_CALLS.load(Ordering::Relaxed),
+        ALLOC_BYTES.load(Ordering::Relaxed),
+        DEALLOC_BYTES.load(Ordering::Relaxed)
+    );
+}

--- a/crates/sockudo-core/src/history.rs
+++ b/crates/sockudo-core/src/history.rs
@@ -690,7 +690,24 @@ impl HistoryStore for MemoryHistoryStore {
         request.validate()?;
         let key = Self::channel_key(&request.app_id, &request.channel);
         let mut channels = self.channels.write().await;
-        let channel_state = channels.entry(key).or_default();
+        let Some(channel_state) = channels.get_mut(&key) else {
+            return Ok(HistoryPage {
+                items: Vec::new(),
+                next_cursor: None,
+                retained: HistoryRetentionStats {
+                    stream_id: None,
+                    retained_messages: 0,
+                    retained_bytes: 0,
+                    oldest_serial: None,
+                    newest_serial: None,
+                    oldest_published_at_ms: None,
+                    newest_published_at_ms: None,
+                },
+                has_more: false,
+                complete: true,
+                truncated_by_retention: false,
+            });
+        };
         let retention = channel_state
             .retention
             .clone()
@@ -1296,5 +1313,25 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![2, 3, 4]
         );
+    }
+
+    #[tokio::test]
+    async fn memory_history_read_page_does_not_materialize_absent_channels() {
+        let store = MemoryHistoryStore::new(MemoryHistoryStoreConfig::default());
+
+        let page = store
+            .read_page(HistoryReadRequest {
+                app_id: "app".to_string(),
+                channel: "missing".to_string(),
+                direction: HistoryDirection::OldestFirst,
+                limit: 10,
+                cursor: None,
+                bounds: HistoryQueryBounds::default(),
+            })
+            .await
+            .unwrap();
+
+        assert!(page.items.is_empty());
+        assert_eq!(store.channels.read().await.len(), 0);
     }
 }

--- a/crates/sockudo-core/src/namespace.rs
+++ b/crates/sockudo-core/src/namespace.rs
@@ -4,6 +4,7 @@ use crate::error::{Error, Result};
 use crate::utils::wildcard_pattern_matches;
 use crate::websocket::{SocketId, WebSocket, WebSocketBufferConfig, WebSocketRef};
 use ahash::AHashMap as HashMap;
+use ahash::AHashSet;
 use dashmap::{DashMap, DashSet};
 use futures_util::future::join_all;
 use sockudo_ws::axum_integration::WebSocketWriter;
@@ -15,6 +16,7 @@ pub struct Namespace {
     pub app_id: String,
     pub sockets: DashMap<SocketId, WebSocketRef>,
     pub channels: DashMap<String, DashSet<SocketId>>,
+    wildcard_channels: DashSet<String>,
     pub users: DashMap<String, DashSet<WebSocketRef>>,
 }
 
@@ -31,6 +33,7 @@ impl Namespace {
             app_id,
             sockets: DashMap::new(),
             channels: DashMap::new(),
+            wildcard_channels: DashSet::new(),
             users: DashMap::new(),
         }
     }
@@ -146,34 +149,25 @@ impl Namespace {
         channel: &str,
         except: Option<&SocketId>,
     ) -> Vec<WebSocketRef> {
-        let mut socket_refs = Vec::new();
-
-        if let Some(channel_sockets_ref) = self.channels.get(channel) {
-            let socket_ids: Vec<SocketId> = channel_sockets_ref
-                .value()
-                .iter()
-                .filter_map(|entry| {
-                    let socket_id = entry.key();
-                    if except == Some(socket_id) {
-                        None
-                    } else {
-                        Some(*socket_id)
-                    }
-                })
-                .collect();
-
-            drop(channel_sockets_ref);
-
-            for socket_id in socket_ids {
-                if let Some(socket_ref) = self.get_connection(&socket_id) {
-                    socket_refs.push(socket_ref);
-                }
-            }
-        } else {
+        let Some(channel_sockets_ref) = self.channels.get(channel) else {
             debug!(
                 "get_channel_socket_refs_except called on non-existent channel: {}",
                 channel
             );
+            return Vec::new();
+        };
+
+        let mut socket_refs = Vec::with_capacity(channel_sockets_ref.len());
+
+        for socket_id_entry in channel_sockets_ref.iter() {
+            let socket_id = socket_id_entry.key();
+            if except == Some(socket_id) {
+                continue;
+            }
+
+            if let Some(socket_ref) = self.get_connection(socket_id) {
+                socket_refs.push(socket_ref);
+            }
         }
 
         socket_refs
@@ -184,29 +178,219 @@ impl Namespace {
         channel: &str,
         except: Option<&SocketId>,
     ) -> Vec<WebSocketRef> {
-        let mut socket_ids = std::collections::HashSet::new();
+        if channel.contains('*') {
+            return self
+                .get_matching_channel_socket_ids_except(channel, except)
+                .into_iter()
+                .filter_map(|socket_id| self.get_connection(&socket_id))
+                .collect();
+        }
 
-        for entry in self.channels.iter() {
-            let subscribed_channel = entry.key();
-            let matches = subscribed_channel == channel
-                || (subscribed_channel.contains('*')
-                    && wildcard_pattern_matches(channel, subscribed_channel));
-            if !matches {
-                continue;
+        let mut socket_refs = self.get_channel_socket_refs_except(channel, except);
+        if self.wildcard_channels.is_empty() {
+            return socket_refs;
+        }
+
+        let mut seen_socket_ids = None;
+        self.collect_matching_socket_refs(channel, except, &mut seen_socket_ids, &mut socket_refs);
+        socket_refs
+    }
+
+    pub fn get_matching_channel_socket_refs_partitioned_except(
+        &self,
+        channel: &str,
+        except: Option<&SocketId>,
+    ) -> (Vec<WebSocketRef>, Vec<WebSocketRef>) {
+        if channel.contains('*') {
+            let mut v1_refs = Vec::new();
+            let mut v2_refs = Vec::new();
+
+            for socket_id in self.get_matching_channel_socket_ids_except(channel, except) {
+                if let Some(socket_ref) = self.get_connection(&socket_id) {
+                    Self::push_socket_ref_by_protocol(socket_ref, &mut v1_refs, &mut v2_refs);
+                }
             }
 
-            for socket_id_entry in entry.value().iter() {
+            return (v1_refs, v2_refs);
+        }
+
+        let mut v1_refs = Vec::new();
+        let mut v2_refs = Vec::new();
+
+        if let Some(channel_sockets_ref) = self.channels.get(channel) {
+            for socket_id_entry in channel_sockets_ref.iter() {
+                let socket_id = socket_id_entry.key();
+                if except == Some(socket_id) {
+                    continue;
+                }
+
+                if let Some(socket_ref) = self.get_connection(socket_id) {
+                    Self::push_socket_ref_by_protocol(socket_ref, &mut v1_refs, &mut v2_refs);
+                }
+            }
+        }
+
+        if self.wildcard_channels.is_empty() {
+            return (v1_refs, v2_refs);
+        }
+
+        let mut seen_socket_ids = None;
+        self.collect_matching_socket_refs_partitioned(
+            channel,
+            except,
+            &mut seen_socket_ids,
+            &mut v1_refs,
+            &mut v2_refs,
+        );
+
+        (v1_refs, v2_refs)
+    }
+
+    pub fn get_matching_channel_socket_ids_except(
+        &self,
+        channel: &str,
+        except: Option<&SocketId>,
+    ) -> AHashSet<SocketId> {
+        let mut socket_ids = AHashSet::new();
+
+        if channel.contains('*') {
+            self.collect_matching_socket_ids(channel, except, &mut socket_ids, true);
+            return socket_ids;
+        }
+
+        self.collect_exact_channel_socket_ids(channel, except, &mut socket_ids);
+        self.collect_matching_socket_ids(channel, except, &mut socket_ids, false);
+        socket_ids
+    }
+
+    fn collect_exact_channel_socket_ids(
+        &self,
+        channel: &str,
+        except: Option<&SocketId>,
+        socket_ids: &mut AHashSet<SocketId>,
+    ) {
+        if let Some(channel_sockets_ref) = self.channels.get(channel) {
+            for socket_id_entry in channel_sockets_ref.iter() {
                 let socket_id = socket_id_entry.key();
                 if except != Some(socket_id) {
                     socket_ids.insert(*socket_id);
                 }
             }
         }
+    }
 
-        socket_ids
-            .into_iter()
-            .filter_map(|socket_id| self.get_connection(&socket_id))
-            .collect()
+    fn collect_matching_socket_ids(
+        &self,
+        channel: &str,
+        except: Option<&SocketId>,
+        socket_ids: &mut AHashSet<SocketId>,
+        include_exact_channels: bool,
+    ) {
+        for wildcard_channel in self.wildcard_channels.iter() {
+            let subscribed_channel = wildcard_channel.key();
+            if !wildcard_pattern_matches(channel, subscribed_channel) {
+                continue;
+            }
+
+            if let Some(channel_sockets_ref) = self.channels.get(subscribed_channel) {
+                for socket_id_entry in channel_sockets_ref.iter() {
+                    let socket_id = socket_id_entry.key();
+                    if except != Some(socket_id) {
+                        socket_ids.insert(*socket_id);
+                    }
+                }
+            }
+        }
+
+        if include_exact_channels {
+            self.collect_exact_channel_socket_ids(channel, except, socket_ids);
+        }
+    }
+
+    fn collect_matching_socket_refs(
+        &self,
+        channel: &str,
+        except: Option<&SocketId>,
+        seen_socket_ids: &mut Option<AHashSet<SocketId>>,
+        socket_refs: &mut Vec<WebSocketRef>,
+    ) {
+        for wildcard_channel in self.wildcard_channels.iter() {
+            let subscribed_channel = wildcard_channel.key();
+            if !wildcard_pattern_matches(channel, subscribed_channel) {
+                continue;
+            }
+
+            let seen_socket_ids = seen_socket_ids.get_or_insert_with(|| {
+                let mut seen = AHashSet::with_capacity(socket_refs.len().saturating_mul(2));
+                for socket_ref in socket_refs.iter() {
+                    seen.insert(*socket_ref.get_socket_id_sync());
+                }
+                seen
+            });
+
+            if let Some(channel_sockets_ref) = self.channels.get(subscribed_channel) {
+                for socket_id_entry in channel_sockets_ref.iter() {
+                    let socket_id = socket_id_entry.key();
+                    if except == Some(socket_id) || !seen_socket_ids.insert(*socket_id) {
+                        continue;
+                    }
+
+                    if let Some(socket_ref) = self.get_connection(socket_id) {
+                        socket_refs.push(socket_ref);
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_matching_socket_refs_partitioned(
+        &self,
+        channel: &str,
+        except: Option<&SocketId>,
+        seen_socket_ids: &mut Option<AHashSet<SocketId>>,
+        v1_refs: &mut Vec<WebSocketRef>,
+        v2_refs: &mut Vec<WebSocketRef>,
+    ) {
+        for wildcard_channel in self.wildcard_channels.iter() {
+            let subscribed_channel = wildcard_channel.key();
+            if !wildcard_pattern_matches(channel, subscribed_channel) {
+                continue;
+            }
+
+            let seen_socket_ids = seen_socket_ids.get_or_insert_with(|| {
+                let mut seen =
+                    AHashSet::with_capacity((v1_refs.len() + v2_refs.len()).saturating_mul(2));
+                for socket_ref in v1_refs.iter().chain(v2_refs.iter()) {
+                    seen.insert(*socket_ref.get_socket_id_sync());
+                }
+                seen
+            });
+
+            if let Some(channel_sockets_ref) = self.channels.get(subscribed_channel) {
+                for socket_id_entry in channel_sockets_ref.iter() {
+                    let socket_id = socket_id_entry.key();
+                    if except == Some(socket_id) || !seen_socket_ids.insert(*socket_id) {
+                        continue;
+                    }
+
+                    if let Some(socket_ref) = self.get_connection(socket_id) {
+                        Self::push_socket_ref_by_protocol(socket_ref, v1_refs, v2_refs);
+                    }
+                }
+            }
+        }
+    }
+
+    fn push_socket_ref_by_protocol(
+        socket_ref: WebSocketRef,
+        v1_refs: &mut Vec<WebSocketRef>,
+        v2_refs: &mut Vec<WebSocketRef>,
+    ) {
+        if socket_ref.protocol_version == sockudo_protocol::ProtocolVersion::V1 {
+            v1_refs.push(socket_ref);
+        } else {
+            v2_refs.push(socket_ref);
+        }
     }
 
     #[inline]
@@ -235,6 +419,9 @@ impl Namespace {
                 set.remove(&socket_id);
                 set.is_empty()
             });
+            if channel_name.contains('*') && !self.channels.contains_key(&channel_name) {
+                self.wildcard_channels.remove(&channel_name);
+            }
         }
 
         let user_id_option = ws_ref.get_user_id().await;
@@ -294,6 +481,10 @@ impl Namespace {
             .insert(*socket_id);
         let t_after_entry = t_start.elapsed().as_nanos();
 
+        if channel.contains('*') {
+            self.wildcard_channels.insert(channel.to_string());
+        }
+
         tracing::debug!(
             "PERF[NS_ADD_CHAN] channel={} socket={} entry_op={}ns inserted={}",
             channel,
@@ -315,6 +506,9 @@ impl Namespace {
                 .remove_if(channel, |_, set| set.is_empty())
                 .is_some()
             {
+                if channel.contains('*') {
+                    self.wildcard_channels.remove(channel);
+                }
                 debug!("Removed empty channel entry: {}", channel);
             }
             return removed.is_some();
@@ -329,12 +523,18 @@ impl Namespace {
     }
 
     pub fn get_channel(&self, channel: &str) -> Result<DashSet<SocketId>> {
-        let channel_data = self.channels.entry(channel.to_string()).or_default();
-        Ok(channel_data.value().clone())
+        Ok(self
+            .channels
+            .get(channel)
+            .map(|channel_data| channel_data.value().clone())
+            .unwrap_or_default())
     }
 
     pub fn remove_channel(&self, channel: &str) {
         self.channels.remove(channel);
+        if channel.contains('*') {
+            self.wildcard_channels.remove(channel);
+        }
         debug!("Removed channel entry: {}", channel);
     }
 
@@ -482,5 +682,157 @@ impl Namespace {
             .iter()
             .map(|entry| (*entry.key(), entry.value().clone()))
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Namespace;
+    use crate::app::{App, AppManager, AppPolicy};
+    use crate::namespace::SocketInitOptions;
+    use crate::websocket::SocketId;
+    use async_trait::async_trait;
+    use sockudo_protocol::{ProtocolVersion, WireFormat};
+    use sockudo_ws::Config as WsConfig;
+    use sockudo_ws::Http1;
+    use sockudo_ws::WebSocketStream;
+    use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
+    use sockudo_ws::client::WebSocketClient;
+    use std::sync::Arc;
+    use tokio::net::{TcpListener, TcpStream};
+
+    #[derive(Clone)]
+    struct TestAppManager {
+        app: App,
+    }
+
+    #[async_trait]
+    impl AppManager for TestAppManager {
+        async fn init(&self) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        async fn create_app(&self, _config: App) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        async fn update_app(&self, _config: App) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        async fn delete_app(&self, _app_id: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        async fn get_apps(&self) -> crate::error::Result<Vec<App>> {
+            Ok(vec![self.app.clone()])
+        }
+
+        async fn find_by_id(&self, app_id: &str) -> crate::error::Result<Option<App>> {
+            Ok((app_id == self.app.id).then(|| self.app.clone()))
+        }
+
+        async fn find_by_key(&self, key: &str) -> crate::error::Result<Option<App>> {
+            Ok((key == self.app.key).then(|| self.app.clone()))
+        }
+
+        async fn check_health(&self) -> crate::error::Result<()> {
+            Ok(())
+        }
+    }
+
+    async fn create_server_writer() -> WebSocketWriter {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+
+        let server_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = sockudo_ws::handshake::server_handshake(&mut stream)
+                .await
+                .unwrap();
+            let ws = WebSocket::from_tcp(stream, WsConfig::default());
+            let (_reader, writer) = ws.split();
+            writer
+        });
+
+        let client_stream = TcpStream::connect(local_addr).await.unwrap();
+        let client = WebSocketClient::<Http1>::new(WsConfig::default());
+        let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+            .connect(client_stream, &local_addr.to_string(), "/", None)
+            .await
+            .unwrap();
+
+        server_task.await.unwrap()
+    }
+
+    #[test]
+    fn exact_channel_matching_uses_exact_and_wildcard_memberships_only() {
+        let namespace = Namespace::new("app".to_string());
+        let exact_socket = SocketId::new();
+        let wildcard_socket = SocketId::new();
+        let unrelated_socket = SocketId::new();
+
+        namespace.add_channel_to_socket("room-42", &exact_socket);
+        namespace.add_channel_to_socket("room-*", &wildcard_socket);
+        namespace.add_channel_to_socket("other-room", &unrelated_socket);
+
+        let matches = namespace.get_matching_channel_socket_ids_except("room-42", None);
+
+        assert!(matches.contains(&exact_socket));
+        assert!(matches.contains(&wildcard_socket));
+        assert!(!matches.contains(&unrelated_socket));
+    }
+
+    #[test]
+    fn wildcard_index_is_removed_when_last_subscription_leaves() {
+        let namespace = Namespace::new("app".to_string());
+        let socket_id = SocketId::new();
+
+        namespace.add_channel_to_socket("room-*", &socket_id);
+        assert!(namespace.wildcard_channels.contains("room-*"));
+
+        namespace.remove_channel_from_socket("room-*", &socket_id);
+
+        assert!(!namespace.wildcard_channels.contains("room-*"));
+    }
+
+    #[tokio::test]
+    async fn wildcard_only_subscription_matches_concrete_channel_in_partitioned_lookup() {
+        let namespace = Namespace::new("app".to_string());
+        let wildcard_socket = SocketId::new();
+        let writer = create_server_writer().await;
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        namespace
+            .add_socket(
+                wildcard_socket,
+                writer,
+                app_manager,
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        namespace.add_channel_to_socket("room-*", &wildcard_socket);
+
+        let (v1, v2) =
+            namespace.get_matching_channel_socket_refs_partitioned_except("room-42", None);
+
+        assert!(v1.is_empty());
+        assert_eq!(v2.len(), 1);
+        assert_eq!(*v2[0].get_socket_id_sync(), wildcard_socket);
     }
 }

--- a/crates/sockudo-core/src/presence_history.rs
+++ b/crates/sockudo-core/src/presence_history.rs
@@ -737,6 +737,14 @@ struct DurablePresenceHistoryPayload {
 pub struct DurablePresenceHistoryStore {
     history_store: Arc<dyn HistoryStore + Send + Sync>,
     metrics: Option<Arc<dyn MetricsInterface + Send + Sync>>,
+    transition_cache: Arc<RwLock<BTreeMap<String, DurablePresenceTransitionCache>>>,
+}
+
+#[derive(Default)]
+struct DurablePresenceTransitionCache {
+    stream_id: Option<String>,
+    dedupe_keys: BTreeMap<String, u64>,
+    latest_event_by_user: BTreeMap<String, (PresenceHistoryEventKind, u64)>,
 }
 
 impl DurablePresenceHistoryStore {
@@ -747,11 +755,16 @@ impl DurablePresenceHistoryStore {
         Self {
             history_store,
             metrics,
+            transition_cache: Arc::new(RwLock::new(BTreeMap::new())),
         }
     }
 
     fn durable_channel_name(channel: &str) -> String {
         format!("[presence-history]{channel}")
+    }
+
+    fn cache_key(app_id: &str, channel: &str) -> String {
+        format!("{app_id}\0{channel}")
     }
 
     fn history_retention(record: &PresenceHistoryTransitionRecord) -> HistoryRetentionPolicy {
@@ -912,10 +925,107 @@ impl DurablePresenceHistoryStore {
         Ok(())
     }
 
+    async fn inspect_durable_channel(
+        &self,
+        app_id: &str,
+        channel: &str,
+    ) -> Result<crate::history::HistoryStreamInspection> {
+        self.history_store
+            .stream_inspection(app_id, &Self::durable_channel_name(channel))
+            .await
+    }
+
+    async fn consult_transition_cache(
+        &self,
+        record: &PresenceHistoryTransitionRecord,
+    ) -> Result<Option<(bool, bool)>> {
+        let inspection = self
+            .inspect_durable_channel(&record.app_id, &record.channel)
+            .await?;
+        let cache_key = Self::cache_key(&record.app_id, &record.channel);
+        let oldest_serial = inspection.retained.oldest_serial.unwrap_or(u64::MAX);
+        let mut caches = self.transition_cache.write().await;
+        let cache = caches.entry(cache_key).or_default();
+
+        if cache.stream_id != inspection.stream_id {
+            cache.stream_id = inspection.stream_id;
+            cache.dedupe_keys.clear();
+            cache.latest_event_by_user.clear();
+        }
+
+        cache
+            .dedupe_keys
+            .retain(|_, serial| *serial >= oldest_serial);
+        cache
+            .latest_event_by_user
+            .retain(|_, (_, serial)| *serial >= oldest_serial);
+
+        if let Some(serial) = cache.dedupe_keys.get(&record.dedupe_key)
+            && *serial >= oldest_serial
+        {
+            return Ok(Some((true, false)));
+        }
+
+        if let Some((event, serial)) = cache.latest_event_by_user.get(&record.user_id)
+            && *serial >= oldest_serial
+        {
+            return Ok(Some((false, *event == record.event_kind)));
+        }
+
+        Ok(None)
+    }
+
+    async fn cache_scanned_transition(
+        &self,
+        app_id: &str,
+        channel: &str,
+        stream_id: &str,
+        payload: &DurablePresenceHistoryPayload,
+        serial: u64,
+    ) {
+        let cache_key = Self::cache_key(app_id, channel);
+        let mut caches = self.transition_cache.write().await;
+        let cache = caches.entry(cache_key).or_default();
+        if cache.stream_id.as_deref() != Some(stream_id) {
+            cache.stream_id = Some(stream_id.to_string());
+            cache.dedupe_keys.clear();
+            cache.latest_event_by_user.clear();
+        }
+        cache.dedupe_keys.insert(payload.dedupe_key.clone(), serial);
+        cache
+            .latest_event_by_user
+            .entry(payload.user_id.clone())
+            .or_insert((payload.event, serial));
+    }
+
+    async fn cache_appended_transition(
+        &self,
+        record: &PresenceHistoryTransitionRecord,
+        stream_id: &str,
+        serial: u64,
+    ) {
+        let cache_key = Self::cache_key(&record.app_id, &record.channel);
+        let mut caches = self.transition_cache.write().await;
+        let cache = caches.entry(cache_key).or_default();
+        if cache.stream_id.as_deref() != Some(stream_id) {
+            cache.stream_id = Some(stream_id.to_string());
+            cache.dedupe_keys.clear();
+            cache.latest_event_by_user.clear();
+        }
+        cache.dedupe_keys.insert(record.dedupe_key.clone(), serial);
+        cache
+            .latest_event_by_user
+            .insert(record.user_id.clone(), (record.event_kind, serial));
+    }
+
     async fn find_existing_transition(
         &self,
         record: &PresenceHistoryTransitionRecord,
     ) -> Result<(bool, bool)> {
+        if let Some(found) = self.consult_transition_cache(record).await? {
+            return Ok(found);
+        }
+
         let mut request = PresenceHistoryReadRequest {
             app_id: record.app_id.clone(),
             channel: record.channel.clone(),
@@ -931,6 +1041,14 @@ impl DurablePresenceHistoryStore {
             let page = self.read_page(request.clone()).await?;
             for item in &page.items {
                 let payload = Self::decode_payload(item.payload_bytes.as_ref())?;
+                self.cache_scanned_transition(
+                    &record.app_id,
+                    &record.channel,
+                    &item.stream_id,
+                    &payload,
+                    item.serial,
+                )
+                .await;
                 if payload.dedupe_key == record.dedupe_key {
                     found_dedupe = true;
                     break;
@@ -982,12 +1100,13 @@ impl PresenceHistoryStore for DurablePresenceHistoryStore {
             }
         };
 
+        let stream_id = reservation.stream_id.clone();
         let append = self
             .history_store
             .append(HistoryAppendRecord {
                 app_id: record.app_id.clone(),
                 channel: Self::durable_channel_name(&record.channel),
-                stream_id: reservation.stream_id,
+                stream_id,
                 serial: reservation.serial,
                 published_at_ms: record.published_at_ms,
                 message_id: None,
@@ -1000,6 +1119,8 @@ impl PresenceHistoryStore for DurablePresenceHistoryStore {
 
         match append {
             Ok(()) => {
+                self.cache_appended_transition(&record, &reservation.stream_id, reservation.serial)
+                    .await;
                 if let Some(metrics) = self.metrics.as_ref() {
                     metrics.mark_presence_history_write(&record.app_id);
                     metrics.track_presence_history_write_latency(
@@ -1108,6 +1229,10 @@ impl PresenceHistoryStore for DurablePresenceHistoryStore {
                 requested_by,
             )
             .await?;
+        self.transition_cache
+            .write()
+            .await
+            .remove(&Self::cache_key(app_id, channel));
         self.update_retained_metrics(app_id, channel).await?;
         Ok(PresenceHistoryResetResult {
             app_id: app_id.to_string(),
@@ -1428,7 +1553,25 @@ impl PresenceHistoryStore for MemoryPresenceHistoryStore {
         request.validate()?;
         let key = Self::channel_key(&request.app_id, &request.channel);
         let mut channels = self.channels.write().await;
-        let channel_state = channels.entry(key).or_default();
+        let Some(channel_state) = channels.get_mut(&key) else {
+            return Ok(PresenceHistoryPage {
+                items: Vec::new(),
+                next_cursor: None,
+                retained: PresenceHistoryRetentionStats {
+                    stream_id: None,
+                    retained_events: 0,
+                    retained_bytes: 0,
+                    oldest_serial: None,
+                    newest_serial: None,
+                    oldest_published_at_ms: None,
+                    newest_published_at_ms: None,
+                },
+                has_more: false,
+                complete: true,
+                truncated_by_retention: false,
+                degraded: false,
+            });
+        };
         let retention = channel_state
             .retention
             .clone()
@@ -2651,6 +2794,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn durable_presence_history_reuses_cached_latest_state() {
+        let history = Arc::new(MemoryHistoryStore::new(MemoryHistoryStoreConfig::default()));
+        let store = DurablePresenceHistoryStore::new(history, None);
+        let base = now_ms();
+
+        store
+            .record_transition(transition(
+                base,
+                "join-alice-1",
+                PresenceHistoryEventKind::MemberAdded,
+                "alice",
+            ))
+            .await
+            .unwrap();
+
+        {
+            let cache = store.transition_cache.read().await;
+            let channel = cache
+                .get(&DurablePresenceHistoryStore::cache_key(
+                    "app",
+                    "presence-room",
+                ))
+                .unwrap();
+            assert_eq!(
+                channel.latest_event_by_user.get("alice"),
+                Some(&(PresenceHistoryEventKind::MemberAdded, 1))
+            );
+        }
+
+        store
+            .record_transition(transition(
+                base + 1,
+                "join-alice-2",
+                PresenceHistoryEventKind::MemberAdded,
+                "alice",
+            ))
+            .await
+            .unwrap();
+
+        let page = store
+            .read_page(PresenceHistoryReadRequest {
+                app_id: "app".to_string(),
+                channel: "presence-room".to_string(),
+                direction: PresenceHistoryDirection::OldestFirst,
+                limit: 10,
+                cursor: None,
+                bounds: PresenceHistoryQueryBounds::default(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(page.items.len(), 1);
+    }
+
+    #[tokio::test]
     async fn durable_presence_history_snapshot_and_reset_follow_presence_semantics() {
         let history = Arc::new(MemoryHistoryStore::new(MemoryHistoryStoreConfig::default()));
         let store = DurablePresenceHistoryStore::new(history, None);
@@ -2725,5 +2923,25 @@ mod tests {
             .await
             .unwrap();
         assert!(page.items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn memory_presence_history_read_page_does_not_materialize_absent_channels() {
+        let store = MemoryPresenceHistoryStore::new(MemoryPresenceHistoryStoreConfig::default());
+
+        let page = store
+            .read_page(PresenceHistoryReadRequest {
+                app_id: "app".to_string(),
+                channel: "missing".to_string(),
+                direction: PresenceHistoryDirection::OldestFirst,
+                limit: 10,
+                cursor: None,
+                bounds: PresenceHistoryQueryBounds::default(),
+            })
+            .await
+            .unwrap();
+
+        assert!(page.items.is_empty());
+        assert_eq!(store.channels.read().await.len(), 0);
     }
 }

--- a/crates/sockudo-delta/src/lib.rs
+++ b/crates/sockudo-delta/src/lib.rs
@@ -6,6 +6,7 @@
 
 // Re-export core delta types so consumers can use `sockudo_delta::*`
 pub use sockudo_core::delta_types::*;
+use sockudo_core::utils::{is_wildcard_subscription_pattern, wildcard_pattern_matches};
 
 pub mod coordination;
 
@@ -288,17 +289,54 @@ impl SocketDeltaState {
         }
 
         if let Some(settings) = self.channel_delta_settings.get(channel) {
+            tracing::debug!(
+                "delta channel exact setting matched: channel={}, enabled={}",
+                channel,
+                settings.enabled
+            );
             return settings.enabled;
         }
 
+        for entry in self.channel_delta_settings.iter() {
+            let subscribed_channel = entry.key();
+            if is_wildcard_subscription_pattern(subscribed_channel)
+                && wildcard_pattern_matches(channel, subscribed_channel)
+            {
+                tracing::debug!(
+                    "delta channel wildcard setting matched: requested_channel={}, subscribed_channel={}, enabled={}",
+                    channel,
+                    subscribed_channel,
+                    entry.enabled
+                );
+                return entry.enabled;
+            }
+        }
+
+        tracing::debug!(
+            "delta channel setting fell back to enabled: channel={}",
+            channel
+        );
         true
     }
 
     fn get_algorithm_for_channel(&self, channel: &str, default: DeltaAlgorithm) -> DeltaAlgorithm {
-        self.channel_delta_settings
-            .get(channel)
-            .and_then(|s| s.algorithm)
-            .unwrap_or(default)
+        if let Some(settings) = self.channel_delta_settings.get(channel)
+            && let Some(algorithm) = settings.algorithm
+        {
+            return algorithm;
+        }
+
+        for entry in self.channel_delta_settings.iter() {
+            let subscribed_channel = entry.key();
+            if is_wildcard_subscription_pattern(subscribed_channel)
+                && wildcard_pattern_matches(channel, subscribed_channel)
+                && let Some(algorithm) = entry.algorithm
+            {
+                return algorithm;
+            }
+        }
+
+        default
     }
 
     fn set_channel_delta_settings(&self, channel: String, settings: PerChannelDeltaSettings) {
@@ -2203,6 +2241,47 @@ mod enhanced_tests {
 
         assert!(!manager.is_enabled_for_socket_channel(&socket_id, "channel-a"));
         assert!(manager.is_enabled_for_socket_channel(&socket_id, "channel-b")); // unaffected
+    }
+
+    #[tokio::test]
+    async fn wildcard_channel_delta_settings_apply_to_matching_channels() {
+        let config = DeltaCompressionConfig::default();
+        let manager = DeltaCompressionManager::new(config);
+        let socket_id = SocketId::new();
+
+        manager.enable_for_socket(&socket_id);
+        manager.set_channel_delta_settings(&socket_id, "ticker:*", Some(false), None);
+
+        assert!(!manager.is_enabled_for_socket_channel(&socket_id, "ticker:BTC"));
+        assert!(!manager.is_enabled_for_socket_channel(&socket_id, "ticker:ETH"));
+        assert!(manager.is_enabled_for_socket_channel(&socket_id, "price:BTC"));
+    }
+
+    #[tokio::test]
+    async fn wildcard_channel_delta_settings_apply_algorithm_override() {
+        let config = DeltaCompressionConfig {
+            algorithm: DeltaAlgorithm::Fossil,
+            ..Default::default()
+        };
+        let manager = DeltaCompressionManager::new(config);
+        let socket_id = SocketId::new();
+
+        manager.enable_for_socket(&socket_id);
+        manager.set_channel_delta_settings(
+            &socket_id,
+            "ticker:*",
+            Some(true),
+            Some(DeltaAlgorithm::Xdelta3),
+        );
+
+        assert_eq!(
+            manager.get_algorithm_for_channel(&socket_id, "ticker:BTC"),
+            DeltaAlgorithm::Xdelta3
+        );
+        assert_eq!(
+            manager.get_algorithm_for_channel(&socket_id, "price:BTC"),
+            DeltaAlgorithm::Fossil
+        );
     }
 
     #[tokio::test]

--- a/crates/sockudo-protocol/src/messages.rs
+++ b/crates/sockudo-protocol/src/messages.rs
@@ -305,6 +305,17 @@ impl From<Value> for MessageData {
 }
 
 impl PusherMessage {
+    pub fn is_protocol_ping_or_pong(&self) -> bool {
+        let Some(event) = self.event.as_deref() else {
+            return false;
+        };
+
+        matches!(
+            ProtocolVersion::parse_any_protocol_event(event),
+            Some(("ping", _)) | Some(("pong", _))
+        )
+    }
+
     pub fn connection_established(socket_id: String, activity_timeout: u64) -> Self {
         Self {
             event: Some("pusher:connection_established".to_string()),
@@ -781,5 +792,36 @@ impl InfoQueryParser for Option<&String> {
 
     fn wants_cache(&self) -> bool {
         self.parse_info().contains(&"cache")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PusherMessage;
+
+    #[test]
+    fn protocol_heartbeat_detection_matches_both_prefix_families() {
+        let mut ping = PusherMessage::ping();
+        assert!(ping.is_protocol_ping_or_pong());
+
+        ping.rewrite_prefix(crate::protocol_version::ProtocolVersion::V2);
+        assert!(ping.is_protocol_ping_or_pong());
+
+        let mut pong = PusherMessage::pong();
+        assert!(pong.is_protocol_ping_or_pong());
+
+        pong.rewrite_prefix(crate::protocol_version::ProtocolVersion::V2);
+        assert!(pong.is_protocol_ping_or_pong());
+    }
+
+    #[test]
+    fn protocol_heartbeat_detection_ignores_regular_messages() {
+        let message = PusherMessage::channel_event(
+            "chat.message",
+            "room",
+            sonic_rs::json!({"text": "hello"}),
+        );
+
+        assert!(!message.is_protocol_ping_or_pong());
     }
 }

--- a/crates/sockudo-queue/src/memory_queue_manager.rs
+++ b/crates/sockudo-queue/src/memory_queue_manager.rs
@@ -2,6 +2,7 @@ use crate::ArcJobProcessorFn;
 use ahash::AHashMap as HashMap;
 use async_trait::async_trait;
 use dashmap::DashMap;
+use futures_util::stream::{self, StreamExt};
 use sockudo_core::queue::QueueInterface;
 use sockudo_core::webhook_types::{JobData, JobProcessorFnAsync};
 use std::collections::VecDeque;
@@ -12,6 +13,8 @@ use tracing::{debug, info, warn};
 
 /// Maximum number of jobs per queue to prevent unbounded memory growth
 const MAX_QUEUE_SIZE: usize = 100_000;
+const MAX_BATCH_SIZE: usize = 1_024;
+const MAX_CONCURRENT_JOBS_PER_QUEUE: usize = 64;
 
 /// Memory-based queue manager for simple deployments
 pub struct MemoryQueueManager {
@@ -62,7 +65,8 @@ impl MemoryQueueManager {
                             continue;
                         }
 
-                        let jobs: Vec<JobData> = jobs_queue.drain(..).collect();
+                        let batch_len = MAX_BATCH_SIZE.min(jobs_queue.len());
+                        let jobs: Vec<JobData> = jobs_queue.drain(..batch_len).collect();
                         debug!(
                             "Processing {} jobs from memory queue {}",
                             jobs.len(),
@@ -70,14 +74,16 @@ impl MemoryQueueManager {
                         );
                         drop(jobs_queue);
 
-                        for job in jobs {
-                            let processor_clone = processor.clone();
-                            tokio::spawn(async move {
-                                if let Err(e) = processor_clone(job).await {
-                                    tracing::error!("Failed to process webhook job: {}", e);
+                        stream::iter(jobs)
+                            .for_each_concurrent(MAX_CONCURRENT_JOBS_PER_QUEUE, |job| {
+                                let processor_clone = processor.clone();
+                                async move {
+                                    if let Err(e) = processor_clone(job).await {
+                                        tracing::error!("Failed to process webhook job: {}", e);
+                                    }
                                 }
-                            });
-                        }
+                            })
+                            .await;
                     }
                 }
             }
@@ -138,6 +144,9 @@ impl QueueInterface for MemoryQueueManager {
 mod tests {
     use super::*;
     use sockudo_core::webhook_types::{JobData, JobPayload};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Notify;
+    use tokio::time::{Duration, timeout};
 
     #[tokio::test]
     async fn test_add_to_queue() {
@@ -180,5 +189,70 @@ mod tests {
 
         manager.disconnect().await.unwrap();
         assert!(manager.queues.is_empty());
+    }
+
+    #[tokio::test]
+    async fn processing_limits_per_queue_concurrency() {
+        let manager = MemoryQueueManager::new();
+        manager.start_processing();
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicUsize::new(0));
+        let done = Arc::new(Notify::new());
+        let total_jobs = MAX_CONCURRENT_JOBS_PER_QUEUE * 2;
+
+        let active_clone = Arc::clone(&active);
+        let max_active_clone = Arc::clone(&max_active);
+        let completed_clone = Arc::clone(&completed);
+        let done_clone = Arc::clone(&done);
+
+        manager
+            .process_queue(
+                "bounded",
+                Box::new(move |_job| {
+                    let active = Arc::clone(&active_clone);
+                    let max_active = Arc::clone(&max_active_clone);
+                    let completed = Arc::clone(&completed_clone);
+                    let done = Arc::clone(&done_clone);
+                    Box::pin(async move {
+                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_active.fetch_max(current, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(25)).await;
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        if completed.fetch_add(1, Ordering::SeqCst) + 1 == total_jobs {
+                            done.notify_waiters();
+                        }
+                        Ok(())
+                    })
+                }),
+            )
+            .await
+            .unwrap();
+
+        for _ in 0..total_jobs {
+            manager
+                .add_to_queue(
+                    "bounded",
+                    JobData {
+                        app_key: "test_key".to_string(),
+                        app_id: "test_id".to_string(),
+                        app_secret: "test_secret".to_string(),
+                        payload: JobPayload {
+                            time_ms: chrono::Utc::now().timestamp_millis(),
+                            events: vec![],
+                        },
+                        original_signature: "test_signature".to_string(),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        timeout(Duration::from_secs(3), done.notified())
+            .await
+            .expect("jobs should finish");
+
+        assert!(max_active.load(Ordering::SeqCst) <= MAX_CONCURRENT_JOBS_PER_QUEUE);
     }
 }

--- a/crates/sockudo-rate-limiter/src/memory_limiter.rs
+++ b/crates/sockudo-rate-limiter/src/memory_limiter.rs
@@ -2,10 +2,8 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use sockudo_core::error::Result;
 use sockudo_core::rate_limiter::{RateLimitConfig, RateLimitResult, RateLimiter};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
-use tokio::time::interval;
 
 /// Entry in the rate limiter map
 #[derive(Clone)]
@@ -21,12 +19,80 @@ struct RateLimitEntry {
 /// In-memory rate limiter implementation
 pub struct MemoryRateLimiter {
     /// Storage for rate limit counters
-    limits: Arc<DashMap<String, RateLimitEntry, ahash::RandomState>>,
+    limits: Arc<RateLimitMap>,
     /// Configuration for rate limiting
     config: RateLimitConfig,
-    /// Cleanup task handle
-    #[allow(dead_code)]
-    cleanup_task: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+}
+
+type RateLimitMap = DashMap<String, RateLimitEntry, ahash::RandomState>;
+
+struct SharedLimiterCleanup {
+    tracked_maps: Arc<Mutex<Vec<Weak<RateLimitMap>>>>,
+}
+
+impl SharedLimiterCleanup {
+    fn global() -> &'static Self {
+        static REGISTRY: OnceLock<SharedLimiterCleanup> = OnceLock::new();
+
+        REGISTRY.get_or_init(|| {
+            let cleanup = SharedLimiterCleanup {
+                tracked_maps: Arc::new(Mutex::new(Vec::new())),
+            };
+            cleanup.spawn_worker();
+            cleanup
+        })
+    }
+
+    fn register(&self, limits: &Arc<RateLimitMap>) {
+        let mut tracked_maps = self.tracked_maps.lock().unwrap();
+        tracked_maps.push(Arc::downgrade(limits));
+    }
+
+    fn spawn_worker(&self) {
+        let tracked_maps = Arc::clone(&self.tracked_maps);
+
+        std::thread::Builder::new()
+            .name("sockudo-rate-limit-sweeper".to_string())
+            .spawn(move || {
+                loop {
+                    std::thread::sleep(shared_cleanup_interval());
+                    let now = Instant::now();
+                    let live_maps = {
+                        let mut tracked = tracked_maps.lock().unwrap();
+                        let mut live_maps = Vec::with_capacity(tracked.len());
+                        tracked.retain(|weak_map| match weak_map.upgrade() {
+                            Some(map) => {
+                                live_maps.push(map);
+                                true
+                            }
+                            None => false,
+                        });
+                        live_maps
+                    };
+
+                    for limits in live_maps {
+                        sweep_expired_entries(&limits, now);
+                    }
+                }
+            })
+            .expect("failed to spawn shared rate limiter cleanup worker");
+    }
+}
+
+fn sweep_expired_entries(limits: &RateLimitMap, now: Instant) {
+    limits.retain(|_, value| value.expiry > now);
+}
+
+fn shared_cleanup_interval() -> Duration {
+    #[cfg(test)]
+    {
+        Duration::from_millis(25)
+    }
+
+    #[cfg(not(test))]
+    {
+        Duration::from_secs(10)
+    }
 }
 
 impl MemoryRateLimiter {
@@ -41,26 +107,10 @@ impl MemoryRateLimiter {
 
     /// Create a new memory-based rate limiter with a specific configuration
     pub fn with_config(config: RateLimitConfig) -> Self {
-        let limits: Arc<DashMap<String, RateLimitEntry, ahash::RandomState>> =
-            Arc::new(DashMap::with_hasher(ahash::RandomState::new()));
-        let limits_clone = Arc::clone(&limits);
+        let limits = Arc::new(DashMap::with_hasher(ahash::RandomState::new()));
+        SharedLimiterCleanup::global().register(&limits);
 
-        // Start cleanup task
-        let cleanup_task = tokio::spawn(async move {
-            let mut interval = interval(Duration::from_secs(10)); // Check every 10 seconds
-            loop {
-                interval.tick().await;
-                let now = Instant::now();
-                // remove all expired limits
-                limits_clone.retain(|_, value| value.expiry > now);
-            }
-        });
-
-        Self {
-            limits,
-            config,
-            cleanup_task: Arc::new(Mutex::new(Some(cleanup_task))),
-        }
+        Self { limits, config }
     }
 }
 
@@ -72,7 +122,8 @@ impl RateLimiter for MemoryRateLimiter {
         if let Some(entry) = self.limits.get(key) {
             // Check if the window has expired
             if entry.expiry <= now {
-                // Window expired, will be cleaned up later
+                drop(entry);
+                self.limits.remove(key);
                 return Ok(RateLimitResult {
                     allowed: true,
                     remaining: self.config.max_requests,
@@ -150,6 +201,8 @@ impl RateLimiter for MemoryRateLimiter {
         if let Some(entry) = self.limits.get(key) {
             // Check if the window has expired
             if entry.expiry <= now {
+                drop(entry);
+                self.limits.remove(key);
                 return Ok(self.config.max_requests);
             }
 
@@ -161,19 +214,10 @@ impl RateLimiter for MemoryRateLimiter {
     }
 }
 
-impl Drop for MemoryRateLimiter {
-    fn drop(&mut self) {
-        if let Ok(mut task_guard) = self.cleanup_task.try_lock()
-            && let Some(task) = task_guard.take()
-        {
-            task.abort();
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::time::{sleep, timeout};
 
     #[tokio::test]
     async fn test_rate_limiter_basic() {
@@ -249,5 +293,26 @@ mod tests {
 
         let result = limiter.check("concurrent_key").await.unwrap();
         assert_eq!(result.remaining, 0, "Should have exactly 100 increments");
+    }
+
+    #[tokio::test]
+    async fn test_shared_cleanup_reaps_idle_expired_entries() {
+        let limiter = MemoryRateLimiter::new(1, 1);
+
+        limiter.increment("test_key").await.unwrap();
+        assert_eq!(limiter.limits.len(), 1);
+
+        sleep(Duration::from_secs(2)).await;
+
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if limiter.limits.is_empty() {
+                    break;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("shared sweeper should reap expired idle limiter entries");
     }
 }

--- a/docker-compose.redis-cluster.yml
+++ b/docker-compose.redis-cluster.yml
@@ -86,6 +86,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    command: ["sockudo", "--config", "/app/config/config.redis-cluster-delta-e2e.json"]
     environment:
       DEBUG: "true"
       ADAPTER_DRIVER: "redis-cluster"
@@ -101,6 +102,9 @@ services:
       QUEUE_DRIVER: "memory"
       RATE_LIMITER_DRIVER: "memory"
       TAG_FILTERING_ENABLED: "true"
+      HISTORY_ENABLED: "true"
+      HISTORY_BACKEND: "memory"
+      PRESENCE_HISTORY_ENABLED: "true"
       SHUTDOWN_GRACE_PERIOD: "1"
       SOCKUDO_DEFAULT_APP_ID: "test-app"
       SOCKUDO_DEFAULT_APP_KEY: "test-key"
@@ -108,6 +112,8 @@ services:
     ports:
       - "6002:6002"
       - "9602:9602"
+    volumes:
+      - ./config/config.redis-cluster-delta-e2e.json:/app/config/config.redis-cluster-delta-e2e.json:ro
     networks:
       - redis-cluster-net
     depends_on:
@@ -117,6 +123,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    command: ["sockudo", "--config", "/app/config/config.redis-cluster-delta-e2e.json"]
     environment:
       DEBUG: "true"
       ADAPTER_DRIVER: "redis-cluster"
@@ -132,6 +139,9 @@ services:
       QUEUE_DRIVER: "memory"
       RATE_LIMITER_DRIVER: "memory"
       TAG_FILTERING_ENABLED: "true"
+      HISTORY_ENABLED: "true"
+      HISTORY_BACKEND: "memory"
+      PRESENCE_HISTORY_ENABLED: "true"
       SHUTDOWN_GRACE_PERIOD: "1"
       SOCKUDO_DEFAULT_APP_ID: "test-app"
       SOCKUDO_DEFAULT_APP_KEY: "test-key"
@@ -139,6 +149,8 @@ services:
     ports:
       - "6003:6003"
       - "9603:9603"
+    volumes:
+      - ./config/config.redis-cluster-delta-e2e.json:/app/config/config.redis-cluster-delta-e2e.json:ro
     networks:
       - redis-cluster-net
     depends_on:
@@ -148,6 +160,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    command: ["sockudo", "--config", "/app/config/config.redis-cluster-delta-e2e.json"]
     environment:
       DEBUG: "true"
       ADAPTER_DRIVER: "redis-cluster"
@@ -163,6 +176,9 @@ services:
       QUEUE_DRIVER: "memory"
       RATE_LIMITER_DRIVER: "memory"
       TAG_FILTERING_ENABLED: "true"
+      HISTORY_ENABLED: "true"
+      HISTORY_BACKEND: "memory"
+      PRESENCE_HISTORY_ENABLED: "true"
       SHUTDOWN_GRACE_PERIOD: "1"
       SOCKUDO_DEFAULT_APP_ID: "test-app"
       SOCKUDO_DEFAULT_APP_KEY: "test-key"
@@ -170,6 +186,8 @@ services:
     ports:
       - "6004:6004"
       - "9604:9604"
+    volumes:
+      - ./config/config.redis-cluster-delta-e2e.json:/app/config/config.redis-cluster-delta-e2e.json:ro
     networks:
       - redis-cluster-net
     depends_on:

--- a/docs/content/2.server/13.rate-limiting.md
+++ b/docs/content/2.server/13.rate-limiting.md
@@ -100,7 +100,7 @@ Retry-After: 45   # only on 429
 
 ## Per-App Message Rate Limit
 
-Limits the total number of inbound WebSocket messages on a single connection, regardless of event type. This protects against connected clients hammering the server with any combination of `pusher:subscribe`, `pusher:ping`, `client-*`, or other events.
+Limits the total number of inbound WebSocket messages on a single connection, regardless of event type. This protects against connected clients hammering the server with any combination of `pusher:subscribe`, `pusher:ping`, `sockudo:ping`, `client-*`, or other events.
 
 Configured per-app in `policy.limits.message_rate_limit`.
 

--- a/docs/content/3.client/1.overview.md
+++ b/docs/content/3.client/1.overview.md
@@ -26,6 +26,12 @@ All Sockudo client SDKs default to **protocol V2** (`?protocol=2`), which provid
 
 Set `protocolVersion: 1` for Pusher-compatible mode (`pusher:` prefix, no V2 features). For V1 you can also use official Pusher SDKs (`pusher-js`, etc.) directly.
 
+Heartbeat behavior:
+
+- Protocol V2 uses native WebSocket ping/pong frames for automatic server heartbeats.
+- Official SDKs may still use lightweight `sockudo:ping` / `sockudo:pong` fallback messages when a runtime does not expose native ping APIs well enough for client-side liveness checks.
+- Those fallback heartbeat messages are intentionally excluded from V2 recovery metadata such as `message_id`, `serial`, and `stream_id`.
+
 ## Core Features (all protocols)
 
 - `subscribe`, `unsubscribe`, `bind`, `unbind`

--- a/docs/content/5.reference/1.protocol.md
+++ b/docs/content/5.reference/1.protocol.md
@@ -26,6 +26,7 @@ Sockudo supports two protocol versions, negotiated per-connection via the `?prot
 | Event prefix | `pusher:` / `pusher_internal:` | `sockudo:` / `sockudo_internal:` |
 | `serial` field | Never sent | Always on every message |
 | `message_id` field | Never sent | Always on every broadcast |
+| Automatic heartbeat | Protocol `pusher:ping` / `pusher:pong` messages | Native WebSocket ping/pong frames |
 | Connection recovery | Not available | Available only when `connection_recovery.enabled = true` |
 | Delta compression | Not available | Native |
 | Tag filtering | Not available | Native |
@@ -104,12 +105,25 @@ Sockudo does not treat V2 as "Pusher plus extras". V2 is its own native contract
 - `sockudo:error`
 - `sockudo:subscribe`
 - `sockudo:unsubscribe`
-- `sockudo:ping`
-- `sockudo:pong`
 - `sockudo:signin`
 - `sockudo_internal:subscription_succeeded`
 - `sockudo_internal:member_added`
 - `sockudo_internal:member_removed`
+
+### V2 Heartbeats
+
+Protocol V2 uses native WebSocket ping/pong control frames for automatic heartbeat traffic.
+
+Implications:
+
+- automatic liveness checks do not consume normal V2 message bandwidth
+- automatic V2 heartbeats do not carry `message_id`, `serial`, or `stream_id`
+- browsers and WebSocket runtimes automatically respond to control-frame pings without surfacing them as normal protocol events
+
+Compatibility note:
+
+- `sockudo:ping` and `sockudo:pong` remain reserved protocol events for explicit diagnostics and SDK fallback behavior on runtimes that cannot use native ping APIs cleanly
+- when those fallback events are used, they are intentionally lightweight and are not part of recovery or broadcast continuity semantics
 
 ## Extension Events (V2 only)
 

--- a/docs/content/5.reference/5.error-codes.md
+++ b/docs/content/5.reference/5.error-codes.md
@@ -30,7 +30,7 @@ For protocol v2, the server rewrites the prefix to `sockudo:error`.
 | ---- | ------- | --------- |
 | `4100` | Capacity exhausted or slow-consumer buffer full | Backoff |
 | `4200` | Generic immediate reconnect condition | Immediate |
-| `4201` | Pong reply not received | Immediate |
+| `4201` | Pong reply not received (V1 or explicit fallback heartbeat) | Immediate |
 | `4202` | Closed after inactivity timeout | Immediate |
 
 ## Channel And Client Event Errors

--- a/scripts/e2e_delta_redis_cluster.mjs
+++ b/scripts/e2e_delta_redis_cluster.mjs
@@ -1,0 +1,400 @@
+import crypto from "node:crypto";
+import process from "node:process";
+
+// Usage:
+//   docker compose -f docker-compose.redis-cluster.yml up --build -d
+//   node scripts/e2e_delta_redis_cluster.mjs
+//
+// Optional overrides:
+//   HTTP_BASES=http://127.0.0.1:6002,http://127.0.0.1:6003,http://127.0.0.1:6004
+//   WS_URLS=ws://127.0.0.1:6002,ws://127.0.0.1:6003,ws://127.0.0.1:6004
+const APP_ID = process.env.APP_ID ?? "test-app";
+const APP_KEY = process.env.APP_KEY ?? "test-key";
+const APP_SECRET = process.env.APP_SECRET ?? "test-secret";
+const HTTP_BASES = (process.env.HTTP_BASES ?? "http://127.0.0.1:6002,http://127.0.0.1:6003,http://127.0.0.1:6004")
+  .split(",")
+  .map((url) => url.trim())
+  .filter(Boolean);
+const WS_URLS = (process.env.WS_URLS ?? "ws://127.0.0.1:6002,ws://127.0.0.1:6003,ws://127.0.0.1:6004")
+  .split(",")
+  .map((url) => `${url.trim().replace(/\/$/, "")}/app/${APP_KEY}?protocol=2`)
+  .filter(Boolean);
+
+const MARKET_CHANNEL = process.env.MARKET_CHANNEL ?? `ticker:BTC`;
+const ETH_CHANNEL = process.env.ETH_CHANNEL ?? `ticker:ETH`;
+const PRESENCE_CHANNEL = process.env.PRESENCE_CHANNEL ?? `presence-delta-cluster-${Date.now()}`;
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function hmac(input) {
+  return crypto.createHmac("sha256", APP_SECRET).update(input).digest("hex");
+}
+
+function signRequest(method, path, body = "", extraParams = {}) {
+  const params = {
+    ...extraParams,
+    auth_key: APP_KEY,
+    auth_timestamp: Math.floor(Date.now() / 1000).toString(),
+    auth_version: "1.0",
+  };
+
+  if (body.length > 0) {
+    params.body_md5 = crypto.createHash("md5").update(body).digest("hex");
+  }
+
+  const queryForSig = Object.keys(params)
+    .sort()
+    .map((key) => `${key}=${params[key]}`)
+    .join("&");
+  params.auth_signature = hmac(`${method}\n${path}\n${queryForSig}`);
+  return new URLSearchParams(params);
+}
+
+async function signedFetch(base, method, path, { bodyObject, query = {} } = {}) {
+  const body = bodyObject ? JSON.stringify(bodyObject) : "";
+  const params = signRequest(method, path, body, query);
+  const response = await fetch(`${base}${path}?${params.toString()}`, {
+    method,
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body || undefined,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${method} ${base}${path} failed (${response.status}): ${text}`);
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+async function publishEvent(base, { channel, name, payload, tags }) {
+  return signedFetch(base, "POST", `/apps/${APP_ID}/events`, {
+    bodyObject: {
+      channel,
+      name,
+      data: JSON.stringify(payload),
+      ...(tags ? { tags } : {}),
+    },
+  });
+}
+
+async function readHistory(base, channel) {
+  return signedFetch(base, "GET", `/apps/${APP_ID}/channels/${channel}/history`, {
+    query: { limit: "20", direction: "newest_first" },
+  });
+}
+
+async function readPresenceHistory(base, channel) {
+  return signedFetch(base, "GET", `/apps/${APP_ID}/channels/${channel}/presence/history`, {
+    query: { limit: "20", direction: "newest_first" },
+  });
+}
+
+function parseData(value) {
+  if (typeof value !== "string") {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizedEventName(event) {
+  return String(event ?? "")
+    .replace(/^pusher_internal:/, "")
+    .replace(/^sockudo_internal:/, "")
+    .replace(/^pusher:/, "")
+    .replace(/^sockudo:/, "");
+}
+
+function isInternal(event) {
+  const normalized = normalizedEventName(event);
+  return (
+    normalized === "connection_established" ||
+    normalized === "subscription_succeeded" ||
+    normalized === "delta_compression_enabled" ||
+    normalized === "delta_cache_sync" ||
+    normalized === "member_added" ||
+    normalized === "member_removed"
+  );
+}
+
+function isDeltaEvent(message) {
+  const data = parseData(message.data);
+  return normalizedEventName(message.event) === "delta" || Boolean(data?.__delta);
+}
+
+function eventSummary(message) {
+  return {
+    event: message.event,
+    channel: message.channel,
+    data: parseData(message.data),
+  };
+}
+
+class TestClient {
+  constructor(name, wsUrl, subscriptions) {
+    this.name = name;
+    this.wsUrl = wsUrl;
+    this.subscriptions = subscriptions;
+    this.events = [];
+    this.socketId = null;
+    this.ws = null;
+  }
+
+  async connect() {
+    this.ws = new WebSocket(this.wsUrl);
+    this.ws.onmessage = (event) => {
+      const payload = JSON.parse(event.data);
+      this.events.push(payload);
+
+      if (normalizedEventName(payload.event) === "connection_established") {
+        const data = parseData(payload.data);
+        this.socketId = data.socket_id;
+        for (const subscription of this.subscriptions(this.socketId)) {
+          this.ws.send(JSON.stringify({ event: "pusher:subscribe", data: subscription }));
+        }
+      }
+    };
+    this.ws.onerror = (event) => {
+      this.events.push({ event: "ws:error", detail: String(event?.message ?? "unknown") });
+    };
+
+    await this.waitFor(
+      () => this.subscribedChannels().length >= this.subscriptions("0.0").length,
+      12000,
+      "all subscriptions to succeed",
+    );
+  }
+
+  subscribedChannels() {
+    return this.events
+      .filter((event) => normalizedEventName(event.event) === "subscription_succeeded")
+      .map((event) => event.channel);
+  }
+
+  async waitFor(predicate, timeoutMs, label) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (predicate()) {
+        return;
+      }
+      await wait(25);
+    }
+    throw new Error(
+      `${this.name}: timed out waiting for ${label}; recent=${JSON.stringify(
+        this.events.slice(-10).map(eventSummary),
+      )}`,
+    );
+  }
+
+  businessEvents() {
+    return this.events.filter((event) => {
+      if (!event.channel?.startsWith("ticker:")) {
+        return false;
+      }
+      if (isInternal(event.event) || isDeltaEvent(event)) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  deltaEvents() {
+    return this.events.filter(isDeltaEvent);
+  }
+
+  close() {
+    try {
+      this.ws?.close();
+    } catch {}
+  }
+}
+
+function publicSubscription(channel, { filter, delta }) {
+  return {
+    channel,
+    ...(filter ? { filter } : {}),
+    ...(delta !== undefined ? { delta } : {}),
+  };
+}
+
+function presenceSubscription(socketId, channel, userId, userInfo) {
+  const channelData = JSON.stringify({ user_id: userId, user_info: userInfo });
+  return {
+    channel,
+    channel_data: channelData,
+    auth: `${APP_KEY}:${hmac(`${socketId}:${channel}:${channelData}`)}`,
+  };
+}
+
+async function waitForHealth() {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    const checks = await Promise.allSettled(
+      HTTP_BASES.map((base) => fetch(`${base}/up`).then((response) => response.ok)),
+    );
+    if (checks.every((check) => check.status === "fulfilled" && check.value)) {
+      return;
+    }
+    await wait(500);
+  }
+  throw new Error(`Sockudo nodes did not become healthy: ${HTTP_BASES.join(", ")}`);
+}
+
+async function main() {
+  assert(typeof WebSocket !== "undefined", "This script needs Node.js with global WebSocket support");
+  assert(HTTP_BASES.length >= 3 && WS_URLS.length >= 3, "Expected three HTTP_BASES and WS_URLS entries");
+
+  await waitForHealth();
+
+  const btcDeltaOnNode1 = new TestClient("btcDeltaOnNode1", WS_URLS[0], () => [
+    publicSubscription(MARKET_CHANNEL, {
+      filter: {
+        events: ["price-update"],
+        tags: { cmp: "eq", key: "symbol", val: "BTC" },
+      },
+      delta: { enabled: true, algorithm: "fossil" },
+    }),
+  ]);
+  const btcWildcardDeltaOnNode2 = new TestClient("btcWildcardDeltaOnNode2", WS_URLS[1], () => [
+    publicSubscription("ticker:*", {
+      filter: {
+        events: ["price-update"],
+        tags: { cmp: "eq", key: "symbol", val: "BTC" },
+      },
+      delta: { enabled: true, algorithm: "fossil" },
+    }),
+  ]);
+  const allPricesNoDeltaOnNode3 = new TestClient("allPricesNoDeltaOnNode3", WS_URLS[2], () => [
+    publicSubscription("ticker:*", {
+      filter: { events: ["price-update"] },
+      delta: false,
+    }),
+  ]);
+  const presenceAOnNode1 = new TestClient("presenceAOnNode1", WS_URLS[0], (socketId) => [
+    presenceSubscription(socketId, PRESENCE_CHANNEL, "user-a", { node: "node1" }),
+  ]);
+  const presenceBOnNode2 = new TestClient("presenceBOnNode2", WS_URLS[1], (socketId) => [
+    presenceSubscription(socketId, PRESENCE_CHANNEL, "user-b", { node: "node2" }),
+  ]);
+
+  const clients = [
+    btcDeltaOnNode1,
+    btcWildcardDeltaOnNode2,
+    allPricesNoDeltaOnNode3,
+    presenceAOnNode1,
+    presenceBOnNode2,
+  ];
+
+  try {
+    for (const client of clients) {
+      await client.connect();
+      await wait(100);
+    }
+
+    const filler = "cluster-delta-e2e-".repeat(80);
+    const publisher = HTTP_BASES[2];
+
+    for (let price = 50000; price <= 50050; price += 10) {
+      await publishEvent(publisher, {
+        channel: MARKET_CHANNEL,
+        name: "price-update",
+        payload: { item_id: "btc-1", symbol: "BTC", price, filler },
+        tags: { symbol: "BTC", asset_class: "crypto" },
+      });
+      await wait(140);
+    }
+
+    await publishEvent(publisher, {
+      channel: ETH_CHANNEL,
+      name: "price-update",
+      payload: { item_id: "eth-1", symbol: "ETH", price: 3000, filler },
+      tags: { symbol: "ETH", asset_class: "crypto" },
+    });
+    await wait(140);
+
+    await publishEvent(publisher, {
+      channel: MARKET_CHANNEL,
+      name: "trade-executed",
+      payload: { item_id: "btc-1", symbol: "BTC", quantity: 2, filler },
+      tags: { symbol: "BTC", asset_class: "crypto" },
+    });
+
+    await wait(1800);
+
+    const btcNode1Business = btcDeltaOnNode1.businessEvents();
+    const btcNode2Business = btcWildcardDeltaOnNode2.businessEvents();
+    const allNode3Business = allPricesNoDeltaOnNode3.businessEvents();
+
+    assert(btcDeltaOnNode1.deltaEvents().length > 0, "node1 BTC delta client did not receive any delta frames");
+    assert(btcWildcardDeltaOnNode2.deltaEvents().length > 0, "node2 wildcard delta client did not receive any delta frames");
+    assert(allPricesNoDeltaOnNode3.deltaEvents().length === 0, "delta-disabled node3 client received delta frames");
+    assert(
+      btcNode1Business.every((event) => event.channel === MARKET_CHANNEL && event.event === "price-update"),
+      "node1 BTC client received an event outside the BTC price filter",
+    );
+    assert(
+      btcNode2Business.every((event) => event.channel === MARKET_CHANNEL && event.event === "price-update"),
+      "node2 wildcard BTC client received an event outside the tag filter",
+    );
+    assert(
+      allNode3Business.some((event) => event.channel === MARKET_CHANNEL && event.event === "price-update") &&
+        allNode3Business.some((event) => event.channel === ETH_CHANNEL && event.event === "price-update") &&
+        allNode3Business.every((event) => event.event === "price-update"),
+      "node3 non-delta wildcard client did not receive both BTC and ETH price updates only",
+    );
+
+    const history = await readHistory(publisher, MARKET_CHANNEL);
+    assert(
+      history.items?.some((item) => item.event_name === "price-update") &&
+        history.items?.every((item) => item.event_name !== "pusher:delta"),
+      "publisher-node message history did not retain full business events",
+    );
+
+    const presenceHistoryA = await readPresenceHistory(HTTP_BASES[0], PRESENCE_CHANNEL);
+    const presenceHistoryB = await readPresenceHistory(HTTP_BASES[1], PRESENCE_CHANNEL);
+    assert(
+      presenceHistoryA.items?.some((item) => item.user_id === "user-a") &&
+        presenceHistoryB.items?.some((item) => item.user_id === "user-b"),
+      "presence history did not record local joins on both cluster nodes",
+    );
+
+    const summary = {
+      ok: true,
+      nodes: HTTP_BASES,
+      marketChannel: MARKET_CHANNEL,
+      presenceChannel: PRESENCE_CHANNEL,
+      deltaFrames: {
+        node1Exact: btcDeltaOnNode1.deltaEvents().length,
+        node2Wildcard: btcWildcardDeltaOnNode2.deltaEvents().length,
+        node3NoDelta: allPricesNoDeltaOnNode3.deltaEvents().length,
+      },
+      businessEvents: {
+        node1Exact: btcNode1Business.map((event) => `${event.channel}:${event.event}`),
+        node2Wildcard: btcNode2Business.map((event) => `${event.channel}:${event.event}`),
+        node3Wildcard: allNode3Business.map((event) => `${event.channel}:${event.event}`),
+      },
+      historyItemsOnPublisher: history.items?.length ?? 0,
+      presenceHistoryItems: {
+        node1: presenceHistoryA.items?.length ?? 0,
+        node2: presenceHistoryB.items?.length ?? 0,
+      },
+    };
+
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    clients.forEach((client) => client.close());
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || String(error));
+  process.exitCode = 1;
+});

--- a/scripts/e2e_v2_realtime_verify.mjs
+++ b/scripts/e2e_v2_realtime_verify.mjs
@@ -1,0 +1,365 @@
+import crypto from "node:crypto";
+import process from "node:process";
+
+const WS_URL = process.env.WS_URL ?? "ws://127.0.0.1:6001/app/app-key?protocol=2";
+const HTTP_BASE = process.env.HTTP_BASE ?? "http://127.0.0.1:6001";
+const APP_ID = process.env.APP_ID ?? "app-id";
+const APP_KEY = process.env.APP_KEY ?? "app-key";
+const APP_SECRET = process.env.APP_SECRET ?? "app-secret";
+let finalSummary = null;
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function signRequest(method, path, body) {
+  const auth_timestamp = Math.floor(Date.now() / 1000).toString();
+  const params = {
+    auth_key: APP_KEY,
+    auth_timestamp,
+    auth_version: "1.0",
+  };
+
+  if (body && body.length > 0) {
+    params.body_md5 = crypto.createHash("md5").update(body).digest("hex");
+  }
+
+  const queryForSig = Object.keys(params)
+    .sort()
+    .map((key) => `${key}=${params[key]}`)
+    .join("&");
+
+  const stringToSign = `${method}\n${path}\n${queryForSig}`;
+  const auth_signature = crypto
+    .createHmac("sha256", APP_SECRET)
+    .update(stringToSign)
+    .digest("hex");
+
+  return new URLSearchParams({ ...params, auth_signature });
+}
+
+async function publishEvent({ channel, name, payload, tags }) {
+  const path = `/apps/${APP_ID}/events`;
+  const body = JSON.stringify({
+    channel,
+    name,
+    data: JSON.stringify(payload),
+    ...(tags ? { tags } : {}),
+  });
+
+  const query = signRequest("POST", path, body);
+  const response = await fetch(`${HTTP_BASE}${path}?${query.toString()}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Publish failed (${response.status}): ${await response.text()}`);
+  }
+}
+
+class TestClient {
+  constructor(name, subscribePayload) {
+    this.name = name;
+    this.subscribePayload = subscribePayload;
+    this.events = [];
+    this.ws = null;
+  }
+
+  async connect() {
+    this.ws = new WebSocket(WS_URL);
+    this.ws.onmessage = (event) => {
+      const payload = JSON.parse(event.data);
+      this.events.push(payload);
+
+      if (payload.event === "sockudo:connection_established") {
+        this.ws.send(JSON.stringify(this.subscribePayload));
+      }
+    };
+    this.ws.onerror = (event) => {
+      this.events.push({ event: "ws:error", detail: String(event?.message ?? "unknown") });
+    };
+
+    await this.waitFor(
+      (msg) => msg.event === "sockudo_internal:subscription_succeeded",
+      10000,
+      "subscription success",
+    );
+  }
+
+  async waitFor(predicate, timeoutMs, label) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const existing = this.events.find(predicate);
+      if (existing) {
+        return existing;
+      }
+      await wait(25);
+    }
+    throw new Error(
+      `${this.name}: timed out waiting for ${label}; recent events=${JSON.stringify(
+        this.events.map((event) => ({ event: event.event, channel: event.channel })),
+      )}`,
+    );
+  }
+
+  businessEvents() {
+    return this.events.filter(
+      (event) =>
+        event.channel?.startsWith("ticker:") &&
+        !event.event?.startsWith("sockudo:") &&
+        !event.event?.startsWith("sockudo_internal:"),
+    );
+  }
+
+  deltaEvents() {
+    return this.events.filter((event) => event.event === "sockudo:delta");
+  }
+
+  deltaEnabledEvents() {
+    return this.events.filter(
+      (event) => event.event === "sockudo:delta_compression_enabled",
+    );
+  }
+
+  close() {
+    try {
+      this.ws?.close();
+    } catch {}
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function main() {
+  const exactCompoundNoDelta = new TestClient("exactCompoundNoDelta", {
+    event: "sockudo:subscribe",
+    data: {
+      channel: "ticker:BTC",
+      filter: {
+        events: ["price-update"],
+        tags: {
+          cmp: "eq",
+          key: "symbol",
+          val: "BTC",
+        },
+      },
+      delta: false,
+    },
+  });
+
+  const exactTradeOnly = new TestClient("exactTradeOnly", {
+    event: "sockudo:subscribe",
+    data: {
+      channel: "ticker:BTC",
+      filter: {
+        events: ["trade-executed"],
+      },
+      delta: false,
+    },
+  });
+
+  const exactDeltaEventOnly = new TestClient("exactDeltaEventOnly", {
+    event: "sockudo:subscribe",
+    data: {
+      channel: "ticker:BTC",
+      filter: {
+        events: ["price-update"],
+      },
+      delta: {
+        enabled: true,
+        algorithm: "fossil",
+      },
+    },
+  });
+
+  const wildcardCompoundDelta = new TestClient("wildcardCompoundDelta", {
+    event: "sockudo:subscribe",
+    data: {
+      channel: "ticker:*",
+      filter: {
+        events: ["price-update"],
+        tags: {
+          cmp: "eq",
+          key: "symbol",
+          val: "BTC",
+        },
+      },
+      delta: {
+        enabled: true,
+        algorithm: "fossil",
+      },
+    },
+  });
+
+  const wildcardEventOnlyNoDelta = new TestClient("wildcardEventOnlyNoDelta", {
+    event: "sockudo:subscribe",
+    data: {
+      channel: "ticker:*",
+      filter: {
+        events: ["price-update"],
+      },
+      delta: false,
+    },
+  });
+
+  const clients = [
+    exactCompoundNoDelta,
+    exactTradeOnly,
+    exactDeltaEventOnly,
+    wildcardCompoundDelta,
+    wildcardEventOnlyNoDelta,
+  ];
+  try {
+    for (const client of clients) {
+      await client.connect();
+      await wait(100);
+    }
+
+    await wait(300);
+
+    const filler = "x".repeat(320);
+
+    await publishEvent({
+      channel: "ticker:BTC",
+      name: "price-update",
+      payload: { item_id: "btc-1", symbol: "BTC", price: 50000, filler },
+      tags: { symbol: "BTC" },
+    });
+    await wait(120);
+
+    await publishEvent({
+      channel: "ticker:ETH",
+      name: "price-update",
+      payload: { item_id: "eth-1", symbol: "ETH", price: 3000, filler },
+      tags: { symbol: "ETH" },
+    });
+    await wait(120);
+
+    await publishEvent({
+      channel: "ticker:BTC",
+      name: "trade-executed",
+      payload: { item_id: "btc-1", symbol: "BTC", quantity: 2, filler },
+      tags: { symbol: "BTC" },
+    });
+    await wait(120);
+
+    await publishEvent({
+      channel: "ticker:BTC",
+      name: "price-update",
+      payload: { item_id: "btc-1", symbol: "BTC", price: 50010, filler },
+      tags: { symbol: "BTC" },
+    });
+    await wait(120);
+
+    await publishEvent({
+      channel: "ticker:BTC",
+      name: "price-update",
+      payload: { item_id: "btc-1", symbol: "BTC", price: 50020, filler },
+      tags: { symbol: "BTC" },
+    });
+
+    await wait(1500);
+
+    const exactCompoundBusiness = exactCompoundNoDelta.businessEvents();
+    const exactTradeBusiness = exactTradeOnly.businessEvents();
+    const exactDeltaBusiness = exactDeltaEventOnly.businessEvents();
+    const wildcardCompoundBusiness = wildcardCompoundDelta.businessEvents();
+    const wildcardEventOnlyBusiness = wildcardEventOnlyNoDelta.businessEvents();
+
+    finalSummary = {
+      exactCompoundNoDelta: {
+        totalEvents: exactCompoundNoDelta.events.length,
+        businessEvents: exactCompoundBusiness.map((event) => `${event.channel}:${event.event}`),
+        deltaEvents: exactCompoundNoDelta.deltaEvents().length,
+        deltaEnabledEvents: exactCompoundNoDelta.deltaEnabledEvents().length,
+      },
+      exactTradeOnly: {
+        totalEvents: exactTradeOnly.events.length,
+        businessEvents: exactTradeBusiness.map((event) => `${event.channel}:${event.event}`),
+        deltaEvents: exactTradeOnly.deltaEvents().length,
+        deltaEnabledEvents: exactTradeOnly.deltaEnabledEvents().length,
+      },
+      exactDeltaEventOnly: {
+        totalEvents: exactDeltaEventOnly.events.length,
+        businessEvents: exactDeltaBusiness.map((event) => `${event.channel}:${event.event}`),
+        deltaEvents: exactDeltaEventOnly.deltaEvents().length,
+        deltaEnabledEvents: exactDeltaEventOnly.deltaEnabledEvents().length,
+      },
+      wildcardCompoundDelta: {
+        totalEvents: wildcardCompoundDelta.events.length,
+        businessEvents: wildcardCompoundBusiness.map((event) => `${event.channel}:${event.event}`),
+        deltaEvents: wildcardCompoundDelta.deltaEvents().length,
+        deltaEnabledEvents: wildcardCompoundDelta.deltaEnabledEvents().length,
+      },
+      wildcardEventOnlyNoDelta: {
+        totalEvents: wildcardEventOnlyNoDelta.events.length,
+        businessEvents: wildcardEventOnlyBusiness.map((event) => `${event.channel}:${event.event}`),
+        deltaEvents: wildcardEventOnlyNoDelta.deltaEvents().length,
+        deltaEnabledEvents: wildcardEventOnlyNoDelta.deltaEnabledEvents().length,
+      },
+    };
+
+    assert(
+      exactCompoundBusiness.length >= 3 &&
+        exactCompoundBusiness.every(
+          (event) => event.event === "price-update" && event.channel === "ticker:BTC",
+        ),
+      "exactCompoundNoDelta did not receive only BTC price-update business events",
+    );
+    assert(
+      exactTradeBusiness.length === 1 &&
+        exactTradeBusiness[0].event === "trade-executed" &&
+        exactTradeBusiness[0].channel === "ticker:BTC",
+      "exactTradeOnly did not receive exactly one trade-executed event",
+    );
+    assert(
+      exactDeltaBusiness.every(
+        (event) => event.event === "price-update" && event.channel === "ticker:BTC",
+      ),
+      "exactDeltaEventOnly received unexpected business event",
+    );
+    assert(
+      wildcardCompoundBusiness.every(
+        (event) => event.event === "price-update" && event.channel === "ticker:BTC",
+      ),
+      "wildcardCompoundDelta received non-BTC or non-price business event",
+    );
+    assert(
+      wildcardEventOnlyBusiness.filter((event) => event.channel === "ticker:BTC").length >= 3 &&
+        wildcardEventOnlyBusiness.filter((event) => event.channel === "ticker:ETH").length >= 1 &&
+        wildcardEventOnlyBusiness.every((event) => event.event === "price-update"),
+      "wildcardEventOnlyNoDelta did not receive both BTC and ETH price updates only",
+    );
+
+    assert(
+      exactDeltaEventOnly.deltaEvents().length >= 1,
+      "exactDeltaEventOnly did not receive any sockudo:delta",
+    );
+    assert(
+      wildcardCompoundDelta.deltaEvents().length >= 1,
+      "wildcardCompoundDelta did not receive any sockudo:delta",
+    );
+    assert(
+      exactCompoundNoDelta.deltaEvents().length === 0 &&
+        exactTradeOnly.deltaEvents().length === 0 &&
+        wildcardEventOnlyNoDelta.deltaEvents().length === 0,
+      "delta-disabled clients received sockudo:delta",
+    );
+
+    console.log(JSON.stringify({ ok: true, summary: finalSummary }, null, 2));
+  } finally {
+    clients.forEach((client) => client.close());
+  }
+}
+
+main().catch((error) => {
+  if (finalSummary) {
+    console.error(JSON.stringify({ ok: false, summary: finalSummary }, null, 2));
+  }
+  console.error(error.stack || String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- switch automatic V2 server heartbeats to native WebSocket ping/pong frames while keeping V1 on protocol `pusher:ping` / `pusher:pong`
- stop attaching V2 recovery metadata to fallback heartbeat messages
- add clustered Redis E2E coverage for delta compression combined with wildcard subscriptions, tag filtering, durable message history, and presence history across three Sockudo nodes
- tighten clustered fanout/request waiting, read-only namespace lookups, per-channel delta enablement, wildcard matching, presence-history dedupe, and in-memory cleanup paths so related features do not interfere with V2 delivery
- add namespace profiling/benchmark helpers for exact/wildcard socket matching performance

## Why
- V2 clients should rely on native WebSocket control frames for idle heartbeats without regressing V1 Pusher compatibility.
- Delta compression can fail in subtle ways when combined with clustered fanout, wildcard subscriptions, tag filters, history, and presence state, so this PR adds a concrete Redis Cluster scenario to exercise those interactions.

## Clustered Delta E2E Scenario
- Compose file: `docker-compose.redis-cluster.yml`
- Config: `config/config.redis-cluster-delta-e2e.json`
- Runner: `scripts/e2e_delta_redis_cluster.mjs`
- Scenario connects clients to different Sockudo nodes, subscribes exact and wildcard `ticker:*` channels, enables delta per subscription, applies tag/event filters, publishes from another node, checks durable history stores full business events, and verifies presence history records joins on separate nodes.

## Verification
- `cargo fmt --all`
- `cargo test -p sockudo-protocol --lib messages -- --nocapture`
- `cargo test -p sockudo-adapter local_adapter -- --nocapture`
- `SOCKUDO_LIVE_TESTS=1 swift test --filter liveV2HeartbeatUsesControlFramesOnIdle`
- `SOCKUDO_LIVE_TESTS=1 swift test --filter liveV2FallbackPongHasNoMetadata`
- `SOCKUDO_LIVE_TESTS=1 swift test --filter liveV1HeartbeatStillUsesProtocolPing`
- `SOCKUDO_LIVE_TESTS=1 swift test --filter localSockudoIntegrationConnectsAndReceivesPublishedEvent`
- `SOCKUDO_LIVE_TESTS=1 bun run vitest run test/live-wire-format.test.ts test/live-framework-hooks.test.ts`
- `SOCKUDO_LIVE_TESTS=1 ./gradlew :lib:test --tests io.sockudo.client.LiveIntegrationTest`
- `SOCKUDO_LIVE_TESTS=1 flutter test test/sockudo_flutter_test.dart`
- `dotnet test client-sdks/sockudo-dotnet/tests/Sockudo.Client.Tests/Sockudo.Client.Tests.csproj`
- `cargo test -p sockudo-delta -p sockudo-core -p sockudo-adapter`
- `cargo test -p sockudo-core --benches --no-run`
- `cargo check -p sockudo-core --examples`

## Not Run
- `docker compose -f docker-compose.redis-cluster.yml up --build -d && node scripts/e2e_delta_redis_cluster.mjs` because the local Docker daemon was unavailable: `Cannot connect to the Docker daemon at unix:///Users/radudiaconu/.docker/run/docker.sock`.

## Related SDK pushes
- sockudo/sockudo-swift pushed to main at 53e2b0b
- sockudo/sockudo-dotnet pushed to main at a70ab7e
