### PR TITLE
fix(nats): replace per-request inbox subscriptions with a shared wildcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2632,7 +2632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3069,7 +3069,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -3600,9 +3600,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3624,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
  "idna",
@@ -3872,7 +3872,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5006,7 +5006,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5298,7 +5298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6088,7 +6088,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6128,7 +6128,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6945,7 +6945,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7019,7 +7019,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7040,7 +7040,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7267,7 +7267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7598,7 +7598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8602,7 +8602,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8623,7 +8623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9677,7 +9677,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/sockudo-adapter/src/factory.rs
+++ b/crates/sockudo-adapter/src/factory.rs
@@ -336,6 +336,9 @@ impl AdapterFactory {
                     nodes_number: config.nats.nodes_number,
                     discovery_max_wait_ms: config.nats.discovery_max_wait_ms,
                     discovery_idle_wait_ms: config.nats.discovery_idle_wait_ms,
+                    subscription_capacity: config.nats.subscription_capacity,
+                    client_capacity: config.nats.client_capacity,
+                    max_reconnects: config.nats.max_reconnects,
                 };
                 match NatsAdapter::new(nats_cfg).await {
                     Ok(mut adapter) => {

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -13,9 +13,7 @@ use crate::horizontal_adapter::{
     AggregationStats, BroadcastMessage, DeadNodeEvent, HorizontalAdapter, OrphanedMember,
     PendingRequest, RequestBody, RequestType, ResponseBody, current_timestamp, generate_request_id,
 };
-use crate::horizontal_transport::{
-    HorizontalTransport, ResponseHandler, TransportConfig, TransportHandlers,
-};
+use crate::horizontal_transport::{HorizontalTransport, TransportConfig, TransportHandlers};
 use crate::local_adapter::LocalAdapter;
 use async_trait::async_trait;
 use crossfire::mpsc;
@@ -279,32 +277,15 @@ where
             }
         }
 
-        // Set up inbox for direct replies (eliminates O(N²) response fan-out).
-        let _inbox_guard = match self.transport.new_inbox() {
+        // Use direct reply routing if supported, otherwise fall back to global subject
+        match self.transport.new_inbox() {
             Some(inbox) => {
-                // Subscribe BEFORE publishing to avoid missing early replies
-                let horizontal = self.horizontal.clone();
-                let handler: ResponseHandler = Arc::new(move |response| {
-                    let horizontal = horizontal.clone();
-                    Box::pin(async move {
-                        let _ = horizontal.process_response(response).await;
-                    })
-                });
-
-                let guard = self
-                    .transport
-                    .subscribe_response_inbox(&inbox, handler)
-                    .await?;
-
                 self.transport
                     .publish_request_with_reply(&request, &inbox)
                     .await?;
-
-                guard
             }
             None => {
                 self.transport.publish_request(&request).await?;
-                None
             }
         };
 

--- a/crates/sockudo-adapter/src/horizontal_transport.rs
+++ b/crates/sockudo-adapter/src/horizontal_transport.rs
@@ -8,12 +8,6 @@ use sockudo_core::error::Result;
 use sockudo_core::metrics::MetricsInterface;
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
-pub type ResponseHandler = Arc<dyn Fn(ResponseBody) -> BoxFuture<'static, ()> + Send + Sync>;
-
-/// Guard that keeps an inbox subscription alive. Drop to unsubscribe.
-pub struct InboxGuard {
-    pub(crate) _cancel: tokio::sync::oneshot::Sender<()>,
-}
 
 /// Handlers for transport events
 pub struct TransportHandlers {
@@ -65,16 +59,6 @@ pub trait HorizontalTransport: Send + Sync + Clone {
         _reply_to: &str,
     ) -> Result<()> {
         self.publish_request(request).await
-    }
-
-    /// Subscribe to an inbox and forward responses to the handler.
-    /// Returns a guard — drop it to unsubscribe.
-    async fn subscribe_response_inbox(
-        &self,
-        _inbox: &str,
-        _handler: ResponseHandler,
-    ) -> Result<Option<InboxGuard>> {
-        Ok(None)
     }
 }
 

--- a/crates/sockudo-adapter/src/transports/nats_transport.rs
+++ b/crates/sockudo-adapter/src/transports/nats_transport.rs
@@ -1,7 +1,5 @@
 use crate::horizontal_adapter::{BroadcastMessage, RequestBody, ResponseBody};
-use crate::horizontal_transport::{
-    HorizontalTransport, InboxGuard, ResponseHandler, TransportConfig, TransportHandlers,
-};
+use crate::horizontal_transport::{HorizontalTransport, TransportConfig, TransportHandlers};
 use async_nats::{Client as NatsClient, ConnectOptions as NatsOptions, Subject};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -15,6 +13,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, warn};
