### PR TITLE
perf(presence): eliminate cross-cluster query on presence subscribe

### DIFF
--- a/crates/sockudo-adapter/src/connection_manager.rs
+++ b/crates/sockudo-adapter/src/connection_manager.rs
@@ -114,6 +114,15 @@ pub trait ConnectionManager: Send + Sync {
         app_id: &str,
         channel: &str,
     ) -> Result<HashMap<String, PresenceMemberInfo>>;
+
+    async fn get_local_channel_members(
+        &self,
+        app_id: &str,
+        channel: &str,
+    ) -> Result<HashMap<String, PresenceMemberInfo>> {
+        self.get_channel_members(app_id, channel).await
+    }
+
     async fn get_channel_sockets(&self, app_id: &str, channel: &str) -> Result<Vec<SocketId>>;
     async fn remove_channel(&self, app_id: &str, channel: &str);
     async fn is_in_channel(

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -671,7 +671,7 @@ impl ConnectionHandler {
             // Get current members and send presence data to new member
             let mut members_map = self
                 .connection_manager
-                .get_channel_members(&app_config.id, &request.channel)
+                .get_local_channel_members(&app_config.id, &request.channel)
                 .await?;
 
             // Ensure the subscribing member is included even if

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -1267,6 +1267,41 @@ where
         Ok(members)
     }
 
+    async fn get_local_channel_members(
+        &self,
+        app_id: &str,
+        channel: &str,
+    ) -> Result<HashMap<String, PresenceMemberInfo>> {
+        let mut members = self
+            .local_adapter
+            .get_channel_members(app_id, channel)
+            .await?;
+
+        {
+            let registry = self.horizontal.cluster_presence_registry.read().await;
+            for (node_id, node_data) in registry.iter() {
+                if node_id == &self.node_id {
+                    continue;
+                }
+                if let Some(channel_sockets) = node_data.get(channel) {
+                    for entry in channel_sockets.values() {
+                        if entry.app_id != app_id {
+                            continue;
+                        }
+                        members.entry(entry.user_id.clone()).or_insert_with(|| {
+                            PresenceMemberInfo {
+                                user_id: entry.user_id.clone(),
+                                user_info: entry.user_info.clone(),
+                            }
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(members)
+    }
+
     async fn get_channel_sockets(&self, app_id: &str, channel: &str) -> Result<Vec<SocketId>> {
         // Get local sockets
         let mut all_socket_ids = self

--- a/crates/sockudo-adapter/tests/adapter/local_channel_members_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/local_channel_members_tests.rs
@@ -1,0 +1,166 @@
+use crate::adapter::horizontal_adapter_helpers::{MockConfig, MockTransport};
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::horizontal_adapter_base::HorizontalAdapterBase;
+use sonic_rs::json;
+
+#[tokio::test]
+async fn test_local_members_merges_local_and_remote() {
+    let config = MockConfig::default();
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config)
+        .await
+        .unwrap();
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "node-2",
+            "presence-chat",
+            "socket-a",
+            "user-local",
+            "app-1",
+            Some(json!({"name": "Alice"})),
+        )
+        .await;
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "node-3",
+            "presence-chat",
+            "socket-b",
+            "user-remote",
+            "app-1",
+            Some(json!({"name": "Bob"})),
+        )
+        .await;
+
+    let result = adapter
+        .get_local_channel_members("app-1", "presence-chat")
+        .await
+        .unwrap();
+
+    assert!(
+        result.contains_key("user-local"),
+        "user-local (node-2) should be in merged result"
+    );
+    assert!(
+        result.contains_key("user-remote"),
+        "user-remote (node-3) should be in merged result"
+    );
+
+    let requests = adapter.transport.get_published_requests().await;
+    assert!(
+        requests.is_empty(),
+        "get_local_channel_members must issue zero NATS requests, got: {:?}",
+        requests.len()
+    );
+}
+
+#[tokio::test]
+async fn test_local_members_filters_app_and_excludes_self_node() {
+    let config = MockConfig::default();
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config)
+        .await
+        .unwrap();
+    let self_node = adapter.node_id.clone();
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            &self_node,
+            "presence-chat",
+            "socket-self",
+            "user-self",
+            "app-1",
+            None,
+        )
+        .await;
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "node-2",
+            "presence-chat",
+            "socket-a1",
+            "user-app1",
+            "app-1",
+            None,
+        )
+        .await;
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "node-2",
+            "presence-chat",
+            "socket-a2",
+            "user-app2",
+            "app-2",
+            None,
+        )
+        .await;
+
+    let result = adapter
+        .get_local_channel_members("app-1", "presence-chat")
+        .await
+        .unwrap();
+
+    assert!(
+        result.contains_key("user-app1"),
+        "user-app1 from remote node under app-1 must be included"
+    );
+    assert!(
+        !result.contains_key("user-self"),
+        "user-self registered under own node_id must be excluded"
+    );
+    assert!(
+        !result.contains_key("user-app2"),
+        "user-app2 from app-2 must be excluded when querying app-1"
+    );
+}
+
+#[tokio::test]
+async fn test_local_members_deduplicates_multi_socket_user() {
+    let config = MockConfig::default();
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config)
+        .await
+        .unwrap();
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "node-2",
+            "presence-chat",
+            "socket-a",
+            "user-1",
+            "app-1",
+            Some(json!({"name": "Eve", "socket": "a"})),
+        )
+        .await;
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "node-3",
+            "presence-chat",
+            "socket-b",
+            "user-1",
+            "app-1",
+            Some(json!({"name": "Eve", "socket": "b"})),
+        )
+        .await;
+
+    let result = adapter
+        .get_local_channel_members("app-1", "presence-chat")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.len(),
+        1,
+        "user-1 must appear exactly once regardless of socket count; got {} entries",
+        result.len()
+    );
+    assert!(
+        result.contains_key("user-1"),
+        "deduplicated result must contain user-1"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -54,3 +54,6 @@ mod single_node_optimization_tests;
 
 #[cfg(test)]
 mod graceful_departure_tests;
+
+#[cfg(test)]
+mod local_channel_members_tests;


### PR DESCRIPTION
When a client subscribes to a presence channel, the adapter was firing a send_request(ChannelMembers) to every peer node and waiting for N-1 responses just to build the initial member list for subscription_succeeded.

Replace with a local read: combine local_adapter.get_channel_members() with a direct scan of cluster_presence_registry (already kept in sync by PresenceMemberJoined broadcasts from all nodes). Zero network round trips, same data.

All other callers of get_channel_members (HTTP API, channel unsubscribe, member count) are unchanged and continue querying the cluster for full accuracy.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->