### PR TITLE
fix(server): configurable /up timeout, parallel subsystem checks, and /live endpoint

### DIFF
--- a/crates/sockudo-core/src/error.rs
+++ b/crates/sockudo-core/src/error.rs
@@ -265,9 +265,6 @@ impl From<Error> for sockudo_protocol::messages::ErrorData {
 // Helper functions for error handling
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Health check timeout in milliseconds - centralized constant for all health checks
-pub const HEALTH_CHECK_TIMEOUT_MS: u64 = 400;
-
 // Health check status
 #[derive(Debug, Clone)]
 pub enum HealthStatus {

--- a/crates/sockudo-core/src/options.rs
+++ b/crates/sockudo-core/src/options.rs
@@ -428,6 +428,9 @@ pub struct ServerOptions {
     pub event_name_filtering: EventNameFilteringConfig,
     pub versioned_messages: VersionedMessagesConfig,
     pub annotations: AnnotationsConfig,
+    /// Timeout in milliseconds for each subsystem check in the `/up` health endpoint.
+    /// Applies to adapter, cache, queue, and app manager checks independently.
+    pub health_check_timeout_ms: u64,
 }
 
 // --- Configuration Sub-Structs ---
@@ -1834,6 +1837,7 @@ impl Default for ServerOptions {
             event_name_filtering: EventNameFilteringConfig::default(),
             versioned_messages: VersionedMessagesConfig::default(),
             annotations: AnnotationsConfig::default(),
+            health_check_timeout_ms: 400,
         }
     }
 }
@@ -3245,6 +3249,10 @@ impl ServerOptions {
             "CLUSTER_HEALTH_CLEANUP_INTERVAL",
             self.cluster_health.cleanup_interval_ms,
         );
+
+        // Health check endpoint timeout
+        self.health_check_timeout_ms =
+            parse_env::<u64>("HEALTH_CHECK_TIMEOUT_MS", self.health_check_timeout_ms);
 
         // Tag filtering configuration
         self.tag_filtering.enabled =

