### PR TITLE
feat(adapter): add per-node NATS delivery and opt-in chunked presence sync

### DIFF
--- a/crates/sockudo-adapter/src/factory.rs
+++ b/crates/sockudo-adapter/src/factory.rs
@@ -339,6 +339,7 @@ impl AdapterFactory {
                     subscription_capacity: config.nats.subscription_capacity,
                     client_capacity: config.nats.client_capacity,
                     max_reconnects: config.nats.max_reconnects,
+                    presence_sync_chunk_size: config.nats.presence_sync_chunk_size,
                 };
                 match NatsAdapter::new(nats_cfg).await {
                     Ok(mut adapter) => {

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -1,6 +1,7 @@
 use ahash::AHashMap as HashMap;
 use std::any::Any;
 use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -29,6 +30,9 @@ use sockudo_ws::axum_integration::WebSocketWriter;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
+
+/// Maximum hash-based spread (ms) when staggering presence-state sync on new-node detection
+const PRESENCE_SYNC_STAGGER_MAX_MS: u64 = 5_000;
 
 /// Generic base adapter that handles all common horizontal scaling logic
 pub struct HorizontalAdapterBase<T: HorizontalTransport> {
@@ -517,6 +521,7 @@ where
             .load(std::sync::atomic::Ordering::Relaxed);
 
         let handlers = TransportHandlers {
+            node_id: self.node_id.clone(),
             on_broadcast: Arc::new(move |broadcast| {
                 let horizontal_clone = broadcast_horizontal.clone();
                 let cache_manager_clone = broadcast_cache_manager.clone();
@@ -727,20 +732,23 @@ where
                         let new_node_id = request.node_id.clone();
                         let horizontal_clone_for_task = horizontal_clone.clone();
                         let transport_for_task = transport_clone.clone();
+                        let node_id = horizontal_clone.node_id.clone();
 
                         tokio::spawn(async move {
-                            // Small delay to let the new node finish initialization
-                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            let mut hasher = std::hash::DefaultHasher::new();
+                            node_id.hash(&mut hasher);
+                            let stagger_ms = hasher.finish() % PRESENCE_SYNC_STAGGER_MAX_MS;
+                            tokio::time::sleep(Duration::from_millis(100 + stagger_ms)).await;
 
-                            if let Err(e) = send_presence_state_to_node(
-                                &horizontal_clone_for_task,
-                                &transport_for_task,
-                                &new_node_id,
-                            )
-                            .await
+                            if let Err(e) = transport_for_task
+                                .sync_presence_state_to_node(
+                                    &horizontal_clone_for_task,
+                                    &new_node_id,
+                                )
+                                .await
                             {
                                 error!(
-                                    "Failed to send presence state to new node {}: {}",
+                                    "Failed to sync presence state to new node {}: {}",
                                     new_node_id, e
                                 );
                             }
@@ -1827,57 +1835,4 @@ impl<T: HorizontalTransport> HorizontalAdapterInterface for HorizontalAdapterBas
             Ok(())
         }
     }
-}
-
-/// Helper function to send presence state to a new node
-async fn send_presence_state_to_node<T: HorizontalTransport>(
-    horizontal: &Arc<HorizontalAdapter>,
-    transport: &T,
-    target_node_id: &str,
-) -> Result<()> {
-    // Get our presence data
-    let (our_node_id, data_to_send) = {
-        let registry = horizontal.cluster_presence_registry.read().await;
-
-        // Get only our node's data
-        if let Some(our_presence_data) = registry.get(&horizontal.node_id) {
-            // Clone the data to avoid holding the lock
-            (horizontal.node_id.clone(), Some(our_presence_data.clone()))
-        } else {
-            (horizontal.node_id.clone(), None)
-        }
-    };
-
-    if let Some(data_to_send) = data_to_send {
-        // Serialize the presence data
-        let serialized_data = sonic_rs::to_value(&data_to_send)?;
-
-        let sync_request = RequestBody {
-            request_id: generate_request_id(),
-            node_id: our_node_id,
-            app_id: "cluster".to_string(),
-            request_type: RequestType::PresenceStateSync,
-            target_node_id: Some(target_node_id.to_string()),
-            user_info: Some(serialized_data), // Reuse this field for bulk data
-            channel: None,
-            socket_id: None,
-            user_id: None,
-            timestamp: None,
-            dead_node_id: None,
-            channels: None,
-        };
-
-        // This broadcasts but only target_node will process it
-        transport.publish_request(&sync_request).await?;
-
-        info!(
-            "Sent presence state to new node: {} ({} channels)",
-            target_node_id,
-            data_to_send.len()
-        );
-    } else {
-        debug!("No presence data to send to new node: {}", target_node_id);
-    }
-
-    Ok(())
 }

--- a/crates/sockudo-adapter/src/horizontal_transport.rs
+++ b/crates/sockudo-adapter/src/horizontal_transport.rs
@@ -2,7 +2,10 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::horizontal_adapter::{BroadcastMessage, RequestBody, ResponseBody};
+use crate::horizontal_adapter::{
+    BroadcastMessage, HorizontalAdapter, RequestBody, RequestType, ResponseBody,
+    generate_request_id,
+};
 use async_trait::async_trait;
 use sockudo_core::error::Result;
 use sockudo_core::metrics::MetricsInterface;
@@ -11,6 +14,7 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Handlers for transport events
 pub struct TransportHandlers {
+    pub node_id: String,
     pub on_broadcast: Arc<dyn Fn(BroadcastMessage) -> BoxFuture<'static, ()> + Send + Sync>,
     pub on_request:
         Arc<dyn Fn(RequestBody) -> BoxFuture<'static, Result<ResponseBody>> + Send + Sync>,
@@ -65,6 +69,75 @@ pub trait HorizontalTransport: Send + Sync + Clone {
     ) -> Result<()> {
         self.publish_request(request).await
     }
+
+    /// Publish a request to a specific node by ID
+    /// Default: broadcasts via publish_request (receiver-side filtering)
+    async fn publish_request_to_node(
+        &self,
+        request: &RequestBody,
+        _target_node_id: &str,
+    ) -> Result<()> {
+        self.publish_request(request).await
+    }
+
+    /// Sync this node's full presence registry snapshot to a target node
+    /// Default: single PresenceStateSync message via publish_request_to_node
+    async fn sync_presence_state_to_node(
+        &self,
+        horizontal: &Arc<HorizontalAdapter>,
+        target_node_id: &str,
+    ) -> Result<()> {
+        send_presence_state_to_node(self, horizontal, target_node_id).await
+    }
+}
+
+/// Helper function to send presence state to a new node
+pub(crate) async fn send_presence_state_to_node<T: HorizontalTransport>(
+    transport: &T,
+    horizontal: &Arc<HorizontalAdapter>,
+    target_node_id: &str,
+) -> Result<()> {
+    // Get our presence data
+    let (our_node_id, payload) = {
+        let registry = horizontal.cluster_presence_registry.read().await;
+        // Get only our node's data
+        let Some(our_data) = registry.get(&horizontal.node_id) else {
+            tracing::debug!("No presence data to send to new node: {}", target_node_id);
+            return Ok(());
+        };
+        if our_data.is_empty() {
+            tracing::debug!("Empty presence data for new node: {}", target_node_id);
+            return Ok(());
+        };
+        // Clone the data to avoid holding the lock
+        (horizontal.node_id.clone(), sonic_rs::to_value(our_data)?)
+    };
+
+    // Serialize the presence data
+    let request = RequestBody {
+        request_id: generate_request_id(),
+        node_id: our_node_id,
+        app_id: "cluster".to_string(),
+        request_type: RequestType::PresenceStateSync,
+        target_node_id: Some(target_node_id.to_string()),
+        user_info: Some(payload), // Reuse this field for bulk data
+        channel: None,
+        socket_id: None,
+        user_id: None,
+        timestamp: None,
+        dead_node_id: None,
+        channels: None,
+    };
+
+    transport
+        .publish_request_to_node(&request, target_node_id)
+        .await?;
+
+    tracing::info!(
+        "Sent presence state to new node: {} (single message)",
+        target_node_id
+    );
+    Ok(())
 }
 
 /// Common configuration traits for transport implementations

--- a/crates/sockudo-adapter/src/transports/nats_transport.rs
+++ b/crates/sockudo-adapter/src/transports/nats_transport.rs
@@ -1,5 +1,8 @@
-use crate::horizontal_adapter::{BroadcastMessage, RequestBody, ResponseBody};
+use crate::horizontal_adapter::{
+    BroadcastMessage, PresenceEntry, RequestBody, RequestType, ResponseBody, generate_request_id,
+};
 use crate::horizontal_transport::{HorizontalTransport, TransportConfig, TransportHandlers};
+use ahash::AHashMap;
 use async_nats::{Client as NatsClient, ConnectOptions as NatsOptions, Subject};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -16,6 +19,23 @@ use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 const NATS_SYS_SERVER_PING_SUBJECT: &str = "$SYS.REQ.SERVER.PING";
+
+#[doc(hidden)]
+pub fn build_presence_state_chunks(
+    our_data: &AHashMap<String, AHashMap<String, PresenceEntry>>,
+    chunk_size: usize,
+) -> sockudo_core::error::Result<Vec<sonic_rs::Value>> {
+    let cap = chunk_size.max(1);
+    let pairs: Vec<(&String, &AHashMap<String, PresenceEntry>)> = our_data.iter().collect();
+    pairs
+        .chunks(cap)
+        .map(|c| {
+            let chunk_map: AHashMap<&String, &AHashMap<String, PresenceEntry>> =
+                c.iter().copied().collect();
+            sonic_rs::to_value(&chunk_map).map_err(Into::into)
+        })
+        .collect()
+}
 
 /// Metrics for tracking message processing and drops
 #[derive(Debug, Default)]
@@ -355,9 +375,16 @@ impl HorizontalTransport for NatsTransport {
             .await
             .map_err(|e| Error::Internal(format!("Failed to subscribe to inbox subject: {e}")))?;
 
+        // Subscribe to per-node channel
+        let node_subject = format!("{}.node.{}", self.config.prefix, handlers.node_id);
+        let mut node_subscription = client
+            .subscribe(Subject::from(node_subject.clone()))
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to subscribe to node subject: {e}")))?;
+
         info!(
-            "NATS transport listening on subjects: {}, {}, {}, {}",
-            broadcast_subject, request_subject, response_subject, inbox_subject
+            "NATS transport listening on subjects: {}, {}, {}, {}, {}",
+            broadcast_subject, request_subject, response_subject, inbox_subject, node_subject
         );
 
         // Spawn a task to handle broadcast messages
@@ -532,6 +559,48 @@ impl HorizontalTransport for NatsTransport {
             warn!("Inbox subscription ended unexpectedly");
         });
 
+        // Spawn a task to handle per-node targeted requests
+        let node_request_handler = handlers.on_request.clone();
+        let metrics_node = self.metrics.clone();
+        let metrics_driver_node = self.metrics_driver.clone();
+        let shutdown_node = self.shutdown.clone();
+        let running_node = self.is_running.clone();
+
+        tokio::spawn(async move {
+            loop {
+                if !running_node.load(Ordering::Relaxed) {
+                    break;
+                }
+                let msg = tokio::select! {
+                    _ = shutdown_node.notified() => break,
+                    msg = node_subscription.next() => msg,
+                };
+                let Some(msg) = msg else {
+                    break;
+                };
+                metrics_node.record_received();
+                match sonic_rs::from_slice::<RequestBody>(&msg.payload) {
+                    Ok(request) => {
+                        let _ = node_request_handler(request).await;
+                        metrics_node.record_processed();
+                    }
+                    Err(e) => {
+                        metrics_node.record_parse_error();
+                        if let Some(m) = metrics_driver_node.get() {
+                            m.mark_horizontal_transport_message_dropped("nats");
+                        }
+                        let preview =
+                            String::from_utf8_lossy(&msg.payload[..msg.payload.len().min(200)]);
+                        error!(
+                            "Failed to parse node-targeted request: {} - preview: {}",
+                            e, preview
+                        );
+                    }
+                }
+            }
+            warn!("Node subscription ended unexpectedly");
+        });
+
         Ok(())
     }
 
@@ -601,6 +670,100 @@ impl HorizontalTransport for NatsTransport {
         debug!(
             "Published request {} with reply_to via NATS",
             request.request_id
+        );
+        Ok(())
+    }
+
+    async fn publish_request_to_node(
+        &self,
+        request: &RequestBody,
+        target_node_id: &str,
+    ) -> Result<()> {
+        let target_subject = format!("{}.node.{}", self.config.prefix, target_node_id);
+        let request_data = sonic_rs::to_vec(request)
+            .map_err(|e| Error::Other(format!("Failed to serialize request: {e}")))?;
+        self.client
+            .publish(Subject::from(target_subject), request_data.into())
+            .await
+            .map_err(|e| {
+                Error::Internal(format!("Failed to publish to node {target_node_id}: {e}"))
+            })?;
+        debug!(
+            "Published request {} to node {} via NATS",
+            request.request_id, target_node_id
+        );
+        Ok(())
+    }
+
+    async fn sync_presence_state_to_node(
+        &self,
+        horizontal: &Arc<crate::horizontal_adapter::HorizontalAdapter>,
+        target_node_id: &str,
+    ) -> Result<()> {
+        use crate::horizontal_transport::send_presence_state_to_node;
+
+        let Some(chunk_size) = self.config.presence_sync_chunk_size else {
+            return send_presence_state_to_node(self, horizontal, target_node_id).await;
+        };
+
+        let (our_node_id, serialized_chunks, total_channels) = {
+            let registry = horizontal.cluster_presence_registry.read().await;
+            let Some(our_data) = registry.get(&horizontal.node_id) else {
+                debug!("No presence data to send to new node: {}", target_node_id);
+                return Ok(());
+            };
+            if our_data.is_empty() {
+                debug!("Empty presence data for new node: {}", target_node_id);
+                return Ok(());
+            }
+            let total = our_data.len();
+            let chunks = build_presence_state_chunks(our_data, chunk_size)?;
+            (horizontal.node_id.clone(), chunks, total)
+        };
+
+        let total_chunks = serialized_chunks.len();
+        debug!(
+            "Sending presence state to node {} in {} chunk(s) ({} channels)",
+            target_node_id, total_chunks, total_channels
+        );
+
+        for (i, chunk_value) in serialized_chunks.into_iter().enumerate() {
+            let sync_request = RequestBody {
+                request_id: generate_request_id(),
+                node_id: our_node_id.clone(),
+                app_id: "cluster".to_string(),
+                request_type: RequestType::PresenceStateSync,
+                target_node_id: Some(target_node_id.to_string()),
+                user_info: Some(chunk_value),
+                channel: None,
+                socket_id: None,
+                user_id: None,
+                timestamp: None,
+                dead_node_id: None,
+                channels: None,
+            };
+
+            if let Err(e) = self
+                .publish_request_to_node(&sync_request, target_node_id)
+                .await
+            {
+                warn!(
+                    "Failed to publish presence chunk {}/{} to node {}: {}",
+                    i + 1,
+                    total_chunks,
+                    target_node_id,
+                    e
+                );
+            }
+        }
+
+        if let Err(e) = self.client.flush().await {
+            warn!("Failed to flush NATS client after chunked sync: {}", e);
+        }
+
+        info!(
+            "Sent presence state to new node: {} ({} channels in {} chunk(s))",
+            target_node_id, total_channels, total_chunks
         );
         Ok(())
     }

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -60,3 +60,6 @@ mod local_channel_members_tests;
 
 #[cfg(test)]
 mod user_has_connections_tests;
+
+#[cfg(test)]
+mod presence_state_sync_default_test;

--- a/crates/sockudo-adapter/tests/adapter/presence_state_sync_default_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_state_sync_default_test.rs
@@ -1,0 +1,54 @@
+use crate::adapter::horizontal_adapter_helpers::{MockConfig, MockTransport};
+use sockudo_adapter::horizontal_adapter::RequestType;
+use sockudo_adapter::horizontal_adapter_base::HorizontalAdapterBase;
+use sockudo_adapter::horizontal_transport::HorizontalTransport;
+
+#[tokio::test]
+async fn default_sync_sends_single_message() {
+    let config = MockConfig::default();
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config)
+        .await
+        .unwrap();
+
+    let our_node_id = adapter.node_id.clone();
+
+    for i in 0..250 {
+        adapter
+            .horizontal
+            .add_presence_entry(
+                &our_node_id,
+                &format!("presence-channel-{}", i),
+                &format!("socket-{}", i),
+                &format!("user-{}", i),
+                "app-id",
+                Some(sonic_rs::json!({"name": format!("User {}", i)})),
+            )
+            .await;
+    }
+
+    adapter
+        .transport
+        .sync_presence_state_to_node(&adapter.horizontal, "target-node")
+        .await
+        .unwrap();
+
+    let requests: Vec<_> = adapter
+        .transport
+        .get_published_requests()
+        .await
+        .into_iter()
+        .filter(|r| r.request_type == RequestType::PresenceStateSync)
+        .collect();
+
+    assert_eq!(
+        requests.len(),
+        1,
+        "Expected exactly one PresenceStateSync message, got {}",
+        requests.len()
+    );
+    assert_eq!(
+        requests[0].target_node_id.as_deref(),
+        Some("target-node"),
+        "Expected target_node_id == \"target-node\""
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/transports/nats_transport_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/nats_transport_test.rs
@@ -630,3 +630,141 @@ async fn test_concurrent_operations() -> Result<()> {
 
     Ok(())
 }
+
+/// Verifies publish_request_to_node delivers ONLY to the target node's
+/// per-node subject, not to the shared requests subject.
+/// Requires running NATS server.
+#[tokio::test]
+#[ignore]
+async fn test_nats_publish_request_to_node_delivers_to_target_only() {
+    let config = get_nats_config();
+    let transport_a = NatsTransport::new(config.clone()).await.unwrap();
+    let transport_b = NatsTransport::new(config.clone()).await.unwrap();
+
+    let collector_a = MessageCollector::new();
+    let collector_b = MessageCollector::new();
+
+    let mut handlers_a = create_test_handlers(collector_a.clone());
+    handlers_a.node_id = "node-a".to_string();
+    transport_a.start_listeners(handlers_a).await.unwrap();
+
+    let mut handlers_b = create_test_handlers(collector_b.clone());
+    handlers_b.node_id = "node-b".to_string();
+    transport_b.start_listeners(handlers_b).await.unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    let request = create_test_request();
+    let request_id = request.request_id.clone();
+    transport_a
+        .publish_request_to_node(&request, "node-b")
+        .await
+        .unwrap();
+
+    let received = collector_b.wait_for_request(500).await;
+    assert!(received.is_some(), "Node B should receive the request");
+    assert_eq!(received.unwrap().request_id, request_id);
+
+    let a_requests = collector_a.get_requests().await;
+    assert!(
+        a_requests.is_empty(),
+        "Node A should NOT receive it, got {}",
+        a_requests.len()
+    );
+}
+
+#[cfg(test)]
+mod chunk_builder_tests {
+    use ahash::AHashMap;
+    use sockudo_adapter::horizontal_adapter::PresenceEntry;
+    use sockudo_adapter::transports::nats_transport::build_presence_state_chunks;
+
+    fn make_entry(socket_id: &str, user_id: &str) -> PresenceEntry {
+        PresenceEntry {
+            user_info: None,
+            node_id: "test-node".to_string(),
+            app_id: "test-app".to_string(),
+            user_id: user_id.to_string(),
+            socket_id: socket_id.to_string(),
+            sequence_number: 0,
+        }
+    }
+
+    fn build_registry(
+        channels: usize,
+        sockets_per: usize,
+    ) -> AHashMap<String, AHashMap<String, PresenceEntry>> {
+        let mut out = AHashMap::with_capacity(channels);
+        for c in 0..channels {
+            let mut sockets = AHashMap::with_capacity(sockets_per);
+            for s in 0..sockets_per {
+                let sid = format!("socket-{c}-{s}");
+                sockets.insert(sid.clone(), make_entry(&sid, &format!("user-{s}")));
+            }
+            out.insert(format!("channel-{c}"), sockets);
+        }
+        out
+    }
+
+    fn channels_in_chunk(chunk: &sonic_rs::Value) -> usize {
+        let bytes = sonic_rs::to_vec(chunk).unwrap();
+        let map: AHashMap<String, sonic_rs::Value> = sonic_rs::from_slice(&bytes).unwrap();
+        map.len()
+    }
+
+    #[test]
+    fn chunks_by_channel_count() {
+        let reg = build_registry(250, 5);
+        let chunks = build_presence_state_chunks(&reg, 100).unwrap();
+        assert_eq!(chunks.len(), 3, "250 channels / 100 = 3 chunks");
+        let total: usize = chunks.iter().map(channels_in_chunk).sum();
+        assert_eq!(total, 250, "all channels accounted for");
+    }
+
+    #[test]
+    fn exact_boundary_no_trailing_empty_chunk() {
+        let reg = build_registry(200, 1);
+        let chunks = build_presence_state_chunks(&reg, 100).unwrap();
+        assert_eq!(chunks.len(), 2, "200/100 = exactly 2, no trailing empty");
+        for c in &chunks {
+            assert_eq!(channels_in_chunk(c), 100);
+        }
+    }
+
+    #[test]
+    fn single_chunk_under_1mb() {
+        let mut reg = build_registry(100, 5);
+        for sockets in reg.values_mut() {
+            for entry in sockets.values_mut() {
+                entry.user_info = Some(sonic_rs::json!({
+                    "name": "Test User Realistic",
+                    "email": "user@example.com",
+                    "tier": "premium",
+                }));
+            }
+        }
+        let chunks = build_presence_state_chunks(&reg, 100).unwrap();
+        assert_eq!(chunks.len(), 1);
+        let bytes = sonic_rs::to_vec(&chunks[0]).unwrap();
+        assert!(
+            bytes.len() < 1_000_000,
+            "chunk must fit under 1MB NATS default, got {}",
+            bytes.len()
+        );
+    }
+
+    #[test]
+    fn empty_registry_zero_chunks() {
+        let reg = AHashMap::new();
+        let chunks = build_presence_state_chunks(&reg, 100).unwrap();
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn single_channel_one_chunk() {
+        let reg = build_registry(1, 3);
+        let chunks = build_presence_state_chunks(&reg, 100).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(channels_in_chunk(&chunks[0]), 1);
+    }
+}

--- a/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
@@ -246,6 +246,7 @@ pub fn create_test_handlers(
     let response_collector = collector.clone();
 
     sockudo_adapter::horizontal_transport::TransportHandlers {
+        node_id: "test-node".to_string(),
         on_broadcast: Arc::new(move |msg| {
             let collector = broadcast_collector.clone();
             Box::pin(async move {

--- a/crates/sockudo-core/src/options.rs
+++ b/crates/sockudo-core/src/options.rs
@@ -547,6 +547,7 @@ pub struct NatsAdapterConfig {
     pub subscription_capacity: Option<usize>,
     pub client_capacity: Option<usize>,
     pub max_reconnects: Option<usize>,
+    pub presence_sync_chunk_size: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1908,6 +1909,7 @@ impl Default for NatsAdapterConfig {
             subscription_capacity: None,
             client_capacity: None,
             max_reconnects: None,
+            presence_sync_chunk_size: None,
         }
     }
 }
@@ -2829,6 +2831,9 @@ impl ServerOptions {
         if let Some(v) = parse_env_optional::<usize>("NATS_MAX_RECONNECTS") {
             self.adapter.nats.max_reconnects = Some(v);
         }
+        if let Some(v) = parse_env_optional::<usize>("NATS_PRESENCE_SYNC_CHUNK_SIZE") {
+            self.adapter.nats.presence_sync_chunk_size = Some(v);
+        }
 
         // --- Pulsar Adapter ---
         if let Ok(url) = std::env::var("PULSAR_URL") {
@@ -3514,6 +3519,10 @@ impl ServerOptions {
         }
         if self.annotations.enabled && !self.versioned_messages.enabled {
             return Err("annotations require versioned_messages.enabled".to_string());
+        }
+
+        if self.adapter.nats.presence_sync_chunk_size == Some(0) {
+            return Err("nats.presence_sync_chunk_size must be > 0 when set".to_string());
         }
 
         Ok(())


### PR DESCRIPTION
Move presence-state sync into `HorizontalTransport` trait with single-message default. NATS overrides with per-node subject targeting and config-driven chunking (`presence_sync_chunk_size`).

Stagger new-node sync with hash-based delay to prevent thundering herd.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->