### PR TITLE
Preserve inline apps when default app enabled is true

### DIFF
--- a/crates/sockudo-core/src/options.rs
+++ b/crates/sockudo-core/src/options.rs
@@ -2691,6 +2691,17 @@ mod tests {
         }
 
         {
+            let _env = EnvGuard::app_bootstrap(&[("SOCKUDO_DEFAULT_APP_ENABLED", "true")]);
+            let mut options = ServerOptions::default();
+            options.app_manager.array.apps.push(inline_test_app());
+
+            options.override_from_env().await.unwrap();
+
+            assert_eq!(options.app_manager.array.apps.len(), 1);
+            assert_eq!(options.app_manager.array.apps[0].id, "app-id");
+        }
+
+        {
             let _env = EnvGuard::app_bootstrap(&[
                 ("SOCKUDO_DEFAULT_APP_ID", "prod-app"),
                 ("SOCKUDO_DEFAULT_APP_KEY", "prod-key"),
@@ -3563,13 +3574,16 @@ impl ServerOptions {
         let default_app_id = std::env::var("SOCKUDO_DEFAULT_APP_ID").ok();
         let default_app_key = std::env::var("SOCKUDO_DEFAULT_APP_KEY").ok();
         let default_app_secret = std::env::var("SOCKUDO_DEFAULT_APP_SECRET").ok();
-        let default_app_env_configured = default_app_id.is_some()
-            || default_app_key.is_some()
-            || default_app_secret.is_some()
-            || std::env::var("SOCKUDO_DEFAULT_APP_ENABLED").is_ok();
+        let default_app_enabled_env = std::env::var("SOCKUDO_DEFAULT_APP_ENABLED").ok();
         let default_app_enabled = parse_bool_env("SOCKUDO_DEFAULT_APP_ENABLED", true);
+        let default_app_credentials_configured =
+            default_app_id.is_some() || default_app_key.is_some() || default_app_secret.is_some();
+        let default_app_env_configured =
+            default_app_credentials_configured || default_app_enabled_env.is_some();
+        let default_app_should_override_inline = default_app_credentials_configured
+            || default_app_enabled_env.is_some_and(|_| !default_app_enabled);
 
-        if default_app_env_configured {
+        if default_app_should_override_inline {
             let app_count = self.app_manager.array.apps.len();
             self.app_manager.array.apps.clear();
             if app_count > 0 {
@@ -3698,7 +3712,7 @@ impl ServerOptions {
             info!("Successfully registered default app from env");
         } else if default_app_env_configured && !default_app_enabled {
             info!("Default app registration disabled by SOCKUDO_DEFAULT_APP_ENABLED=false");
-        } else if default_app_env_configured {
+        } else if default_app_credentials_configured {
             warn!(
                 "SOCKUDO_DEFAULT_APP_* environment was configured but id, key, and secret were not all provided; no default app registered"
             );

--- a/docs/content/2.server/2.environment-variables.md
+++ b/docs/content/2.server/2.environment-variables.md
@@ -31,7 +31,7 @@ Create a default app from environment variables without a config file.
 | `SOCKUDO_DEFAULT_APP_ID` | `string` | — | App ID (required with key+secret) |
 | `SOCKUDO_DEFAULT_APP_KEY` | `string` | — | App key (required with id+secret) |
 | `SOCKUDO_DEFAULT_APP_SECRET` | `string` | — | App secret (required with id+key) |
-| `SOCKUDO_DEFAULT_APP_ENABLED` | `bool` | `true` | Enable the default app. When set, `SOCKUDO_DEFAULT_APP_*` replaces inline configured apps; `false` clears them without registering a replacement. |
+| `SOCKUDO_DEFAULT_APP_ENABLED` | `bool` | `true` | Enable an environment-defined default app. `false` clears inline configured apps without registering a replacement. `true` alone leaves inline apps unchanged. |
 | `SOCKUDO_SKIP_INLINE_APPS` | `bool` | `false` | Skip apps defined under `app_manager.array.apps` in the config file. |
 | `APP_MANAGER_REGISTER_INLINE_APPS` | `bool` | `true` | Register apps defined under `app_manager.array.apps`; set to `false` to skip them. |
 | `SOCKUDO_ENABLE_CLIENT_MESSAGES` | `bool` | `false` | Allow client-to-client events |

--- a/docs/content/2.server/9.app-managers.md
+++ b/docs/content/2.server/9.app-managers.md
@@ -76,7 +76,7 @@ SOCKUDO_DEFAULT_APP_SECRET=my-app-secret
 SOCKUDO_DEFAULT_APP_ENABLED=true
 ```
 
-When any `SOCKUDO_DEFAULT_APP_*` bootstrap variable is set, the environment-defined app replaces apps from `app_manager.array.apps`. Set `SOCKUDO_DEFAULT_APP_ENABLED=false` to clear inline apps without registering a replacement, or set `APP_MANAGER_REGISTER_INLINE_APPS=false` / `SOCKUDO_SKIP_INLINE_APPS=true` to skip inline app registration directly.
+When `SOCKUDO_DEFAULT_APP_ID`, `SOCKUDO_DEFAULT_APP_KEY`, or `SOCKUDO_DEFAULT_APP_SECRET` is set, the environment-defined app replaces apps from `app_manager.array.apps`. Set `SOCKUDO_DEFAULT_APP_ENABLED=false` to clear inline apps without registering a replacement, or set `APP_MANAGER_REGISTER_INLINE_APPS=false` / `SOCKUDO_SKIP_INLINE_APPS=true` to skip inline app registration directly.
 
 See [Environment Variables](/server/environment-variables#default-app-bootstrap) for all `SOCKUDO_DEFAULT_APP_*` options.
 


### PR DESCRIPTION
## Summary
- keep existing inline app definitions when only SOCKUDO_DEFAULT_APP_ENABLED=true is set
- continue clearing inline apps when SOCKUDO_DEFAULT_APP_ENABLED=false is set
- continue replacing inline apps when SOCKUDO_DEFAULT_APP_ID/KEY/SECRET are provided
- clarify the bootstrap docs for true-only vs replacement behavior

## Tests
- cargo fmt --all
- cargo test -p sockudo-core app_bootstrap_env_overrides_inline_apps
- cargo test -p sockudo-core
- git diff --check