### PR TITLE
fix(adapter): downgrade channel-closed logs from warn/error to debug

### DIFF
--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -554,11 +554,15 @@ impl ConnectionHandler {
                         .handle_message(message, socket_id, app_config.clone())
                         .await
                     {
-                        error!("Message handling error for socket {}: {}", socket_id, e);
                         if e.is_fatal() {
+                            error!("Message handling error for socket {}: {}", socket_id, e);
                             self.handle_fatal_error(socket_id, app_config, &e).await?;
                             break;
+                        } else if matches!(&e, Error::ConnectionClosed(_)) {
+                            debug!("Message handling error for socket {}: {}", socket_id, e);
+                            break;
                         } else {
+                            error!("Message handling error for socket {}: {}", socket_id, e);
                             // Send pusher:error for non-fatal errors
                             if let Err(send_err) =
                                 self.send_error(&app_config.id, socket_id, &e, None).await

--- a/crates/sockudo-core/src/websocket.rs
+++ b/crates/sockudo-core/src/websocket.rs
@@ -827,7 +827,9 @@ impl MessageSender {
     pub fn send(&self, message: Message) -> Result<()> {
         self.sender.try_send(message).map_err(|e| match e {
             TrySendError::Full(_) => Error::BufferFull("Message buffer is full".into()),
-            TrySendError::Disconnected(_) => Error::Connection("Message channel closed".into()),
+            TrySendError::Disconnected(_) => {
+                Error::ConnectionClosed("Message channel closed".into())
+            }
         })
     }
 


### PR DESCRIPTION
A disconnected mpsc channel is normal when a client drops mid-broadcast. `MessageSender::send()` was returning `Error::Connection` (wrong variant) instead of `Error::ConnectionClosed`, causing `log_send_errors` to route it to warn! instead of debug!.

Additionally, the message loop logged `ConnectionClosed` as error! and tried to `send_error` back to the dead socket (which also failed and logged a second error!).

Changes:
- websocket.rs: `TrySendError::Disconnected` now maps to `ConnectionClosed` (consistent with the identical mapping for broadcast channels)
- handler/mod.rs: `ConnectionClosed` in the message loop logs at debug, skips the futile send_error, and breaks to avoid wasted work

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->