+use uuid::Uuid;
 
 const NATS_SYS_SERVER_PING_SUBJECT: &str = "$SYS.REQ.SERVER.PING";
 
@@ -62,6 +61,8 @@ pub struct NatsTransport {
     broadcast_subject: String,
     request_subject: String,
     response_subject: String,
+    /// Shared inbox prefix for direct reply routing
+    inbox_prefix: String,
     config: NatsAdapterConfig,
     /// Metrics for tracking message processing
     metrics: Arc<TransportMetrics>,
@@ -165,7 +166,51 @@ impl HorizontalTransport for NatsTransport {
         );
 
         // Build NATS Options
-        let mut nats_options = NatsOptions::new();
+        let mut nats_options = NatsOptions::new()
+            .retry_on_initial_connect()
+            .event_callback(|event| async move {
+                match event {
+                    async_nats::Event::Connected => {
+                        info!("NATS connection established");
+                    }
+                    async_nats::Event::Disconnected => {
+                        warn!("NATS connection lost");
+                    }
+                    async_nats::Event::SlowConsumer(sid) => {
+                        error!(subscription_id = sid, "NATS slow consumer detected");
+                    }
+                    async_nats::Event::ServerError(err) => {
+                        error!("NATS server error: {}", err);
+                    }
+                    async_nats::Event::ClientError(ref err) => match err {
+                        async_nats::ClientError::MaxReconnects => {
+                            error!("NATS max reconnects exhausted");
+                        }
+                        async_nats::ClientError::Other(msg) => {
+                            error!("NATS client error: {}", msg);
+                        }
+                    },
+                    async_nats::Event::LameDuckMode => {
+                        warn!("NATS server entering lame duck mode");
+                    }
+                    async_nats::Event::Draining => {
+                        info!("NATS client draining");
+                    }
+                    async_nats::Event::Closed => {
+                        warn!("NATS connection closed");
+                    }
+                }
+            });
+
+        if let Some(cap) = config.subscription_capacity {
+            nats_options = nats_options.subscription_capacity(cap);
+        }
+        if let Some(cap) = config.client_capacity {
+            nats_options = nats_options.client_capacity(cap);
+        }
+        if let Some(max) = config.max_reconnects {
+            nats_options = nats_options.max_reconnects(max);
+        }
 
         // Set credentials conditionally
         if let (Some(username), Some(password)) =
@@ -192,11 +237,15 @@ impl HorizontalTransport for NatsTransport {
         let request_subject = format!("{}.requests", config.prefix);
         let response_subject = format!("{}.responses", config.prefix);
 
+        // Build inbox prefix
+        let inbox_prefix = format!("_INBOX.{}.", Uuid::new_v4().as_simple());
+
         Ok(Self {
             client,
             broadcast_subject,
             request_subject,
             response_subject,
+            inbox_prefix,
             config,
             metrics: Arc::new(TransportMetrics::new()),
             metrics_driver: Arc::new(OnceLock::new()),
@@ -263,15 +312,19 @@ impl HorizontalTransport for NatsTransport {
         let metrics_broadcast = self.metrics.clone();
         let metrics_request = self.metrics.clone();
         let metrics_response = self.metrics.clone();
+        let metrics_inbox = self.metrics.clone();
         let metrics_driver_broadcast = self.metrics_driver.clone();
         let metrics_driver_request = self.metrics_driver.clone();
         let metrics_driver_response = self.metrics_driver.clone();
+        let metrics_driver_inbox = self.metrics_driver.clone();
         let shutdown_broadcast = self.shutdown.clone();
         let shutdown_request = self.shutdown.clone();
         let shutdown_response = self.shutdown.clone();
+        let shutdown_inbox = self.shutdown.clone();
         let running_broadcast = self.is_running.clone();
         let running_request = self.is_running.clone();
         let running_response = self.is_running.clone();
+        let running_inbox = self.is_running.clone();
 
         // Subscribe to broadcast channel
         let mut broadcast_subscription = client
@@ -295,9 +348,16 @@ impl HorizontalTransport for NatsTransport {
                 Error::Internal(format!("Failed to subscribe to response subject: {e}"))
             })?;
 
+        // Subscribe to shared inbox wildcard
+        let inbox_subject = format!("{}*", self.inbox_prefix);
+        let mut inbox_subscription = client
+            .subscribe(Subject::from(inbox_subject.clone()))
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to subscribe to inbox subject: {e}")))?;
+
         info!(
-            "NATS transport listening on subjects: {}, {}, {}",
-            broadcast_subject, request_subject, response_subject
+            "NATS transport listening on subjects: {}, {}, {}, {}",
+            broadcast_subject, request_subject, response_subject, inbox_subject
         );
 
         // Spawn a task to handle broadcast messages
@@ -361,7 +421,6 @@ impl HorizontalTransport for NatsTransport {
                 let metrics = metrics_request.clone();
                 let metrics_driver = metrics_driver_request.clone();
                 let client = response_client.clone();
-                let subject = response_subject.clone();
                 tokio::spawn(async move {
                     match sonic_rs::from_slice::<RequestBody>(&msg.payload) {
                         Ok(request) => {
@@ -370,11 +429,12 @@ impl HorizontalTransport for NatsTransport {
                             if let Ok(response) = response_result
                                 && let Ok(response_data) = sonic_rs::to_vec(&response)
                             {
-                                // Reply to requester's inbox if available,
-                                // otherwise fall back to global subject
-                                let target = msg.reply.unwrap_or_else(|| Subject::from(subject));
-
-                                if let Err(e) = client.publish(target, response_data.into()).await {
+                                // Some requests (heartbeats, presence sync) have no reply address
+                                // and expect no response. Only reply when explicitly asked.
+                                if let Some(reply_to) = msg.reply
+                                    && let Err(e) =
+                                        client.publish(reply_to, response_data.into()).await
+                                {
                                     warn!("Failed to publish response: {}", e);
                                 }
                             }
@@ -413,31 +473,63 @@ impl HorizontalTransport for NatsTransport {
                     break;
                 };
                 metrics_response.record_received();
-                let handler = response_handler.clone();
-                let metrics = metrics_response.clone();
-                let metrics_driver = metrics_driver_response.clone();
-                tokio::spawn(async move {
-                    match sonic_rs::from_slice::<ResponseBody>(&msg.payload) {
-                        Ok(response) => {
-                            handler(response).await;
-                            metrics.record_processed();
-                        }
-                        Err(e) => {
-                            metrics.record_parse_error();
-                            if let Some(m) = metrics_driver.get() {
-                                m.mark_horizontal_transport_message_dropped("nats");
-                            }
-                            let payload_preview =
-                                String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
-                            error!(
-                                "Failed to parse response message: {} - payload preview: {}",
-                                e, payload_preview
-                            );
-                        }
+                match sonic_rs::from_slice::<ResponseBody>(&msg.payload) {
+                    Ok(response) => {
+                        response_handler(response).await;
+                        metrics_response.record_processed();
                     }
-                });
+                    Err(e) => {
+                        metrics_response.record_parse_error();
+                        if let Some(m) = metrics_driver_response.get() {
+                            m.mark_horizontal_transport_message_dropped("nats");
+                        }
+                        let payload_preview =
+                            String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
+                        error!(
+                            "Failed to parse response message: {} - payload preview: {}",
+                            e, payload_preview
+                        );
+                    }
+                }
             }
             warn!("Response subscription ended unexpectedly");
+        });
+
+        // Spawn a task to handle inbox responses
+        let inbox_handler = handlers.on_response.clone();
+        tokio::spawn(async move {
+            loop {
+                if !running_inbox.load(Ordering::Relaxed) {
+                    break;
+                }
+                let msg = tokio::select! {
+                    _ = shutdown_inbox.notified() => break,
+                    msg = inbox_subscription.next() => msg,
+                };
+                let Some(msg) = msg else {
+                    break;
+                };
+                metrics_inbox.record_received();
+                match sonic_rs::from_slice::<ResponseBody>(&msg.payload) {
+                    Ok(response) => {
+                        inbox_handler(response).await;
+                        metrics_inbox.record_processed();
+                    }
+                    Err(e) => {
+                        metrics_inbox.record_parse_error();
+                        if let Some(m) = metrics_driver_inbox.get() {
+                            m.mark_horizontal_transport_message_dropped("nats");
+                        }
+                        let payload_preview =
+                            String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
+                        error!(
+                            "Failed to parse inbox response: {} - payload preview: {}",
+                            e, payload_preview
+                        );
+                    }
+                }
+            }
+            warn!("Inbox subscription ended unexpectedly");
         });
 
         Ok(())
@@ -482,7 +574,11 @@ impl HorizontalTransport for NatsTransport {
     }
 
     fn new_inbox(&self) -> Option<String> {
-        Some(self.client.new_inbox())
+        Some(format!(
+            "{}{}",
+            self.inbox_prefix,
+            Uuid::new_v4().as_simple()
+        ))
     }
 
     async fn publish_request_with_reply(
@@ -508,37 +604,6 @@ impl HorizontalTransport for NatsTransport {
         );
         Ok(())
     }
-
-    async fn subscribe_response_inbox(
-        &self,
-        inbox: &str,
-        handler: ResponseHandler,
-    ) -> Result<Option<InboxGuard>> {
-        let mut sub = self
-            .client
-            .subscribe(Subject::from(inbox.to_string()))
-            .await
-            .map_err(|e| Error::Internal(format!("Failed to subscribe to inbox: {e}")))?;
-
-        let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel::<()>();
-
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = &mut cancel_rx => break,
-                    msg = sub.next() => {
-                        let Some(msg) = msg else { break };
-                        if let Ok(response) = sonic_rs::from_slice::<ResponseBody>(&msg.payload) {
-                            handler(response).await;
-                        }
-                    }
-                }
-            }
-        });
-
-        Ok(Some(InboxGuard { _cancel: cancel_tx }))
-    }
 }
 
 impl Drop for NatsTransport {
@@ -546,6 +611,19 @@ impl Drop for NatsTransport {
         if self.owner_count.fetch_sub(1, Ordering::AcqRel) == 1 {
             self.is_running.store(false, Ordering::Relaxed);
             self.shutdown.notify_waiters();
+
+            // Drain flushes pending messages and sends UNSUB before closing.
+            // try_current() avoids panicking if the runtime is already gone.
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                let client = self.client.clone();
+                handle.spawn(async move {
+                    match tokio::time::timeout(Duration::from_secs(5), client.drain()).await {
+                        Ok(Ok(())) => debug!("NATS client drained successfully"),
+                        Ok(Err(e)) => warn!("NATS client drain failed: {}", e),
+                        Err(_) => warn!("NATS client drain timed out"),
+                    }
+                });
+            }
         }
     }
 }
@@ -558,6 +636,7 @@ impl Clone for NatsTransport {
             broadcast_subject: self.broadcast_subject.clone(),
             request_subject: self.request_subject.clone(),
             response_subject: self.response_subject.clone(),
+            inbox_prefix: self.inbox_prefix.clone(),
             config: self.config.clone(),
             metrics: self.metrics.clone(),
             metrics_driver: self.metrics_driver.clone(),

--- a/crates/sockudo-adapter/tests/adapter/horizontal_adapter_integration.rs
+++ b/crates/sockudo-adapter/tests/adapter/horizontal_adapter_integration.rs
@@ -63,6 +63,9 @@ async fn test_horizontal_adapter_with_nats_transport() -> Result<()> {
     let adapter_mut = HorizontalAdapterBase::<NatsTransport>::new(config).await?;
     adapter_mut.init().await;
 
+    // Give time for connections to establish
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
     // Start listeners
     adapter.start_listeners().await?;
 
@@ -458,6 +461,9 @@ async fn test_transport_failure_isolation_redis() -> Result<()> {
 async fn test_transport_failure_isolation_nats() -> Result<()> {
     let config = get_nats_config();
     let adapter = HorizontalAdapterBase::<NatsTransport>::new(config).await?;
+
+    // Give time for connection to establish
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
     // Start listeners
     adapter.start_listeners().await?;

--- a/crates/sockudo-adapter/tests/adapter/nats_adapter_cluster_health_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/nats_adapter_cluster_health_tests.rs
@@ -37,6 +37,7 @@ async fn create_nats_adapter(node_id: &str, cluster_config: &ClusterHealthConfig
         token: env::var("NATS_TOKEN").ok(),
         connection_timeout_ms: 5000,
         nodes_number: Some(1),
+        ..Default::default()
     };
 
     let mut adapter = NatsAdapter::new(config).await.unwrap();

--- a/crates/sockudo-adapter/tests/adapter/transports/nats_inbox_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/nats_inbox_test.rs
@@ -1,5 +1,5 @@
 use sockudo_adapter::horizontal_adapter::ResponseBody;
-use sockudo_adapter::horizontal_transport::{BoxFuture, HorizontalTransport, ResponseHandler};
+use sockudo_adapter::horizontal_transport::HorizontalTransport;
 use sockudo_adapter::transports::NatsTransport;
 use sockudo_core::error::Result;
 use std::sync::Arc;
@@ -7,56 +7,51 @@ use tokio::sync::Mutex;
 
 use super::test_helpers::*;
 
+/// Test that responses arrive via the shared inbox wildcard subscription
+/// when requests use publish_request_with_reply.
 #[tokio::test]
-async fn test_inbox_request_reply_flow() -> Result<()> {
+async fn test_shared_inbox_request_reply_flow() -> Result<()> {
     let config = get_nats_config();
     let transport = NatsTransport::new(config.clone()).await?;
 
-    // Start listeners (responder side)
+    // Collect responses that arrive via the shared inbox and global response
+    // subject. Both use on_response which we capture via the collector.
     let collector = MessageCollector::new();
     let handlers = create_test_handlers(collector.clone());
     transport.start_listeners(handlers).await?;
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    // Set up inbox subscription (requester side)
+    // Publish request with reply-to pointing to the shared inbox prefix
     let inbox = transport.new_inbox().unwrap();
-    let inbox_responses = Arc::new(Mutex::new(Vec::new()));
-    let inbox_responses_clone = inbox_responses.clone();
-    let handler: ResponseHandler = Arc::new(move |response| {
-        let responses = inbox_responses_clone.clone();
-        Box::pin(async move {
-            responses.lock().await.push(response);
-        }) as BoxFuture<'static, ()>
-    });
-    let _guard = transport.subscribe_response_inbox(&inbox, handler).await?;
-
-    // Publish request with reply-to
     let request = create_test_request();
     let request_id = request.request_id.clone();
     transport
         .publish_request_with_reply(&request, &inbox)
         .await?;
 
-    // Response should arrive at the inbox
+    // Response should arrive via the shared inbox subscription
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(500);
     loop {
-        let responses = inbox_responses.lock().await;
-        if !responses.is_empty() {
-            assert_eq!(responses[0].request_id, request_id);
+        if let Some(response) = collector.wait_for_response(50).await {
+            assert_eq!(response.request_id, request_id);
             break;
         }
-        drop(responses);
         if tokio::time::Instant::now() >= deadline {
             panic!("Timed out waiting for inbox response");
         }
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
     }
 
     Ok(())
 }
 
+/// Test that requests without reply_to do NOT generate a response on the
+/// global subject.  Fire-and-forget requests (heartbeats, presence
+/// replication, dead-node notifications) are published without a reply
+/// address and nobody is waiting for their response.  Publishing to the
+/// global response subject in that case fans out to every node, wasting
+/// bandwidth and overwhelming subscriptions under presence-heavy load.
 #[tokio::test]
-async fn test_no_reply_to_falls_back_to_global_subject() -> Result<()> {
+async fn test_no_reply_to_does_not_publish_response() -> Result<()> {
     let config = get_nats_config();
     let transport = NatsTransport::new(config.clone()).await?;
 
@@ -66,64 +61,22 @@ async fn test_no_reply_to_falls_back_to_global_subject() -> Result<()> {
     transport.start_listeners(handlers).await?;
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    // Publish request WITHOUT reply_to (simulates old pod)
+    // Publish request WITHOUT reply_to (fire-and-forget)
     let request = create_test_request();
-    let request_id = request.request_id.clone();
     transport.publish_request(&request).await?;
 
-    // Response should arrive via global subject
+    // No response should arrive on the global subject
     let received = collector.wait_for_response(500).await;
     assert!(
-        received.is_some(),
-        "Response should arrive via global subject when no reply_to"
-    );
-    assert_eq!(received.unwrap().request_id, request_id);
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_inbox_guard_drop_stops_receiving() -> Result<()> {
-    let config = get_nats_config();
-    let transport = NatsTransport::new(config.clone()).await?;
-
-    let inbox = transport.new_inbox().unwrap();
-    let received = Arc::new(Mutex::new(Vec::<ResponseBody>::new()));
-    let received_clone = received.clone();
-    let handler: ResponseHandler = Arc::new(move |response| {
-        let received = received_clone.clone();
-        Box::pin(async move {
-            received.lock().await.push(response);
-        }) as BoxFuture<'static, ()>
-    });
-
-    let guard = transport
-        .subscribe_response_inbox(&inbox, handler)
-        .await?
-        .unwrap();
-
-    // Drop the guard
-    drop(guard);
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
-    // Publish after drop — should not be received
-    let response = create_test_response("should-not-arrive");
-    let response_data = sonic_rs::to_vec(&response).unwrap();
-    transport
-        .client()
-        .publish(async_nats::Subject::from(inbox), response_data.into())
-        .await
-        .map_err(|e| sockudo_core::error::Error::Internal(e.to_string()))?;
-
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-    assert!(
-        received.lock().await.is_empty(),
-        "Should not receive messages after guard dropped"
+        received.is_none(),
+        "Fire-and-forget requests (no reply_to) must not generate responses on the global subject"
     );
 
     Ok(())
 }
 
+/// Test that two transports with separate inbox prefixes receive only their
+/// own responses, not each other's.
 #[tokio::test]
 async fn test_two_transports_inbox_isolation() -> Result<()> {
     let config = get_nats_config();
@@ -141,42 +94,32 @@ async fn test_two_transports_inbox_isolation() -> Result<()> {
         .await?;
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    // Transport A sends a request with inbox
+    // Transport A sends a request with its inbox
     let inbox_a = transport_a.new_inbox().unwrap();
-    let responses_a = Arc::new(Mutex::new(Vec::new()));
-    let responses_a_clone = responses_a.clone();
-    let handler_a: ResponseHandler = Arc::new(move |response| {
-        let responses = responses_a_clone.clone();
-        Box::pin(async move {
-            responses.lock().await.push(response);
-        }) as BoxFuture<'static, ()>
-    });
-    let _guard_a = transport_a
-        .subscribe_response_inbox(&inbox_a, handler_a)
-        .await?;
-
     let request = create_test_request();
     let request_id = request.request_id.clone();
     transport_a
         .publish_request_with_reply(&request, &inbox_a)
         .await?;
 
-    // Wait for responses
+    // Wait for responses on transport A's collector.
+    // Both transport_a and transport_b receive the request and respond to inbox_a.
+    // transport_a's shared inbox subscription receives both responses.
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(1);
+    let responses_a = Arc::new(Mutex::new(Vec::<ResponseBody>::new()));
     loop {
-        let resps = responses_a.lock().await;
-        // Both transport_a and transport_b receive the request and respond to inbox_a.
-        // transport_a's own listener also responds. So we expect 2 responses.
-        if resps.len() >= 2 {
-            assert!(resps.iter().all(|r| r.request_id == request_id));
-            break;
+        if let Some(response) = collector_a.wait_for_response(50).await {
+            let mut resps = responses_a.lock().await;
+            resps.push(response);
+            if resps.len() >= 2 {
+                assert!(resps.iter().all(|r| r.request_id == request_id));
+                break;
+            }
         }
-        drop(resps);
         if tokio::time::Instant::now() >= deadline {
             let count = responses_a.lock().await.len();
             panic!("Timed out: expected 2 inbox responses, got {}", count);
         }
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
     }
 
     Ok(())

--- a/crates/sockudo-adapter/tests/adapter/transports/nats_transport_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/nats_transport_test.rs
@@ -10,6 +10,9 @@ async fn test_nats_transport_new() -> Result<()> {
     let config = get_nats_config();
     let transport = NatsTransport::new(config.clone()).await?;
 
+    // Give time for connection to establish
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
     // Verify the transport was created successfully by checking health
     transport.check_health().await?;
 
@@ -17,7 +20,7 @@ async fn test_nats_transport_new() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_nats_transport_new_with_invalid_url() {
+async fn test_nats_health_fails_when_server_unreachable() {
     // Use localhost with a port that's not listening - should fail quickly
     let config = NatsAdapterConfig {
         servers: vec!["nats://127.0.0.1:19999/".to_string()],
@@ -30,6 +33,7 @@ async fn test_nats_transport_new_with_invalid_url() {
         password: None,
         token: None,
         nodes_number: Some(1),
+        ..Default::default()
     };
 
     // Add a timeout to prevent test from hanging
@@ -39,8 +43,9 @@ async fn test_nats_transport_new_with_invalid_url() {
     )
     .await;
 
-    // Either timeout or connection error is fine
-    assert!(result.is_err() || result.unwrap().is_err());
+    // retry_on_initial_connect means new() succeeds; health check catches it
+    let transport = result.unwrap().unwrap();
+    assert!(transport.check_health().await.is_err());
 }
 
 #[tokio::test]
@@ -182,6 +187,9 @@ async fn test_check_health() -> Result<()> {
     let config = get_nats_config();
     let transport = NatsTransport::new(config).await?;
 
+    // Give time for connection to establish
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
     // Health check should succeed
     transport.check_health().await?;
 
@@ -204,6 +212,7 @@ async fn test_subject_names() -> Result<()> {
         password: None,
         token: None,
         nodes_number: Some(2),
+        ..Default::default()
     };
 
     let transport = NatsTransport::new(config.clone()).await?;
@@ -297,7 +306,10 @@ async fn test_request_response_flow() -> Result<()> {
     assert!(received_request.is_some());
     assert_eq!(received_request.unwrap().request_id, request_id);
 
-    // The handler automatically sends a response (see test_helpers)
+    // Transport2 publishes a response back
+    let response = create_test_response(&request_id);
+    transport2.publish_response(&response).await?;
+
     // Transport1 should receive the response
     let received_response = collector1.wait_for_response(500).await;
     assert!(received_response.is_some());
@@ -323,9 +335,11 @@ async fn test_nats_with_no_credentials() -> Result<()> {
         password: None,
         token: None,
         nodes_number: Some(2),
+        ..Default::default()
     };
 
     let transport = NatsTransport::new(config).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     transport.check_health().await?;
 
     Ok(())
@@ -345,10 +359,12 @@ async fn test_nats_with_username_but_no_password() -> Result<()> {
         password: None, // Missing password
         token: None,
         nodes_number: Some(1),
+        ..Default::default()
     };
 
     // Our code should not set credentials if both username AND password aren't provided
     let transport = NatsTransport::new(config).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     transport.check_health().await?;
 
     Ok(())
@@ -368,10 +384,12 @@ async fn test_nats_with_password_but_no_username() -> Result<()> {
         password: Some("testpass".to_string()),
         token: None,
         nodes_number: Some(1),
+        ..Default::default()
     };
 
     // Our code should not set credentials if both username AND password aren't provided
     let transport = NatsTransport::new(config).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     transport.check_health().await?;
 
     Ok(())
@@ -391,6 +409,7 @@ async fn test_nats_token_takes_precedence_over_username_password() -> Result<()>
         password: Some("pass".to_string()),
         token: Some("fake_token".to_string()), // Token should take precedence
         nodes_number: Some(1),
+        ..Default::default()
     };
 
     // This tests our conditional logic: token is checked first, so username/password are ignored
@@ -419,35 +438,14 @@ async fn test_nats_empty_string_credentials() -> Result<()> {
         password: Some("".to_string()), // Empty string
         token: None,
         nodes_number: Some(1),
+        ..Default::default()
     };
 
     // Our code should still try to set credentials with empty strings
     // This tests that we don't do additional validation beyond Option checking
     let transport = NatsTransport::new(config).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     transport.check_health().await?;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_nats_connection_timeout() -> Result<()> {
-    // Test with very short connection timeout to non-existent server
-    let config = NatsAdapterConfig {
-        servers: vec!["nats://127.0.0.1:19999".to_string()],
-        prefix: "test_timeout".to_string(),
-        request_timeout_ms: 1000,
-        discovery_max_wait_ms: 1000,
-        discovery_idle_wait_ms: 150,
-        connection_timeout_ms: 100, // Very short timeout
-        username: None,
-        password: None,
-        token: None,
-        nodes_number: Some(1),
-    };
-
-    // This should fail quickly due to short connection timeout
-    let result = NatsTransport::new(config).await;
-    assert!(result.is_err());
 
     Ok(())
 }
@@ -466,9 +464,11 @@ async fn test_nats_config_edge_cases() -> Result<()> {
         password: None,
         token: None,
         nodes_number: Some(1),
+        ..Default::default()
     };
 
     let transport = NatsTransport::new(config).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     transport.check_health().await?;
 
     // Test with very short timeouts (but not zero to avoid timeout issues)
@@ -483,10 +483,12 @@ async fn test_nats_config_edge_cases() -> Result<()> {
         password: None,
         token: None,
         nodes_number: Some(1),
+        ..Default::default()
     };
 
     // This should still work - our code doesn't validate timeouts
     let transport = NatsTransport::new(config).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     transport.check_health().await?;
 
     // Test with very large values
@@ -501,9 +503,11 @@ async fn test_nats_config_edge_cases() -> Result<()> {
         password: None,
         token: None,
         nodes_number: Some(0), // Zero nodes
+        ..Default::default()
     };
 
     let transport = NatsTransport::new(config).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     transport.check_health().await?;
 
     Ok(())
@@ -526,10 +530,14 @@ async fn test_nats_invalid_config() {
         password: None,
         token: None,
         nodes_number: Some(1),
+        ..Default::default()
     };
 
-    let result = NatsTransport::new(config).await;
-    assert!(result.is_err(), "Expected error for non-existent server");
+    let transport = NatsTransport::new(config).await.unwrap();
+    assert!(
+        transport.check_health().await.is_err(),
+        "Expected error for non-existent server"
+    );
 
     // Test with malformed server URLs
     let malformed_servers = vec![
@@ -552,6 +560,7 @@ async fn test_nats_invalid_config() {
             password: None,
             token: None,
             nodes_number: Some(1),
+            ..Default::default()
         };
 
         let result = tokio::time::timeout(
@@ -560,11 +569,13 @@ async fn test_nats_invalid_config() {
         )
         .await;
 
-        assert!(
-            result.is_err() || result.unwrap().is_err(),
-            "Expected error for malformed server URL: {}",
-            server
-        );
+        if let Ok(Ok(transport)) = result {
+            assert!(
+                transport.check_health().await.is_err(),
+                "Expected error for malformed server URL: {}",
+                server
+            );
+        }
     }
 }
 

--- a/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
@@ -57,6 +57,7 @@ pub fn get_nats_config() -> NatsAdapterConfig {
         password: None,
         token: None,
         nodes_number: Some(2),
+        ..Default::default()
     }
 }
 

--- a/crates/sockudo-core/src/options.rs
+++ b/crates/sockudo-core/src/options.rs
@@ -541,6 +541,9 @@ pub struct NatsAdapterConfig {
     pub nodes_number: Option<u32>,
     pub discovery_max_wait_ms: u64,
     pub discovery_idle_wait_ms: u64,
+    pub subscription_capacity: Option<usize>,
+    pub client_capacity: Option<usize>,
+    pub max_reconnects: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1898,6 +1901,9 @@ impl Default for NatsAdapterConfig {
             nodes_number: None,
             discovery_max_wait_ms: 1000,
             discovery_idle_wait_ms: 150,
+            subscription_capacity: None,
+            client_capacity: None,
+            max_reconnects: None,
         }
     }
 }
@@ -2809,6 +2815,15 @@ impl ServerOptions {
         );
         if let Some(nodes) = parse_env_optional::<u32>("NATS_NODES_NUMBER") {
             self.adapter.nats.nodes_number = Some(nodes);
+        }
+        if let Some(v) = parse_env_optional::<usize>("NATS_SUBSCRIPTION_CAPACITY") {
+            self.adapter.nats.subscription_capacity = Some(v);
+        }
+        if let Some(v) = parse_env_optional::<usize>("NATS_CLIENT_CAPACITY") {
+            self.adapter.nats.client_capacity = Some(v);
+        }
+        if let Some(v) = parse_env_optional::<usize>("NATS_MAX_RECONNECTS") {
+            self.adapter.nats.max_reconnects = Some(v);
         }
 
         // --- Pulsar Adapter ---


### PR DESCRIPTION
Every `send_request_with_body` call creates a temporary `_INBOX.*` subscription and tears it down after the response. This constant subscribe/unsubscribe churn inflates NATS server routing tables, increases broker memory, and under sustained load triggers slow-consumer disconnects that cascade into pod restarts.

Replace with a single `_INBOX.<uuid>.*` wildcard subscription per transport instance. Responses route through the shared subscription and are dispatched by the existing `on_response` handler.

- Add `inbox_prefix` field on `NatsTransport`, subscribe once in `start_listeners` with a wildcard, remove `subscribe_response_inbox` and `InboxGuard` from the `HorizontalTransport` trait
- Process response and inbox messages inline (no per-message `tokio::spawn`) to avoid tokio budget exhaustion under high message volume, matching other transports
- Skip response publishing when no reply address is set — heartbeats and presence sync are fire-and-forget
- Add `retry_on_initial_connect`, structured `event_callback` logging, configurable `subscription_capacity` / `client_capacity` / `max_reconnects`, and graceful `drain()` on Drop
- Simplify `send_request_with_body` — no more per-request inbox guard

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->