### PR TITLE
perf(adapter): batch disconnect queries to reduce transport pressure

### DIFF
--- a/crates/sockudo-adapter/src/channel_manager.rs
+++ b/crates/sockudo-adapter/src/channel_manager.rs
@@ -14,6 +14,13 @@ use sonic_rs::{Value, json};
 
 use std::sync::Arc;
 
+struct ChannelLeave {
+    channel_name: String,
+    app_id: String,
+    was_removed: bool,
+    local_remaining: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PresenceMember {
     pub(crate) user_id: Box<str>,
@@ -225,9 +232,8 @@ impl ChannelManager {
                 .await?;
 
             let remaining = connection_manager
-                .get_channel_sockets(app_id, channel_name)
-                .await?
-                .len();
+                .get_channel_socket_count(app_id, channel_name)
+                .await;
 
             // Clean up empty channels
             if remaining == 0 {
@@ -448,8 +454,9 @@ impl ChannelManager {
             .await
     }
 
-    /// Batch unsubscribe operation - single lock acquisition for multiple operations
-    /// Returns results with channel names for explicit correlation
+    /// Batch unsubscribe operation for multiple channels
+    /// Returns results with channel names for explicit correlation.
+    /// Uses a single batched cross-node query instead of one per channel.
     pub async fn batch_unsubscribe(
         connection_manager: &Arc<dyn ConnectionManager + Send + Sync>,
         operations: Vec<(String, String, String)>, // (socket_id, channel_name, app_id)
@@ -458,35 +465,105 @@ impl ChannelManager {
             return Ok(Vec::new());
         }
 
-        let mut results = Vec::with_capacity(operations.len());
-        let mut channels_to_cleanup = Vec::new();
+        // Remove sockets locally and collect local counts (no cross-node traffic)
+        let mut local_results: Vec<Result<ChannelLeave, (String, Error)>> =
+            Vec::with_capacity(operations.len());
 
-        for (socket_id, channel_name, app_id) in operations {
-            let socket_id_owned = SocketId::from_string(&socket_id)
-                .map_err(|e| Error::Connection(format!("Invalid socket ID: {}", e)))?;
+        for (socket_id, channel_name, app_id) in &operations {
+            let socket_id_owned = match SocketId::from_string(socket_id) {
+                Ok(sid) => sid,
+                Err(e) => {
+                    local_results.push(Err((
+                        channel_name.clone(),
+                        Error::Connection(format!("Invalid socket ID: {}", e)),
+                    )));
+                    continue;
+                }
+            };
+
             match connection_manager
-                .remove_from_channel(&app_id, &channel_name, &socket_id_owned)
+                .remove_from_channel(app_id, channel_name, &socket_id_owned)
                 .await
             {
                 Ok(was_removed) => {
-                    // Get remaining count
-                    match connection_manager
-                        .get_channel_sockets(&app_id, &channel_name)
-                        .await
-                    {
-                        Ok(sockets) => {
-                            let remaining = sockets.len();
-                            results.push((channel_name.clone(), Ok((was_removed, remaining))));
+                    let local_remaining = connection_manager
+                        .get_local_channel_socket_count(app_id, channel_name)
+                        .await;
+                    local_results.push(Ok(ChannelLeave {
+                        channel_name: channel_name.clone(),
+                        app_id: app_id.clone(),
+                        was_removed,
+                        local_remaining,
+                    }));
+                }
+                Err(e) => {
+                    local_results.push(Err((channel_name.clone(), e)));
+                }
+            }
+        }
 
-                            // Mark for cleanup if empty
-                            if remaining == 0 {
-                                channels_to_cleanup.push((app_id.clone(), channel_name.clone()));
-                            }
-                        }
-                        Err(e) => results.push((channel_name.clone(), Err(e))),
+        // Batched remote query for all channels (deduplicated per app)
+        let mut channels_by_app: AHashMap<String, Vec<String>> = AHashMap::new();
+        for r in local_results.iter().flatten() {
+            let (channel_name, app_id) = (&r.channel_name, &r.app_id);
+            channels_by_app
+                .entry(app_id.clone())
+                .or_default()
+                .push(channel_name.clone());
+        }
+        for channels in channels_by_app.values_mut() {
+            channels.sort_unstable();
+            channels.dedup();
+        }
+
+        let mut remote_counts: AHashMap<(String, String), usize> = AHashMap::new();
+        for (app_id, channels) in &channels_by_app {
+            let channel_refs: Vec<&str> = channels.iter().map(|s| s.as_str()).collect();
+            match connection_manager
+                .get_batch_channel_socket_counts(app_id, &channel_refs)
+                .await
+            {
+                Ok(counts) => {
+                    for (channel, count) in counts {
+                        remote_counts.insert((app_id.clone(), channel), count);
                     }
                 }
-                Err(e) => results.push((channel_name.clone(), Err(e))),
+                Err(e) => {
+                    tracing::error!(
+                        "Batch channel socket count failed for app {}: {}. \
+                         Webhook counts will reflect local node only.",
+                        app_id,
+                        e
+                    );
+                }
+            }
+        }
+
+        // Merge local and remote counts, clean up empty channels
+        let mut results = Vec::with_capacity(local_results.len());
+        let mut channels_to_cleanup: Vec<(String, String)> = Vec::new();
+
+        for result in local_results {
+            match result {
+                Ok(ChannelLeave {
+                    channel_name,
+                    app_id,
+                    was_removed,
+                    local_remaining,
+                }) => {
+                    let remote = remote_counts
+                        .remove(&(app_id.clone(), channel_name.clone()))
+                        .unwrap_or(0);
+                    let total = local_remaining + remote;
+
+                    if total == 0 {
+                        channels_to_cleanup.push((app_id, channel_name.clone()));
+                    }
+                    results.push((channel_name, Ok((was_removed, total))));
+                }
+                Err((channel_name, e)) => {
+                    results.push((channel_name, Err(e)));
+                }
             }
         }
 

--- a/crates/sockudo-adapter/src/connection_manager.rs
+++ b/crates/sockudo-adapter/src/connection_manager.rs
@@ -172,6 +172,27 @@ pub trait ConnectionManager: Send + Sync {
     async fn get_namespaces(&self) -> Result<Vec<(String, Arc<Namespace>)>>;
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
+    /// Local-only socket count (no cross-node query)
+    async fn get_local_channel_socket_count(&self, app_id: &str, channel: &str) -> usize {
+        self.get_channel_socket_count(app_id, channel).await
+    }
+
+    /// Batch cross-node channel socket counts in one round-trip
+    async fn get_batch_channel_socket_counts(
+        &self,
+        app_id: &str,
+        channels: &[&str],
+    ) -> Result<HashMap<String, usize>> {
+        let mut result = HashMap::new();
+        for channel in channels {
+            let count = self.get_channel_socket_count(app_id, channel).await;
+            if count > 0 {
+                result.insert(channel.to_string(), count);
+            }
+        }
+        Ok(result)
+    }
+
     /// Check the health of the connection manager and its underlying adapter
     /// Returns Ok(()) if healthy, Err(error_message) if unhealthy with specific reason
     async fn check_health(&self) -> Result<()>;

--- a/crates/sockudo-adapter/src/horizontal_adapter.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter.rs
@@ -49,7 +49,8 @@ pub enum RequestType {
     NodeDead,  // Dead node notification
 
     // State synchronization
-    PresenceStateSync, // Send bulk presence state to a specific node
+    PresenceStateSync,        // Send bulk presence state to a specific node
+    BatchChannelSocketsCount, // Get socket counts for a list of channels in one round-trip
 }
 
 /// Request body for horizontal communication
@@ -68,6 +69,10 @@ pub struct RequestBody {
     pub timestamp: Option<u64>,             // For heartbeat timestamp
     pub dead_node_id: Option<String>,       // For dead node notifications
     pub target_node_id: Option<String>,     // Which node should process this request
+
+    // List of channels for BatchChannelSocketsCount
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channels: Option<Vec<String>>,
 }
 
 /// Response body for horizontal requests
@@ -484,6 +489,21 @@ impl HorizontalAdapter {
                     self.cleanup_local_presence_registry(dead_node_id).await;
                 }
             }
+            RequestType::BatchChannelSocketsCount => {
+                if let Some(channels) = &request.channels {
+                    for channel in channels {
+                        let count = self
+                            .local_adapter
+                            .get_channel_socket_count(&request.app_id, channel)
+                            .await;
+                        if count > 0 {
+                            response
+                                .channels_with_sockets_count
+                                .insert(channel.clone(), count);
+                        }
+                    }
+                }
+            }
             RequestType::PresenceStateSync => {
                 if let Some(presence_data) = request.user_info {
                     let deser_result = sonic_rs::to_vec(&presence_data).and_then(|bytes| {
@@ -686,6 +706,7 @@ impl HorizontalAdapter {
             timestamp: None,
             dead_node_id: None,
             target_node_id: None,
+            channels: None,
         };
 
         // Add to pending requests with proper initialization
@@ -893,6 +914,15 @@ impl HorizontalAdapter {
                     // Sum connection counts from all nodes
                     combined_response.sockets_count += response.sockets_count;
                 }
+                RequestType::BatchChannelSocketsCount => {
+                    for (channel, count) in response.channels_with_sockets_count {
+                        *combined_response
+                            .channels_with_sockets_count
+                            .entry(channel)
+                            .or_insert(0) += count;
+                    }
+                }
+
                 // Presence replication - no response aggregation needed (broadcast-only)
                 RequestType::PresenceMemberJoined => {
                     // These are broadcast-only requests, no response aggregation needed

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -227,15 +227,12 @@ where
         self.enable_socket_counting = enable;
     }
 
-    /// Enhanced send_request that properly integrates with HorizontalAdapter
-    pub async fn send_request(
-        &self,
-        app_id: &str,
-        request_type: RequestType,
-        channel: Option<&str>,
-        socket_id: Option<&str>,
-        user_id: Option<&str>,
-    ) -> Result<ResponseBody> {
+    /// Publish a pre-built RequestBody and collect responses from other nodes
+    pub async fn send_request_with_body(&self, request: RequestBody) -> Result<ResponseBody> {
+        let app_id = request.app_id.clone();
+        let request_type = request.request_type.clone();
+        let request_id = request.request_id.clone();
+
         let should_skip_horizontal = self.should_skip_horizontal_communication().await;
         let discovered_node_count = self.horizontal.get_effective_node_count().await;
         let node_count = if should_skip_horizontal {
@@ -245,25 +242,6 @@ where
                 discovered_node_count,
                 self.transport.get_node_count().await?,
             )
-        };
-
-        // Create the request
-        let request_id = Uuid::new_v4().to_string();
-        let node_id = self.horizontal.node_id.clone();
-
-        let request = RequestBody {
-            request_id: request_id.clone(),
-            node_id,
-            app_id: app_id.to_string(),
-            request_type: request_type.clone(),
-            channel: channel.map(String::from),
-            socket_id: socket_id.map(String::from),
-            user_id: user_id.map(String::from),
-            // Cluster presence fields (not used for regular requests)
-            user_info: None,
-            timestamp: None,
-            dead_node_id: None,
-            target_node_id: None,
         };
 
         if should_skip_horizontal {
@@ -297,7 +275,7 @@ where
             );
 
             if let Some(metrics) = self.horizontal.metrics.get() {
-                metrics.mark_horizontal_adapter_request_sent(app_id);
+                metrics.mark_horizontal_adapter_request_sent(&app_id);
             }
         }
 
@@ -489,7 +467,7 @@ where
         // Track metrics
         if let Some(metrics) = self.horizontal.metrics.get() {
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.0; // Convert to milliseconds with 3 decimal places
-            metrics.track_horizontal_adapter_resolve_time(app_id, duration_ms);
+            metrics.track_horizontal_adapter_resolve_time(&app_id, duration_ms);
 
             let resolved = combined_response.sockets_count > 0
                 || !combined_response.members.is_empty()
@@ -498,10 +476,36 @@ where
                 || combined_response.members_count > 0
                 || !combined_response.channels_with_sockets_count.is_empty();
 
-            metrics.track_horizontal_adapter_resolved_promises(app_id, resolved);
+            metrics.track_horizontal_adapter_resolved_promises(&app_id, resolved);
         }
 
         Ok(combined_response)
+    }
+
+    /// Enhanced send_request that properly integrates with HorizontalAdapter
+    pub async fn send_request(
+        &self,
+        app_id: &str,
+        request_type: RequestType,
+        channel: Option<&str>,
+        socket_id: Option<&str>,
+        user_id: Option<&str>,
+    ) -> Result<ResponseBody> {
+        let request = RequestBody {
+            request_id: Uuid::new_v4().to_string(),
+            node_id: self.horizontal.node_id.clone(),
+            app_id: app_id.to_string(),
+            request_type,
+            channel: channel.map(String::from),
+            socket_id: socket_id.map(String::from),
+            user_id: user_id.map(String::from),
+            user_info: None,
+            timestamp: None,
+            dead_node_id: None,
+            target_node_id: None,
+            channels: None,
+        };
+        self.send_request_with_body(request).await
     }
 
     pub async fn start_listeners(&self) -> Result<()> {
@@ -821,6 +825,7 @@ where
                     timestamp: Some(current_timestamp()),
                     dead_node_id: None,
                     target_node_id: None,
+                    channels: None,
                 };
 
                 if let Err(e) = transport.publish_request(&heartbeat_request).await {
@@ -935,6 +940,7 @@ where
                                     timestamp: Some(current_timestamp()),
                                     dead_node_id: Some(dead_node_id.clone()),
                                     target_node_id: None,
+                                    channels: None,
                                 };
 
                                 if let Err(e) = transport.publish_request(&dead_node_request).await
@@ -1410,6 +1416,59 @@ where
             .count
     }
 
+    async fn get_local_channel_socket_count(&self, app_id: &str, channel: &str) -> usize {
+        self.local_adapter
+            .get_channel_socket_count(app_id, channel)
+            .await
+    }
+
+    async fn get_batch_channel_socket_counts(
+        &self,
+        app_id: &str,
+        channels: &[&str],
+    ) -> Result<HashMap<String, usize>> {
+        // Get local counts (no cross-node communication)
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for ch in channels {
+            let c = self
+                .local_adapter
+                .get_channel_socket_count(app_id, ch)
+                .await;
+            if c > 0 {
+                counts.insert(ch.to_string(), c);
+            }
+        }
+
+        if self.should_skip_horizontal_communication().await {
+            return Ok(counts);
+        }
+
+        // Single batched request for all channels
+        let request = RequestBody {
+            request_id: Uuid::new_v4().to_string(),
+            node_id: self.horizontal.node_id.clone(),
+            app_id: app_id.to_string(),
+            request_type: RequestType::BatchChannelSocketsCount,
+            channel: None,
+            socket_id: None,
+            user_id: None,
+            user_info: None,
+            timestamp: None,
+            dead_node_id: None,
+            target_node_id: None,
+            channels: Some(channels.iter().map(|c| c.to_string()).collect()),
+        };
+
+        let response = self.send_request_with_body(request).await?;
+
+        // Merge remote counts into local
+        for (ch, count) in response.channels_with_sockets_count {
+            *counts.entry(ch).or_insert(0) += count;
+        }
+
+        Ok(counts)
+    }
+
     async fn add_to_channel(
         &self,
         app_id: &str,
@@ -1621,6 +1680,7 @@ impl<T: HorizontalTransport> HorizontalAdapterInterface for HorizontalAdapterBas
             timestamp: None,
             dead_node_id: None,
             target_node_id: None,
+            channels: None,
         };
 
         // Send without waiting for response (broadcast) - skip if single node
@@ -1662,6 +1722,7 @@ impl<T: HorizontalTransport> HorizontalAdapterInterface for HorizontalAdapterBas
             timestamp: None,
             dead_node_id: None,
             target_node_id: None,
+            channels: None,
         };
 
         // Send without waiting for response (broadcast) - skip if single node
@@ -1708,6 +1769,7 @@ async fn send_presence_state_to_node<T: HorizontalTransport>(
             user_id: None,
             timestamp: None,
             dead_node_id: None,
+            channels: None,
         };
 
         // This broadcasts but only target_node will process it

--- a/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
@@ -35,6 +35,7 @@ async fn test_heartbeat_tracking_updates_node_registry() {
         timestamp: Some(1234567890),
         dead_node_id: None,
         target_node_id: None,
+        channels: None,
     };
 
     // Process the heartbeat through the adapter's request handler
@@ -383,6 +384,7 @@ async fn test_follower_cleanup_only_removes_registry_data() {
         timestamp: Some(1234567890),
         dead_node_id: Some(dead_node_id.to_string()),
         target_node_id: None,
+        channels: None,
     };
 
     // Process the dead node notification

--- a/crates/sockudo-adapter/tests/adapter/presence_state_consistency_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_state_consistency_tests.rs
@@ -110,6 +110,7 @@ async fn test_presence_state_with_clock_skew() {
         timestamp: Some(1000), // Earlier timestamp
         dead_node_id: None,
         target_node_id: None,
+        channels: None,
     };
 
     let request_late = RequestBody {
@@ -124,6 +125,7 @@ async fn test_presence_state_with_clock_skew() {
         timestamp: Some(2000), // Later timestamp
         dead_node_id: None,
         target_node_id: None,
+        channels: None,
     };
 
     // Process requests (late one first to test handling)

--- a/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
@@ -92,6 +92,7 @@ pub fn create_test_request() -> RequestBody {
         timestamp: None,
         dead_node_id: None,
         target_node_id: None,
+        channels: None,
     }
 }
 


### PR DESCRIPTION
`batch_unsubscribe` calls `get_channel_sockets().len()` per channel on disconnect — a broadcast-and-collect that fetches complete socket ID lists from every node just to count them. For large private channels with thousands of sockets per node, each response can reach ~216 KB. At high disconnect rates this fills NATS 64 MB outbound buffers faster than they drain, producing slow-consumer disconnects that cascade into pod restarts.
Replace the per-channel full socket list query with a single `BatchChannelSocketsCount` round-trip that returns `{channel: count}` for all channels at once. Restructure `batch_unsubscribe` into two phases: local removes, then one batched remote query.
- Add `BatchChannelSocketsCount` request type with `channels` field on `RequestBody` (`serde(default, skip_serializing_if)` — old nodes deserialize as `None`, safe for rolling deploys)
- Extract `send_request_with_body` from `send_request` (pure refactor) so the batched path reuses all existing plumbing
- Add `get_local_channel_socket_count` and `get_batch_channel_socket_counts` default-impl trait methods on `ConnectionManager` — `LocalAdapter` needs no changes
- Rewrite `batch_unsubscribe` with phase 1 (local removes) + phase 2 (one batched remote query) + phase 3 (merge + cleanup)

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->