### PR TITLE
perf(presence): skip remote query when user has local connections

### DIFF
--- a/crates/sockudo-adapter/src/connection_manager.rs
+++ b/crates/sockudo-adapter/src/connection_manager.rs
@@ -175,6 +175,21 @@ pub trait ConnectionManager: Send + Sync {
         channel: &str,
         excluding_socket: Option<&SocketId>,
     ) -> Result<usize>;
+
+    /// Returns true if the user has any connections in the channel (excluding one socket).
+    async fn user_has_connections_in_channel(
+        &self,
+        user_id: &str,
+        app_id: &str,
+        channel: &str,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<bool> {
+        Ok(self
+            .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
+            .await?
+            > 0)
+    }
+
     async fn get_channels_with_socket_count(&self, app_id: &str) -> Result<HashMap<String, usize>>;
 
     async fn get_sockets_count(&self, app_id: &str) -> Result<usize>;

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -1582,6 +1582,40 @@ where
         }
     }
 
+    async fn user_has_connections_in_channel(
+        &self,
+        user_id: &str,
+        app_id: &str,
+        channel: &str,
+        excluding_socket: Option<&SocketId>,
+    ) -> Result<bool> {
+        let local_count = self
+            .local_adapter
+            .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
+            .await?;
+
+        if local_count > 0 {
+            return Ok(true);
+        }
+
+        match self
+            .send_request(
+                app_id,
+                RequestType::CountUserConnectionsInChannel,
+                Some(channel),
+                None,
+                Some(user_id),
+            )
+            .await
+        {
+            Ok(response) => Ok(response.sockets_count > 0),
+            Err(e) => {
+                error!("Failed to get remote user connections count: {}", e);
+                Ok(false)
+            }
+        }
+    }
+
     async fn get_channels_with_socket_count(&self, app_id: &str) -> Result<HashMap<String, usize>> {
         // Get local channels
         let mut channels = self

--- a/crates/sockudo-adapter/src/presence.rs
+++ b/crates/sockudo-adapter/src/presence.rs
@@ -487,14 +487,9 @@ impl PresenceManager {
         user_id: &str,
         excluding_socket: Option<&SocketId>,
     ) -> Result<bool> {
-        // Use cluster-wide connection check for multi-node support
-        let subscribed_count = connection_manager
-            .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
-            .await?;
-
-        let has_other_connections = subscribed_count > 0;
-
-        Ok(has_other_connections)
+        connection_manager
+            .user_has_connections_in_channel(user_id, app_id, channel, excluding_socket)
+            .await
     }
 
     /// Broadcast a message to all clients in a channel, optionally excluding one socket

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -57,3 +57,6 @@ mod graceful_departure_tests;
 
 #[cfg(test)]
 mod local_channel_members_tests;
+
+#[cfg(test)]
+mod user_has_connections_tests;

--- a/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
@@ -1,0 +1,132 @@
+use crate::adapter::horizontal_adapter_helpers::MockConfig;
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::horizontal_adapter::RequestType;
+use sockudo_core::error::Result;
+use sockudo_core::namespace::Namespace;
+use sockudo_core::websocket::{SocketId, WebSocket, WebSocketRef};
+use sockudo_ws::axum_integration;
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, WebSocketStream};
+use std::sync::Arc;
+use tokio::net::{TcpListener, TcpStream};
+
+async fn create_test_writer() -> axum_integration::WebSocketWriter {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let _ = sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+        .connect(client_stream, &addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    server.await.unwrap()
+}
+
+async fn seed_local_user_connection(
+    adapter: &sockudo_adapter::horizontal_adapter_base::HorizontalAdapterBase<
+        crate::adapter::horizontal_adapter_helpers::MockTransport,
+    >,
+    app_id: &str,
+    channel: &str,
+    user_id: &str,
+    socket_id: SocketId,
+) {
+    let writer = create_test_writer().await;
+    let mut ws = WebSocket::new(socket_id, writer);
+    ws.subscribe_to_channel(channel.to_string());
+    ws.state.user_id = Some(user_id.to_string());
+
+    let ws_ref = WebSocketRef::new(ws);
+
+    let namespace = adapter
+        .local_adapter
+        .namespaces
+        .entry(app_id.to_string())
+        .or_insert_with(|| Arc::new(Namespace::new(app_id.to_string())))
+        .clone();
+
+    namespace
+        .users
+        .entry(user_id.to_string())
+        .or_default()
+        .insert(ws_ref);
+}
+
+/// Test that local connections short-circuit without a cross-cluster request
+#[tokio::test]
+async fn test_user_has_connections_returns_true_from_local_without_remote_request() -> Result<()> {
+    let adapter = MockConfig::create_multi_node_adapter().await?;
+
+    let socket_id = SocketId::from_string("local-socket-1").unwrap();
+    seed_local_user_connection(&adapter, "app-1", "presence-chat", "local-user", socket_id).await;
+
+    let result = adapter
+        .user_has_connections_in_channel("local-user", "app-1", "presence-chat", None)
+        .await?;
+
+    assert!(result, "should be true when user has a local connection");
+
+    let requests = adapter.transport.get_published_requests().await;
+    let remote_count_requests: Vec<_> = requests
+        .iter()
+        .filter(|r| r.request_type == RequestType::CountUserConnectionsInChannel)
+        .collect();
+    assert!(
+        remote_count_requests.is_empty(),
+        "expected zero remote requests when local count > 0, got {}",
+        remote_count_requests.len()
+    );
+
+    Ok(())
+}
+
+/// Test that absent local connections trigger a cross-cluster request
+#[tokio::test]
+async fn test_user_has_connections_falls_back_to_remote_when_no_local_connections() -> Result<()> {
+    let adapter = MockConfig::create_multi_node_adapter().await?;
+
+    let result = adapter
+        .user_has_connections_in_channel("absent-user", "app-1", "presence-chat", None)
+        .await?;
+
+    assert!(
+        !result,
+        "should be false when neither local nor remote nodes have the user"
+    );
+
+    let requests = adapter.transport.get_published_requests().await;
+    let count_requests: Vec<_> = requests
+        .iter()
+        .filter(|r| r.request_type == RequestType::CountUserConnectionsInChannel)
+        .collect();
+
+    assert_eq!(
+        count_requests.len(),
+        1,
+        "exactly one remote request expected"
+    );
+    assert_eq!(
+        count_requests[0].user_id,
+        Some("absent-user".to_string()),
+        "request must carry the queried user_id"
+    );
+    assert_eq!(
+        count_requests[0].channel,
+        Some("presence-chat".to_string()),
+        "request must carry the queried channel"
+    );
+
+    Ok(())
+}

--- a/crates/sockudo-queue/tests/iggy_queue_live_test.rs
+++ b/crates/sockudo-queue/tests/iggy_queue_live_test.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "iggy")]
+
 use sockudo_core::options::IggyConfig;
 use sockudo_core::queue::QueueInterface;
 use sockudo_core::webhook_types::{JobData, JobPayload};


### PR DESCRIPTION
Add `user_has_connections_in_channel` to `ConnectionManager` trait. `HorizontalAdapterBase` overrides it to check local count first — if > 0, return true without firing a cross-cluster query. `presence.rs` calls the new method instead of `count_user_connections_in_channel`.

The general-purpose count function is untouched. When local count is 0, the full query still fires — webhook correctness unaffected.

Eliminates cross-cluster queries for users with multiple connections on the same node (multi-tab, multi-device).

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->