### PR TITLE
fix(websocket): send error message before closing status transition

### DIFF
--- a/crates/sockudo-core/src/websocket.rs
+++ b/crates/sockudo-core/src/websocket.rs
@@ -919,8 +919,7 @@ impl WebSocket {
             _ => {}
         }
 
-        self.state.status = ConnectionStatus::Closing;
-
+        // Send error message while connection still active
         if code >= 4000 {
             let error_message = PusherMessage::error(code, reason.clone(), None);
             if let Err(e) = self.send_message(&error_message) {
@@ -928,6 +927,7 @@ impl WebSocket {
             }
         }
 
+        self.state.status = ConnectionStatus::Closing;
         self.message_sender.send_close(code, &reason)?;
         self.state.clear_timeouts();
         self.state.status = ConnectionStatus::Closed;
@@ -1629,5 +1629,88 @@ mod tests {
         let config = WebSocketBufferConfig::new(500, false);
         assert_eq!(config.channel_capacity(), 500);
         assert!(!config.disconnect_on_full);
+    }
+
+    use futures_util::StreamExt;
+
+    type ClientWs = sockudo_ws::WebSocketStream<sockudo_ws::Stream<sockudo_ws::Http1>>;
+
+    async fn create_server_writer_with_client() -> (WebSocketWriter, ClientWs) {
+        use sockudo_ws::Config as WsConfig;
+        use sockudo_ws::Http1;
+        use sockudo_ws::axum_integration::WebSocket;
+        use sockudo_ws::client::WebSocketClient;
+        use tokio::net::{TcpListener, TcpStream};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+
+        let server_task: tokio::task::JoinHandle<WebSocketWriter> = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = sockudo_ws::handshake::server_handshake(&mut stream)
+                .await
+                .unwrap();
+            let ws = WebSocket::from_tcp(stream, WsConfig::default());
+            let (_reader, writer) = ws.split();
+            writer
+        });
+
+        let client_stream = TcpStream::connect(local_addr).await.unwrap();
+        let client = WebSocketClient::<Http1>::new(WsConfig::default());
+        let (client_ws, _): (ClientWs, _) = client
+            .connect(client_stream, &local_addr.to_string(), "/", None)
+            .await
+            .unwrap();
+
+        let writer = server_task.await.unwrap();
+        (writer, client_ws)
+    }
+
+    #[tokio::test]
+    async fn close_with_error_code_sends_error_then_close_frame() {
+        use sockudo_ws::Message;
+
+        let socket_id = SocketId::new();
+        let (writer, mut client) = create_server_writer_with_client().await;
+        let mut ws = WebSocket::new(socket_id, writer);
+
+        assert!(ws.is_connected());
+        let result = ws.close(4200, "Server shutting down".to_string()).await;
+        assert!(result.is_ok(), "close() should succeed: {result:?}");
+        assert_eq!(ws.state.status, ConnectionStatus::Closed);
+
+        // Give the background writer task time to flush both frames.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // First frame received by the client must be the text error message.
+        let first = tokio::time::timeout(std::time::Duration::from_secs(1), client.next())
+            .await
+            .expect("timed out waiting for first frame")
+            .expect("client stream ended unexpectedly")
+            .expect("frame read error");
+
+        assert!(
+            matches!(first, Message::Text(_)),
+            "expected text error frame first, got: {first:?}"
+        );
+        if let Message::Text(payload) = &first {
+            let text = std::str::from_utf8(payload).expect("error frame is not UTF-8");
+            assert!(
+                text.contains("4200"),
+                "error frame should contain code 4200, got: {text}"
+            );
+        }
+
+        // Second frame must be the close frame.
+        let second = tokio::time::timeout(std::time::Duration::from_secs(1), client.next())
+            .await
+            .expect("timed out waiting for close frame")
+            .expect("client stream ended unexpectedly")
+            .expect("frame read error");
+
+        assert!(
+            matches!(second, Message::Close(_)),
+            "expected close frame second, got: {second:?}"
+        );
     }
 }


### PR DESCRIPTION
`WebSocket::close()` was setting status to Closing before calling `send_message()`, but `ensure_can_send()` rejects anything that isn't Active or PingSent. This caused every close with code >= 4000 (shutdown=4200, pong-timeout=4201, app-disconnect=4009) to silently fail to deliver the error message, producing a lot of warnings on rollout.

Fix: move the error-message send before the status transition so `ensure_can_send()` passes while the connection is still Active.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->