### PR TITLE
perf(metrics): use local socket count for broadcast latency metrics

### DIFF
--- a/crates/sockudo-adapter/src/filter_index.rs
+++ b/crates/sockudo-adapter/src/filter_index.rs
@@ -109,7 +109,7 @@ impl FilterIndex {
                     .insert(socket_id);
             }
             Some(filter_node) => {
-                if let Some(indexable) = self.extract_indexable_filter(filter_node) {
+                if let Some(indexable) = Self::extract_indexable_filter(filter_node) {
                     // Filter can be indexed
                     tracing::debug!(
                         "FilterIndex: Adding socket {} to eq_index for channel {}, key={}, values_count={}",
@@ -192,7 +192,7 @@ impl FilterIndex {
         // Remove from eq_index based on filter (if provided)
         // This is the only index where we need to know the filter to find the right entries
         if let Some(filter_node) = filter
-            && let Some(indexable) = self.extract_indexable_filter(filter_node)
+            && let Some(indexable) = Self::extract_indexable_filter(filter_node)
         {
             self.remove_from_eq_index(channel, socket_id, &indexable);
         }
@@ -296,7 +296,7 @@ impl FilterIndex {
     /// - Simple equality: `key = value`
     /// - IN operator: `key IN [v1, v2, ...]`
     /// - OR of indexable filters (all children must be indexable with same key)
-    fn extract_indexable_filter(&self, filter: &FilterNode) -> Option<IndexableFilter> {
+    fn extract_indexable_filter(filter: &FilterNode) -> Option<IndexableFilter> {
         // Check if it's a logical operation
         if let Some(op) = filter.logical_op() {
             match op {
@@ -306,7 +306,7 @@ impl FilterIndex {
                     let mut common_key: Option<String> = None;
 
                     for child in filter.nodes() {
-                        if let Some(indexable) = self.extract_indexable_filter(child) {
+                        if let Some(indexable) = Self::extract_indexable_filter(child) {
                             match &common_key {
                                 None => common_key = Some(indexable.key.clone()),
                                 Some(k) if k != &indexable.key => return None, // Different keys

--- a/crates/sockudo-adapter/src/handler/connection_management.rs
+++ b/crates/sockudo-adapter/src/handler/connection_management.rs
@@ -2,6 +2,7 @@
 
 // src/adapter/handler/connection_management.rs
 use super::ConnectionHandler;
+use crate::connection_manager::ConnectionManager;
 use bytes::Bytes;
 use sockudo_core::app::App;
 use sockudo_core::error::{Error, Result};
@@ -255,10 +256,18 @@ impl ConnectionHandler {
 
         // Get the number of sockets in the channel before sending and send the message
         let (result, target_socket_count) = {
-            let socket_count = self
-                .connection_manager
-                .get_channel_socket_count(&app_config.id, channel)
-                .await;
+            // Use local-only socket count — this value is only used for metrics, not
+            // broadcast correctness. Avoids the distributed adapter round-trip (e.g.
+            // cross-region NATS request/reply latency).
+            let socket_count = if let Some(ref local_adapter) = self.local_adapter {
+                local_adapter
+                    .get_channel_socket_count(&app_config.id, channel)
+                    .await
+            } else {
+                self.connection_manager
+                    .get_channel_socket_count(&app_config.id, channel)
+                    .await
+            };
 
             // Adjust for excluded socket
             let target_socket_count = if exclude_socket.is_some() && socket_count > 0 {


### PR DESCRIPTION
Avoids a distributed adapter round-trip (e.g. cross-region NATS request/reply) when fetching channel socket count purely for track_broadcast_latency metrics. Falls back to the connection manager when no local adapter is available.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->