--- a/crates/sockudo-rate-limiter/src/middleware.rs
+++ b/crates/sockudo-rate-limiter/src/middleware.rs
@@ -190,7 +190,7 @@ where
                 "websocket_upgrade"
             } else if path.starts_with("/apps/") {
                 "http_api"
-            } else if path.starts_with("/up/") {
+            } else if path.starts_with("/up/") || path == "/live" {
                 "health_check"
             } else {
                 "other"

--- a/crates/sockudo-server/src/http_handler.rs
+++ b/crates/sockudo-server/src/http_handler.rs
@@ -17,7 +17,7 @@ use sockudo_core::annotations::{
     AnnotationSerial, AnnotationType, RawAnnotationReplayRequest,
 };
 use sockudo_core::app::App;
-use sockudo_core::error::{HEALTH_CHECK_TIMEOUT_MS, HealthStatus};
+use sockudo_core::error::HealthStatus;
 use sockudo_core::history::{
     HistoryCursor, HistoryDirection, HistoryPurgeMode, HistoryPurgeRequest, HistoryQueryBounds,
     HistoryReadRequest,
@@ -3386,18 +3386,40 @@ pub async fn terminate_user_connections(
     Ok((StatusCode::OK, Json(response_payload)))
 }
 
-/// System health check function
-async fn check_system_health(handler: &Arc<ConnectionHandler>) -> HealthStatus {
+/// System health check function. Subsystem checks (adapter, cache, webhook
+/// queue) run in parallel under per-check timeouts so a slow subsystem cannot
+/// starve the others.
+async fn check_system_health(
+    handler: &Arc<ConnectionHandler>,
+    timeout_duration: Duration,
+) -> HealthStatus {
+    let cache_enabled =
+        handler.server_options().cache.driver != sockudo_core::options::CacheDriver::None;
+    let webhook_integration = handler.webhook_integration();
+
+    let adapter_fut = timeout(
+        timeout_duration,
+        handler.connection_manager().check_health(),
+    );
+    let cache_fut = async {
+        if !cache_enabled {
+            return None;
+        }
+        Some(timeout(timeout_duration, handler.cache_manager().check_health()).await)
+    };
+    let queue_fut = async {
+        let Some(integration) = webhook_integration else {
+            return None;
+        };
+        Some(timeout(timeout_duration, integration.check_queue_health()).await)
+    };
+
+    let (adapter_check, cache_check, queue_check) = tokio::join!(adapter_fut, cache_fut, queue_fut);
+
     let mut critical_issues = Vec::new();
     let mut non_critical_issues = Vec::new();
 
     // CRITICAL CHECK 1: Adapter health
-    let adapter_check = timeout(
-        Duration::from_millis(HEALTH_CHECK_TIMEOUT_MS),
-        handler.connection_manager().check_health(),
-    )
-    .await;
-
     match adapter_check {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
@@ -3409,13 +3431,7 @@ async fn check_system_health(handler: &Arc<ConnectionHandler>) -> HealthStatus {
     }
 
     // CRITICAL CHECK 2: Cache manager health
-    if handler.server_options().cache.driver != sockudo_core::options::CacheDriver::None {
-        let cache_check = timeout(
-            Duration::from_millis(HEALTH_CHECK_TIMEOUT_MS),
-            handler.cache_manager().check_health(),
-        )
-        .await;
-
+    if let Some(cache_check) = cache_check {
         match cache_check {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
@@ -3428,13 +3444,7 @@ async fn check_system_health(handler: &Arc<ConnectionHandler>) -> HealthStatus {
     }
 
     // NON-CRITICAL CHECK: Queue system health
-    if let Some(webhook_integration) = handler.webhook_integration() {
-        let queue_check = timeout(
-            Duration::from_millis(HEALTH_CHECK_TIMEOUT_MS),
-            webhook_integration.check_queue_health(),
-        )
-        .await;
-
+    if let Some(queue_check) = queue_check {
         match queue_check {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
@@ -3455,29 +3465,35 @@ async fn check_system_health(handler: &Arc<ConnectionHandler>) -> HealthStatus {
     }
 }
 
+/// GET /live
+pub async fn live() -> StatusCode {
+    StatusCode::OK
+}
+
 /// GET /up or /up/{app_id}
 #[instrument(skip(handler), fields(app_id = field::Empty))]
 pub async fn up(
     app_id: Option<Path<String>>,
     State(handler): State<Arc<ConnectionHandler>>,
 ) -> Result<impl IntoResponse, AppError> {
+    let timeout_duration = Duration::from_millis(handler.server_options().health_check_timeout_ms);
+
     let (health_status, app_id_str) = if let Some(Path(app_id)) = app_id {
         tracing::Span::current().record("app_id", &app_id);
         debug!("Health check received for app_id: {}", app_id);
 
-        let app_check = timeout(
-            Duration::from_millis(HEALTH_CHECK_TIMEOUT_MS),
-            handler.app_manager().find_by_id(&app_id),
-        )
-        .await;
+        let app_check = timeout(timeout_duration, handler.app_manager().find_by_id(&app_id)).await;
 
         let app_status = match app_check {
-            Ok(Ok(Some(app))) if app.enabled => check_system_health(&handler).await,
+            Ok(Ok(Some(app))) if app.enabled => {
+                check_system_health(&handler, timeout_duration).await
+            }
             Ok(Ok(Some(_))) => HealthStatus::Error(vec!["App is disabled".to_string()]),
             Ok(Ok(None)) => HealthStatus::NotFound,
             Ok(Err(e)) => HealthStatus::Error(vec![format!("App manager: {e}")]),
             Err(_) => HealthStatus::Error(vec![format!(
-                "App manager timeout (>{HEALTH_CHECK_TIMEOUT_MS}ms)"
+                "App manager timeout (>{}ms)",
+                timeout_duration.as_millis()
             )]),
         };
 
@@ -3485,21 +3501,18 @@ pub async fn up(
     } else {
         debug!("General health check received (no app_id)");
 
-        let apps_check = timeout(
-            Duration::from_millis(HEALTH_CHECK_TIMEOUT_MS),
-            handler.app_manager().get_apps(),
-        )
-        .await;
+        let apps_check = timeout(timeout_duration, handler.app_manager().get_apps()).await;
 
         let app_status = match apps_check {
             Ok(Ok(apps)) if !apps.is_empty() => {
                 debug!("Found {} configured apps", apps.len());
-                check_system_health(&handler).await
+                check_system_health(&handler, timeout_duration).await
             }
             Ok(Ok(_)) => HealthStatus::Error(vec!["No apps configured".to_string()]),
             Ok(Err(e)) => HealthStatus::Error(vec![format!("App manager: {e}")]),
             Err(_) => HealthStatus::Error(vec![format!(
-                "App manager timeout (>{HEALTH_CHECK_TIMEOUT_MS}ms)"
+                "App manager timeout (>{}ms)",
+                timeout_duration.as_millis()
             )]),
         };
 

--- a/crates/sockudo-server/src/main.rs
+++ b/crates/sockudo-server/src/main.rs
@@ -49,8 +49,8 @@ use crate::http_handler::{
     channel_history_reset, channel_history_state, channel_message, channel_message_annotations,
     channel_message_versions, channel_presence_history, channel_presence_history_reset,
     channel_presence_history_snapshot, channel_presence_history_state, channel_users, channels,
-    delete_annotation, delete_message, events, fallback_404, metrics, publish_annotation, stats,
-    terminate_user_connections, up, update_message, usage,
+    delete_annotation, delete_message, events, fallback_404, live, metrics, publish_annotation,
+    stats, terminate_user_connections, up, update_message, usage,
 };
 use crate::presence_history::create_presence_history_store;
 use sockudo_adapter::factory::AdapterFactory;
@@ -1560,6 +1560,7 @@ impl SockudoServer {
             .merge(api_router)
             .route("/up", get(up))
             .route("/up/{appId}", get(up))
+            .route("/live", get(live))
             .layer(DefaultBodyLimit::max(body_limit_bytes))
             .layer(cors);
 


### PR DESCRIPTION
The `/up` endpoint runs adapter, cache, queue, and app-manager checks under a fixed 400ms-per-check budget compiled into the binary, and the checks run sequentially so a slow subsystem accumulates latency across the entire response. A single 400ms threshold is also too aggressive for some deployments and too forgiving for others, with no way to tune it without a rebuild.

Make the per-check timeout runtime-configurable, run the subsystem checks in parallel so total wall-clock approaches max(check) rather than sum(check), and expose a dependency-free `/live` endpoint that operators can target with kubelet livenessProbe instead of `/up`.

- Replace `HEALTH_CHECK_TIMEOUT_MS` const with `ServerOptions.health_check_timeout_ms` (default 400, env override `HEALTH_CHECK_TIMEOUT_MS`)
- Run adapter, cache, and webhook-queue checks via `tokio::join!` under per-check timeouts in `check_system_health`; per-subsystem error strings preserved exactly (`Adapter health check timeout`, `Cache health check timeout`, etc.) so operators keep the diagnostic fingerprint
- Add `live` handler returning `StatusCode::OK`; route at `/live` and classify alongside `/up/` in the rate-limiter middleware request context

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->