### PR TITLE
fix: add graceful node departure announcement and use proper node count

### DIFF
--- a/crates/sockudo-adapter/src/connection_manager.rs
+++ b/crates/sockudo-adapter/src/connection_manager.rs
@@ -208,4 +208,10 @@ pub trait ConnectionManager: Send + Sync {
     fn configure_dead_node_events(&self) -> Option<DeadNodeEventBusReceiver> {
         None // Default: no clustering support
     }
+
+    /// Tell cluster peers this node is leaving so they prune
+    /// heartbeat tracking without waiting for the timeout window
+    async fn announce_node_departure(&self) -> Result<()> {
+        Ok(())
+    }
 }

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -235,7 +235,14 @@ where
         let discovered_node_count = self.horizontal.get_effective_node_count().await;
         let node_count = if should_skip_horizontal {
             1
+        } else if self.transport.node_count_is_real_time() {
+            // Transport supports accurate node counting, use it directly
+            self.transport.get_node_count().await?
+        } else if self.cluster_health_enabled && discovered_node_count > 1 {
+            // Cluster health heartbeats are tracking peers
+            discovered_node_count
         } else {
+            // Fallback to transport hint
             std::cmp::max(
                 discovered_node_count,
                 self.transport.get_node_count().await?,
@@ -1603,6 +1610,44 @@ where
 
     async fn check_health(&self) -> Result<()> {
         self.transport.check_health().await
+    }
+
+    async fn announce_node_departure(&self) -> Result<()> {
+        let request = RequestBody {
+            request_id: generate_request_id(),
+            node_id: self.node_id.clone(),
+            app_id: "cluster".to_string(),
+            request_type: RequestType::NodeDead,
+            channel: None,
+            socket_id: None,
+            user_id: None,
+            user_info: None,
+            timestamp: Some(current_timestamp()),
+            dead_node_id: Some(self.node_id.clone()),
+            target_node_id: None,
+            channels: None,
+        };
+
+        match tokio::time::timeout(
+            Duration::from_secs(2),
+            self.transport.publish_request(&request),
+        )
+        .await
+        {
+            Ok(Ok(())) => {
+                info!("Announced node departure to cluster peers");
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                Ok(())
+            }
+            Ok(Err(e)) => {
+                warn!("Failed to announce node departure: {}", e);
+                Ok(())
+            }
+            Err(_) => {
+                warn!("Node departure announcement timed out");
+                Ok(())
+            }
+        }
     }
 
     fn get_node_id(&self) -> String {

--- a/crates/sockudo-adapter/src/horizontal_transport.rs
+++ b/crates/sockudo-adapter/src/horizontal_transport.rs
@@ -40,6 +40,11 @@ pub trait HorizontalTransport: Send + Sync + Clone {
     /// Get the current number of nodes in the cluster
     async fn get_node_count(&self) -> Result<usize>;
 
+    /// Whether real-time nodes counting is reliable or not
+    fn node_count_is_real_time(&self) -> bool {
+        false
+    }
+
     /// Check transport health
     async fn check_health(&self) -> Result<()>;
 

--- a/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
+++ b/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
@@ -550,6 +550,10 @@ impl HorizontalTransport for RedisClusterTransport {
         }
     }
 
+    fn node_count_is_real_time(&self) -> bool {
+        true
+    }
+
     async fn check_health(&self) -> Result<()> {
         // Use dedicated health check connection to avoid contention with publish operations
         // Under high load (10K+ msg/s), sharing the publish connection causes timeouts

--- a/crates/sockudo-adapter/src/transports/redis_transport.rs
+++ b/crates/sockudo-adapter/src/transports/redis_transport.rs
@@ -377,6 +377,10 @@ impl HorizontalTransport for RedisTransport {
         }
     }
 
+    fn node_count_is_real_time(&self) -> bool {
+        true
+    }
+
     async fn check_health(&self) -> Result<()> {
         // Use a dedicated connection for health check to avoid impacting main operations
         let mut conn = self

--- a/crates/sockudo-adapter/tests/adapter/graceful_departure_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/graceful_departure_tests.rs
@@ -1,0 +1,110 @@
+use crate::adapter::horizontal_adapter_helpers::{MockConfig, MockNodeState, MockTransport};
+use sockudo_adapter::connection_manager::ConnectionManager;
+use sockudo_adapter::horizontal_adapter::{
+    RequestBody, RequestType, current_timestamp, generate_request_id,
+};
+use sockudo_adapter::horizontal_adapter_base::HorizontalAdapterBase;
+use sockudo_adapter::horizontal_transport::HorizontalTransport;
+
+#[tokio::test]
+async fn test_announce_node_departure_publishes_node_dead() {
+    let config = MockConfig {
+        node_states: vec![MockNodeState::new("single-node")],
+        ..Default::default()
+    };
+
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config)
+        .await
+        .unwrap();
+
+    let own_node_id = adapter.get_node_id();
+
+    adapter.announce_node_departure().await.unwrap();
+
+    let published = adapter.transport.get_published_requests().await;
+    let node_dead: Vec<_> = published
+        .iter()
+        .filter(|r| r.request_type == RequestType::NodeDead)
+        .collect();
+
+    assert_eq!(node_dead.len(), 1);
+    assert_eq!(
+        node_dead[0].dead_node_id.as_deref(),
+        Some(own_node_id.as_str())
+    );
+    assert_eq!(node_dead[0].node_id, own_node_id);
+    assert_eq!(node_dead[0].app_id, "cluster");
+}
+
+#[tokio::test]
+async fn test_receiving_node_dead_prunes_peer_heartbeat() {
+    let config = MockConfig {
+        node_states: vec![MockNodeState::new("single-node")],
+        ..Default::default()
+    };
+
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config)
+        .await
+        .unwrap();
+
+    adapter
+        .horizontal
+        .add_discovered_node_for_test("peer-node".to_string())
+        .await;
+
+    assert_eq!(adapter.horizontal.get_effective_node_count().await, 2);
+
+    let departure_request = RequestBody {
+        request_id: generate_request_id(),
+        node_id: "peer-node".to_string(),
+        app_id: "cluster".to_string(),
+        request_type: RequestType::NodeDead,
+        channel: None,
+        socket_id: None,
+        user_id: None,
+        user_info: None,
+        timestamp: Some(current_timestamp()),
+        dead_node_id: Some("peer-node".to_string()),
+        target_node_id: None,
+        channels: None,
+    };
+
+    adapter
+        .horizontal
+        .process_request(departure_request)
+        .await
+        .expect("processing NodeDead must succeed");
+
+    assert_eq!(adapter.horizontal.get_effective_node_count().await, 1);
+}
+
+#[tokio::test]
+async fn test_announce_node_departure_ok_when_transport_unhealthy() {
+    let config = MockConfig {
+        node_states: vec![MockNodeState::new("single-node")],
+        ..Default::default()
+    };
+
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config)
+        .await
+        .unwrap();
+
+    adapter.transport.set_health_status(false).await;
+
+    let result = adapter.announce_node_departure().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_mock_transport_node_count_is_not_real_time() {
+    let config = MockConfig {
+        node_states: vec![MockNodeState::new("single-node")],
+        ..Default::default()
+    };
+
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config)
+        .await
+        .unwrap();
+
+    assert!(!adapter.transport.node_count_is_real_time());
+}

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -51,3 +51,6 @@ mod local_adapter_fallback_tests;
 
 #[cfg(test)]
 mod single_node_optimization_tests;
+
+#[cfg(test)]
+mod graceful_departure_tests;

--- a/crates/sockudo-server/src/main.rs
+++ b/crates/sockudo-server/src/main.rs
@@ -1881,6 +1881,16 @@ impl SockudoServer {
         info!("Stopping server...");
         self.state.running.store(false, Ordering::SeqCst);
 
+        // Tell cluster peers this node is leaving and no responses are expected
+        if let Err(e) = self
+            .state
+            .connection_manager
+            .announce_node_departure()
+            .await
+        {
+            warn!("Failed to announce node departure: {}", e);
+        }
+
         let mut connections_to_cleanup: Vec<(String, WebSocketRef)> = Vec::new();
 
         {


### PR DESCRIPTION
During rolling deployments, discovered_node_count (heartbeat-based) stays stale for up to node_timeout_ms (~30s) after a pod terminates, causing requests to wait for responses from dead nodes until timeout.

Two fixes:

- On graceful shutdown (SIGTERM), broadcast NodeDead with dead_node_id set to our own node ID. Peers receive it and immediately prune their node_heartbeats map via the existing handler, so get_effective_node_count() drops without waiting for the timeout window. The existing dead-node detection loop handles presence cleanup on its next tick as usual.

- Add node_count_is_real_time() to HorizontalTransport. Redis and Redis Cluster override it to true (PUBSUB NUMSUB is a single round-trip and reflects disconnections within TCP timeout). When true, the adapter uses the transport count directly on the request hot-path instead of the stale heartbeat count, which helps for hard kills where no departure message is sent. NATS and static-config transports keep the default false.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->