### PR TITLE
feat(adapter): add targeted routing and sharded pub/sub for Redis transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -247,7 +247,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2734,7 +2734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3171,7 +3171,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -4015,7 +4015,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -5236,7 +5236,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5528,7 +5528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6328,7 +6328,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6368,7 +6368,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6593,9 +6593,9 @@ checksum = "bbc4a4ea2a66a41a1152c4b3d86e8954dc087bdf33af35446e6e176db4e73c8c"
 
 [[package]]
 name = "redis"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44e94c96d8870a387d88ce3de3fdd608cbfc0705f03cb343cdde91509d3e49a"
+checksum = "72d32a1ac9123f0d84fda64bfc02a271d9868483162dd2d9099b5c362ece064c"
 dependencies = [
  "arc-swap",
  "arcstr",
@@ -7190,7 +7190,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7264,7 +7264,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7285,7 +7285,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7512,7 +7512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7863,7 +7863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8929,7 +8929,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8950,7 +8950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10029,7 +10029,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sockudo-adapter/src/horizontal_adapter.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter.rs
@@ -73,6 +73,10 @@ pub struct RequestBody {
     // List of channels for BatchChannelSocketsCount
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub channels: Option<Vec<String>>,
+
+    // Inbox channel for targeted response routing, falls back to global channel
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
 }
 
 /// Response body for horizontal requests
@@ -706,6 +710,7 @@ impl HorizontalAdapter {
             timestamp: None,
             dead_node_id: None,
             target_node_id: None,
+            reply_to: None,
             channels: None,
         };
 

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -495,6 +495,7 @@ where
             timestamp: None,
             dead_node_id: None,
             target_node_id: None,
+            reply_to: None,
             channels: None,
         };
         self.send_request_with_body(request).await
@@ -821,6 +822,7 @@ where
                     timestamp: Some(current_timestamp()),
                     dead_node_id: None,
                     target_node_id: None,
+                    reply_to: None,
                     channels: None,
                 };
 
@@ -936,6 +938,7 @@ where
                                     timestamp: Some(current_timestamp()),
                                     dead_node_id: Some(dead_node_id.clone()),
                                     target_node_id: None,
+                                    reply_to: None,
                                     channels: None,
                                 };
 
@@ -1487,6 +1490,7 @@ where
             timestamp: None,
             dead_node_id: None,
             target_node_id: None,
+            reply_to: None,
             channels: Some(channels.iter().map(|c| c.to_string()).collect()),
         };
 
@@ -1702,6 +1706,7 @@ where
             timestamp: Some(current_timestamp()),
             dead_node_id: Some(self.node_id.clone()),
             target_node_id: None,
+            reply_to: None,
             channels: None,
         };
 
@@ -1783,6 +1788,7 @@ impl<T: HorizontalTransport> HorizontalAdapterInterface for HorizontalAdapterBas
             timestamp: None,
             dead_node_id: None,
             target_node_id: None,
+            reply_to: None,
             channels: None,
         };
 
@@ -1825,6 +1831,7 @@ impl<T: HorizontalTransport> HorizontalAdapterInterface for HorizontalAdapterBas
             timestamp: None,
             dead_node_id: None,
             target_node_id: None,
+            reply_to: None,
             channels: None,
         };
 

--- a/crates/sockudo-adapter/src/horizontal_transport.rs
+++ b/crates/sockudo-adapter/src/horizontal_transport.rs
@@ -126,6 +126,7 @@ pub(crate) async fn send_presence_state_to_node<T: HorizontalTransport>(
         user_id: None,
         timestamp: None,
         dead_node_id: None,
+        reply_to: None,
         channels: None,
     };
 

--- a/crates/sockudo-adapter/src/transports/mod.rs
+++ b/crates/sockudo-adapter/src/transports/mod.rs
@@ -11,6 +11,8 @@ pub mod pulsar_transport;
 #[cfg(feature = "rabbitmq")]
 pub mod rabbitmq_transport;
 #[cfg(feature = "redis-cluster")]
+pub mod redis_cluster_sharded_pubsub;
+#[cfg(feature = "redis-cluster")]
 pub mod redis_cluster_transport;
 #[cfg(feature = "redis")]
 pub mod redis_transport;

--- a/crates/sockudo-adapter/src/transports/nats_transport.rs
+++ b/crates/sockudo-adapter/src/transports/nats_transport.rs
@@ -740,6 +740,7 @@ impl HorizontalTransport for NatsTransport {
                 user_id: None,
                 timestamp: None,
                 dead_node_id: None,
+                reply_to: None,
                 channels: None,
             };
 

--- a/crates/sockudo-adapter/src/transports/redis_cluster_sharded_pubsub.rs
+++ b/crates/sockudo-adapter/src/transports/redis_cluster_sharded_pubsub.rs
@@ -1,0 +1,1049 @@
+//! Slot-aware, per-shard Pub/Sub for Redis Cluster.
+//!
+//! `redis-rs` does not expose sharded Pub/Sub subscriptions on its cluster
+//! client. This module works around that by discovering the cluster topology,
+//! grouping channels by hash slot, and opening a direct (non-cluster)
+//! connection to each shard master. Inspired by `go-redis` and `fred.rs`.
+
+use crossfire::mpsc;
+use redis::cluster_routing::Slot;
+use sockudo_core::error::{Error, Result};
+use sockudo_core::metrics::MetricsInterface;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use tokio::sync::{Mutex, Notify};
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+const TOPOLOGY_REFRESH_INTERVAL_SECS: u64 = 30;
+const TOPOLOGY_REFRESH_FAILURE_THRESHOLD: u64 = 3;
+
+type ShardedPushChannelFlavor = mpsc::Array<redis::PushInfo>;
+type ShardedPushSender = crossfire::MAsyncTx<ShardedPushChannelFlavor>;
+
+/// Receiver end of the bounded fan-in channel returned by `ShardedSubscriber::start`.
+pub type ShardedPushReceiver = crossfire::AsyncRx<ShardedPushChannelFlavor>;
+
+/// Address of a single Redis Cluster shard master.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct NodeAddr {
+    pub host: String,
+    pub port: u16,
+}
+
+impl NodeAddr {
+    fn new(host: impl Into<String>, port: u16) -> Self {
+        Self {
+            host: host.into(),
+            port,
+        }
+    }
+
+    pub(crate) fn to_url(&self, scheme: &str, password: Option<&str>) -> String {
+        match password {
+            Some(pw) => format!(
+                "{}://:{}@{}:{}/?protocol=resp3",
+                scheme, pw, self.host, self.port
+            ),
+            None => format!("{}://{}:{}/?protocol=resp3", scheme, self.host, self.port),
+        }
+    }
+}
+
+/// Snapshot of Redis Cluster topology: hash slot to owning shard master.
+pub(crate) struct Topology {
+    slot_owners: HashMap<Slot, NodeAddr>,
+    fallback: NodeAddr,
+    #[allow(dead_code)]
+    masters: Vec<NodeAddr>,
+}
+
+impl Topology {
+    /// Query any of the `seed_urls` and return a parsed cluster topology.
+    ///
+    /// Tries each seed in turn; returns the first success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if all seeds fail or the response cannot be parsed.
+    pub(crate) async fn discover(seed_urls: &[String]) -> Result<Self> {
+        let mut last_err: Option<Error> = None;
+        for url in seed_urls {
+            match Self::discover_one(url).await {
+                Ok(topo) => return Ok(topo),
+                Err(e) => {
+                    warn!("Topology::discover: seed {url} failed: {e}");
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err
+            .unwrap_or_else(|| Error::Redis("Topology::discover: no seed URLs provided".into())))
+    }
+
+    async fn discover_one(url: &str) -> Result<Self> {
+        let client = redis::Client::open(url)
+            .map_err(|e| Error::Redis(format!("Topology: failed to open client for {url}: {e}")))?;
+
+        let mut conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| Error::Redis(format!("Topology: connect to {url} failed: {e}")))?;
+
+        let shards_result: redis::RedisResult<redis::Value> = redis::cmd("CLUSTER")
+            .arg("SHARDS")
+            .query_async(&mut conn)
+            .await;
+
+        match shards_result {
+            Ok(raw) => parse_cluster_shards(raw),
+            Err(_) => {
+                let raw: redis::Value = redis::cmd("CLUSTER")
+                    .arg("SLOTS")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| Error::Redis(format!("CLUSTER SLOTS on {url} failed: {e}")))?;
+                parse_cluster_slots(raw)
+            }
+        }
+    }
+
+    pub(crate) fn shard_for(&self, channel: &str) -> &NodeAddr {
+        let slot = Slot::for_key(channel);
+        self.slot_owners.get(&slot).unwrap_or(&self.fallback)
+    }
+}
+
+fn parse_cluster_shards(raw: redis::Value) -> Result<Topology> {
+    let shards = match raw {
+        redis::Value::Array(arr) => arr,
+        other => {
+            return Err(Error::Redis(format!(
+                "CLUSTER SHARDS: unexpected top-level type: {other:?}"
+            )));
+        }
+    };
+
+    let mut slot_owners: HashMap<Slot, NodeAddr> = HashMap::new();
+    let mut masters: Vec<NodeAddr> = Vec::new();
+
+    for shard_val in shards {
+        let shard_arr = match shard_val {
+            redis::Value::Array(a) => a,
+            _ => continue,
+        };
+
+        let mut slot_ranges: Vec<(u16, u16)> = Vec::new();
+        let mut master_node: Option<NodeAddr> = None;
+
+        let mut i = 0;
+        while i + 1 < shard_arr.len() {
+            let key = value_to_string(&shard_arr[i]);
+            match key.as_deref() {
+                Some("slots") => {
+                    if let redis::Value::Array(slot_vals) = &shard_arr[i + 1] {
+                        let nums: Vec<u16> = slot_vals
+                            .iter()
+                            .filter_map(|v| match v {
+                                redis::Value::Int(n) => Some(*n as u16),
+                                _ => None,
+                            })
+                            .collect();
+                        for chunk in nums.chunks(2) {
+                            if let [start, end] = *chunk {
+                                slot_ranges.push((start, end));
+                            }
+                        }
+                    }
+                }
+                Some("nodes") => {
+                    if let redis::Value::Array(nodes) = &shard_arr[i + 1] {
+                        for node_val in nodes {
+                            if let redis::Value::Array(fields) = node_val {
+                                if let Some((addr, role)) = parse_node_entry(fields) {
+                                    if role == "master" || role == "primary" {
+                                        master_node = Some(addr);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+            i += 2;
+        }
+
+        if let Some(master) = master_node {
+            for (start, end) in slot_ranges {
+                for n in start..=end {
+                    if let Some(slot) = Slot::new(n) {
+                        slot_owners.insert(slot, master.clone());
+                    }
+                }
+            }
+            if !masters.contains(&master) {
+                masters.push(master);
+            }
+        }
+    }
+
+    if masters.is_empty() {
+        return Err(Error::Redis(
+            "CLUSTER SHARDS: no master nodes found in response".into(),
+        ));
+    }
+
+    let fallback = masters[0].clone();
+
+    Ok(Topology {
+        slot_owners,
+        fallback,
+        masters,
+    })
+}
+
+fn parse_node_entry(fields: &[redis::Value]) -> Option<(NodeAddr, String)> {
+    let mut host: Option<String> = None;
+    let mut port: Option<u16> = None;
+    let mut role: Option<String> = None;
+
+    let mut i = 0;
+    while i + 1 < fields.len() {
+        let key = value_to_string(&fields[i]);
+        match key.as_deref() {
+            // Prefer "endpoint" (ElastiCache/Valkey) over "ip" (OSS Redis).
+            Some("endpoint") => host = value_to_string(&fields[i + 1]),
+            Some("ip") => {
+                if host.is_none() {
+                    host = value_to_string(&fields[i + 1]);
+                }
+            }
+            Some("tls-port") => {
+                if let redis::Value::Int(n) = &fields[i + 1] {
+                    if *n > 0 {
+                        port = Some(*n as u16);
+                    }
+                }
+            }
+            Some("port") => {
+                if port.is_none() {
+                    if let redis::Value::Int(n) = &fields[i + 1] {
+                        port = Some(*n as u16);
+                    }
+                }
+            }
+            Some("role") => role = value_to_string(&fields[i + 1]),
+            _ => {}
+        }
+        i += 2;
+    }
+
+    Some((NodeAddr::new(host?, port?), role?))
+}
+
+fn parse_cluster_slots(raw: redis::Value) -> Result<Topology> {
+    let entries = match raw {
+        redis::Value::Array(arr) => arr,
+        other => {
+            return Err(Error::Redis(format!(
+                "CLUSTER SLOTS: unexpected top-level type: {other:?}"
+            )));
+        }
+    };
+
+    let mut slot_owners: HashMap<Slot, NodeAddr> = HashMap::new();
+    let mut masters: Vec<NodeAddr> = Vec::new();
+
+    for entry_val in entries {
+        let entry = match entry_val {
+            redis::Value::Array(a) => a,
+            _ => continue,
+        };
+        if entry.len() < 3 {
+            continue;
+        }
+
+        let start = match &entry[0] {
+            redis::Value::Int(n) => *n as u16,
+            _ => continue,
+        };
+        let end = match &entry[1] {
+            redis::Value::Int(n) => *n as u16,
+            _ => continue,
+        };
+
+        // entry[2] = master: [ip, port, node-id]
+        let master_addr = {
+            let node = match &entry[2] {
+                redis::Value::Array(a) => a,
+                _ => continue,
+            };
+            if node.len() < 2 {
+                continue;
+            }
+            let ip = match &node[0] {
+                redis::Value::BulkString(b) => match std::str::from_utf8(b) {
+                    Ok(s) => s.to_owned(),
+                    Err(_) => continue,
+                },
+                redis::Value::SimpleString(s) => s.clone(),
+                _ => continue,
+            };
+            let port = match &node[1] {
+                redis::Value::Int(n) => *n as u16,
+                _ => continue,
+            };
+            NodeAddr::new(ip, port)
+        };
+
+        for n in start..=end {
+            if let Some(slot) = Slot::new(n) {
+                slot_owners.insert(slot, master_addr.clone());
+            }
+        }
+        if !masters.contains(&master_addr) {
+            masters.push(master_addr);
+        }
+    }
+
+    if masters.is_empty() {
+        return Err(Error::Redis(
+            "CLUSTER SLOTS: no master nodes found in response".into(),
+        ));
+    }
+
+    let fallback = masters[0].clone();
+
+    Ok(Topology {
+        slot_owners,
+        fallback,
+        masters,
+    })
+}
+
+fn value_to_string(v: &redis::Value) -> Option<String> {
+    match v {
+        redis::Value::BulkString(b) => std::str::from_utf8(b).ok().map(str::to_owned),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        redis::Value::VerbatimString { format: _, text } => Some(text.clone()),
+        _ => None,
+    }
+}
+
+pub(crate) struct ShardListenerParams {
+    url: String,
+    channels: Vec<String>,
+    fan_in_tx: ShardedPushSender,
+    is_running: Arc<AtomicBool>,
+    shutdown: Arc<Notify>,
+    shard_addr: String,
+    metrics: Arc<OnceLock<Arc<dyn MetricsInterface + Send + Sync>>>,
+    refresh_notify: Arc<Notify>,
+}
+
+/// Long-running task for one shard master.
+///
+/// Connects via a non-cluster `redis::Client`, issues `SSUBSCRIBE` for each
+/// assigned channel (one per call to avoid `CROSSSLOT`), and forwards
+/// `SMessage` pushes to the bounded fan-in sender.  Reconnects with
+/// exponential back-off (500 ms to 10 s) on any failure.
+pub(crate) async fn shard_listener_loop(params: ShardListenerParams) {
+    // Unbounded because push_sender must not block the redis runtime;
+    // backpressure is applied at the bounded fan-in boundary.
+    type InternalFlavor = mpsc::List<redis::PushInfo>;
+
+    let mut retry_delay = 500u64;
+    const MAX_RETRY_DELAY: u64 = 10_000;
+    let mut reconnection_count = 0u64;
+    let mut consecutive_failures: u64 = 0;
+
+    'outer: loop {
+        if !params.is_running.load(Ordering::Relaxed) {
+            break;
+        }
+
+        let (internal_tx, internal_rx): (
+            crossfire::MTx<InternalFlavor>,
+            crossfire::AsyncRx<InternalFlavor>,
+        ) = mpsc::unbounded_async();
+
+        let push_sender = {
+            let tx = internal_tx;
+            move |msg: redis::PushInfo| -> std::result::Result<(), redis::aio::SendError> {
+                tx.send(msg).map_err(|_| redis::aio::SendError)
+            }
+        };
+
+        let cfg = redis::AsyncConnectionConfig::new().set_push_sender(push_sender);
+
+        let client = match redis::Client::open(params.url.as_str()) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(
+                    "shard_listener[{}]: failed to open client: {e}, retry in {retry_delay}ms",
+                    params.shard_addr
+                );
+                tokio::select! {
+                    _ = params.shutdown.notified() => break 'outer,
+                    _ = tokio::time::sleep(Duration::from_millis(retry_delay)) => {}
+                }
+                retry_delay = retry_delay.saturating_mul(2).min(MAX_RETRY_DELAY);
+                continue;
+            }
+        };
+
+        let mut conn = match client
+            .get_multiplexed_async_connection_with_config(&cfg)
+            .await
+        {
+            Ok(c) => {
+                if reconnection_count > 0 {
+                    info!(
+                        "shard_listener[{}]: reconnected after {} attempt(s)",
+                        params.shard_addr, reconnection_count
+                    );
+                }
+                retry_delay = 500;
+                consecutive_failures = 0;
+                c
+            }
+            Err(e) => {
+                reconnection_count += 1;
+                warn!(
+                    "shard_listener[{}]: connect failed (attempt {}): {e}, retry in {retry_delay}ms",
+                    params.shard_addr, reconnection_count
+                );
+                if let Some(m) = params.metrics.get() {
+                    m.mark_horizontal_transport_reconnection("redis_cluster_sharded");
+                }
+                consecutive_failures += 1;
+                if consecutive_failures >= TOPOLOGY_REFRESH_FAILURE_THRESHOLD {
+                    params.refresh_notify.notify_one();
+                    consecutive_failures = 0;
+                }
+                tokio::select! {
+                    _ = params.shutdown.notified() => break 'outer,
+                    _ = tokio::time::sleep(Duration::from_millis(retry_delay)) => {}
+                }
+                retry_delay = retry_delay.saturating_mul(2).min(MAX_RETRY_DELAY);
+                continue;
+            }
+        };
+
+        // One SSUBSCRIBE per channel to avoid CROSSSLOT errors on multi-slot batches.
+        let mut subscribe_ok = true;
+        for ch in &params.channels {
+            if let Err(e) = redis::cmd("SSUBSCRIBE")
+                .arg(ch.as_str())
+                .exec_async(&mut conn)
+                .await
+            {
+                warn!(
+                    "shard_listener[{}]: SSUBSCRIBE failed for {ch}: {e}",
+                    params.shard_addr
+                );
+                subscribe_ok = false;
+                break;
+            }
+        }
+
+        if !subscribe_ok {
+            if let Some(m) = params.metrics.get() {
+                m.mark_horizontal_transport_reconnection("redis_cluster_sharded");
+            }
+            tokio::select! {
+                _ = params.shutdown.notified() => break 'outer,
+                _ = tokio::time::sleep(Duration::from_millis(retry_delay)) => {}
+            }
+            retry_delay = retry_delay.saturating_mul(2).min(MAX_RETRY_DELAY);
+            continue;
+        }
+
+        info!(
+            "shard_listener[{}]: subscribed to {} channel(s)",
+            params.shard_addr,
+            params.channels.len()
+        );
+        reconnection_count = 0;
+
+        loop {
+            let recv = tokio::select! {
+                _ = params.shutdown.notified() => break 'outer,
+                msg = internal_rx.recv() => msg,
+            };
+
+            let push_info = match recv {
+                Err(_) => break, // internal channel closed = redis connection dropped
+                Ok(p) => p,
+            };
+
+            match push_info.kind {
+                redis::PushKind::Disconnection => {
+                    warn!(
+                        "shard_listener[{}]: Disconnection push received, reconnecting",
+                        params.shard_addr
+                    );
+                    break;
+                }
+                redis::PushKind::SMessage | redis::PushKind::Message => {
+                    match params.fan_in_tx.try_send(push_info) {
+                        Ok(()) => {}
+                        Err(crossfire::TrySendError::Full(_)) => {
+                            // Bounded fan-in is full; drop this message.
+                            // The 10 000-cap prevents OOM under sustained backpressure.
+                        }
+                        Err(crossfire::TrySendError::Disconnected(_)) => {
+                            break 'outer; // caller dropped the receiver; stop
+                        }
+                    }
+                }
+                _ => {} // SSubscribe confirmation, Pong, etc. not forwarded
+            }
+        }
+
+        reconnection_count += 1;
+        warn!(
+            "shard_listener[{}]: connection ended, reconnecting in {retry_delay}ms",
+            params.shard_addr
+        );
+        tokio::select! {
+            _ = params.shutdown.notified() => break 'outer,
+            _ = tokio::time::sleep(Duration::from_millis(retry_delay)) => {}
+        }
+        retry_delay = retry_delay.saturating_mul(2).min(MAX_RETRY_DELAY);
+    }
+
+    info!("shard_listener[{}]: stopped", params.shard_addr);
+}
+
+/// Top-level orchestrator for slot-aware Redis Cluster sharded Pub/Sub.
+pub(crate) struct ShardedSubscriber {
+    channels: Vec<String>,
+    seed_urls: Vec<String>,
+    metrics: Arc<OnceLock<Arc<dyn MetricsInterface + Send + Sync>>>,
+    is_running: Arc<AtomicBool>,
+    shutdown: Arc<Notify>,
+    refresh_notify: Arc<Notify>,
+}
+
+impl ShardedSubscriber {
+    // Caller's is_running and shutdown are shared with spawned shard tasks.
+    pub(crate) fn new(
+        channels: Vec<String>,
+        seed_urls: Vec<String>,
+        metrics: Arc<OnceLock<Arc<dyn MetricsInterface + Send + Sync>>>,
+        is_running: Arc<AtomicBool>,
+        shutdown: Arc<Notify>,
+    ) -> Self {
+        Self {
+            channels,
+            seed_urls,
+            metrics,
+            is_running,
+            shutdown,
+            refresh_notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Discover cluster topology, spawn per-shard listeners, and return the
+    /// single fan-in receiver.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from `Topology::discover`. Individual shard
+    /// connection failures are retried internally.
+    pub(crate) async fn start(&self) -> Result<ShardedPushReceiver> {
+        let topology = Topology::discover(&self.seed_urls).await?;
+
+        let mut by_shard: HashMap<NodeAddr, Vec<String>> = HashMap::new();
+        for ch in &self.channels {
+            let shard = topology.shard_for(ch).clone();
+            by_shard.entry(shard).or_default().push(ch.clone());
+        }
+
+        info!(
+            "ShardedSubscriber: {} channel(s) across {} shard(s)",
+            self.channels.len(),
+            by_shard.len()
+        );
+
+        let (fan_tx, fan_rx): (ShardedPushSender, ShardedPushReceiver) =
+            mpsc::bounded_async(10_000);
+
+        let scheme = if self.seed_urls.iter().any(|u| u.starts_with("rediss://")) {
+            "rediss"
+        } else {
+            "redis"
+        };
+        let password: Option<String> = self
+            .seed_urls
+            .first()
+            .and_then(|u| redis::IntoConnectionInfo::into_connection_info(u.as_str()).ok())
+            .and_then(|ci| ci.redis_settings().password().map(str::to_owned));
+
+        // Clone fan_tx for the refresh task BEFORE the drop at the end.
+        let fan_tx_for_refresh = fan_tx.clone();
+
+        let channel_shard_map: Arc<Mutex<HashMap<String, NodeAddr>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let shard_handles: Arc<Mutex<HashMap<String, JoinHandle<()>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        {
+            let mut channel_map = channel_shard_map.lock().await;
+            for (shard_addr, shard_channels) in &by_shard {
+                for ch in shard_channels {
+                    channel_map.insert(ch.clone(), shard_addr.clone());
+                }
+            }
+        }
+
+        {
+            let mut shard_map = shard_handles.lock().await;
+            for (shard_addr, shard_channels) in by_shard {
+                if shard_channels.is_empty() {
+                    continue;
+                }
+                let url = shard_addr.to_url(scheme, password.as_deref());
+                let shard_addr_str = format!("{}:{}", shard_addr.host, shard_addr.port);
+                let params = ShardListenerParams {
+                    url,
+                    channels: shard_channels,
+                    fan_in_tx: fan_tx.clone(),
+                    is_running: self.is_running.clone(),
+                    shutdown: self.shutdown.clone(),
+                    shard_addr: shard_addr_str.clone(),
+                    metrics: self.metrics.clone(),
+                    refresh_notify: self.refresh_notify.clone(),
+                };
+                shard_map.insert(shard_addr_str, tokio::spawn(shard_listener_loop(params)));
+            }
+        }
+
+        let refresh_notify_clone = self.refresh_notify.clone();
+        let shutdown_clone = self.shutdown.clone();
+        let is_running_clone = self.is_running.clone();
+        let seed_urls_clone = self.seed_urls.clone();
+        let channel_shard_map_clone = channel_shard_map.clone();
+        let shard_handles_clone = shard_handles.clone();
+        let metrics_clone = self.metrics.clone();
+        let scheme_clone = scheme.to_owned();
+        let password_clone = password.clone();
+
+        let refresh_task = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_secs(TOPOLOGY_REFRESH_INTERVAL_SECS)) => {},
+                    _ = refresh_notify_clone.notified() => {},
+                    _ = shutdown_clone.notified() => break,
+                }
+                if !is_running_clone.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                let new_topo = match Topology::discover(&seed_urls_clone).await {
+                    Ok(t) => t,
+                    Err(e) => {
+                        warn!("topology refresh failed: {e}");
+                        continue;
+                    }
+                };
+
+                let current_map = channel_shard_map_clone.lock().await.clone();
+                let mut new_map = current_map.clone();
+
+                // old_shards_to_abort: channels moving away from a shard
+                // new_shard_channels: channels arriving on a new shard
+                let mut old_shards_to_abort: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                let mut new_shard_channels: HashMap<String, Vec<String>> = HashMap::new();
+
+                for (ch, old_shard) in &current_map {
+                    let new_shard = new_topo.shard_for(ch);
+                    if new_shard != old_shard {
+                        new_map.insert(ch.clone(), new_shard.clone());
+                        let old_str = format!("{}:{}", old_shard.host, old_shard.port);
+                        let new_str = format!("{}:{}", new_shard.host, new_shard.port);
+                        old_shards_to_abort.insert(old_str);
+                        new_shard_channels
+                            .entry(new_str)
+                            .or_default()
+                            .push(ch.clone());
+                    }
+                }
+
+                if new_shard_channels.is_empty() {
+                    continue;
+                }
+
+                let mut sh = shard_handles_clone.lock().await;
+
+                for old_str in old_shards_to_abort {
+                    if let Some(handle) = sh.remove(&old_str) {
+                        handle.abort();
+                    }
+                }
+
+                for (new_str, channels) in new_shard_channels {
+                    let new_shard_addr = new_topo.shard_for(&channels[0]).clone();
+                    let url = new_shard_addr.to_url(&scheme_clone, password_clone.as_deref());
+                    let params = ShardListenerParams {
+                        url,
+                        channels,
+                        fan_in_tx: fan_tx_for_refresh.clone(),
+                        is_running: is_running_clone.clone(),
+                        shutdown: shutdown_clone.clone(),
+                        shard_addr: new_str.clone(),
+                        metrics: metrics_clone.clone(),
+                        refresh_notify: refresh_notify_clone.clone(),
+                    };
+                    sh.insert(new_str, tokio::spawn(shard_listener_loop(params)));
+                }
+
+                let total_shards = sh.len();
+                drop(sh);
+                *channel_shard_map_clone.lock().await = new_map;
+                info!(
+                    "topology refresh: migrated channels across {} shard(s)",
+                    total_shards
+                );
+            }
+        });
+        drop(refresh_task);
+
+        // Drop the original sender so the channel closes when all listeners exit.
+        drop(fan_tx);
+
+        Ok(fan_rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_addr_to_url_no_password() {
+        let addr = NodeAddr::new("127.0.0.1", 6379);
+        assert_eq!(
+            addr.to_url("redis", None),
+            "redis://127.0.0.1:6379/?protocol=resp3"
+        );
+    }
+
+    #[test]
+    fn node_addr_to_url_with_password() {
+        let addr = NodeAddr::new("127.0.0.1", 6380);
+        assert_eq!(
+            addr.to_url("rediss", Some("secret")),
+            "rediss://:secret@127.0.0.1:6380/?protocol=resp3"
+        );
+    }
+
+    #[test]
+    fn parse_cluster_slots_basic() {
+        let raw = redis::Value::Array(vec![redis::Value::Array(vec![
+            redis::Value::Int(0),
+            redis::Value::Int(5460),
+            redis::Value::Array(vec![
+                redis::Value::BulkString(b"127.0.0.1".to_vec()),
+                redis::Value::Int(6379),
+                redis::Value::BulkString(b"node-id-1".to_vec()),
+            ]),
+        ])]);
+
+        let topo = parse_cluster_slots(raw).expect("parse_cluster_slots failed");
+        assert_eq!(topo.masters.len(), 1);
+        assert_eq!(topo.masters[0], NodeAddr::new("127.0.0.1", 6379));
+        assert_eq!(
+            topo.shard_for("sockudo_adapter::#requests"),
+            &NodeAddr::new("127.0.0.1", 6379)
+        );
+    }
+
+    #[test]
+    fn parse_cluster_slots_no_masters_returns_error() {
+        let raw = redis::Value::Array(vec![]);
+        assert!(parse_cluster_slots(raw).is_err());
+    }
+
+    fn make_shard_value(start: i64, end: i64, host: &str, port: i64) -> redis::Value {
+        redis::Value::Array(vec![
+            redis::Value::BulkString(b"slots".to_vec()),
+            redis::Value::Array(vec![redis::Value::Int(start), redis::Value::Int(end)]),
+            redis::Value::BulkString(b"nodes".to_vec()),
+            redis::Value::Array(vec![redis::Value::Array(vec![
+                redis::Value::BulkString(b"endpoint".to_vec()),
+                redis::Value::BulkString(host.as_bytes().to_vec()),
+                redis::Value::BulkString(b"port".to_vec()),
+                redis::Value::Int(port),
+                redis::Value::BulkString(b"role".to_vec()),
+                redis::Value::BulkString(b"master".to_vec()),
+            ])]),
+        ])
+    }
+
+    #[test]
+    fn parse_cluster_shards_three_shards_verify_routing() {
+        // shard1: 0..5461 owns #requests (slot 3625)
+        // shard2: 5462..10922 owns #broadcast (slot 7996)
+        // shard3: 10923..16383 owns #responses (slot 11538)
+        let raw = redis::Value::Array(vec![
+            make_shard_value(0, 5461, "10.0.0.1", 6379),
+            make_shard_value(5462, 10922, "10.0.0.2", 6379),
+            make_shard_value(10923, 16383, "10.0.0.3", 6379),
+        ]);
+
+        let topo = parse_cluster_shards(raw).expect("parse_cluster_shards 3-shard failed");
+        assert_eq!(topo.masters.len(), 3, "expected 3 master nodes");
+        assert_eq!(
+            topo.shard_for("sockudo_adapter::#requests"),
+            &NodeAddr::new("10.0.0.1", 6379),
+            "#requests (slot 3625) should route to shard1",
+        );
+        assert_eq!(
+            topo.shard_for("sockudo_adapter::#broadcast"),
+            &NodeAddr::new("10.0.0.2", 6379),
+            "#broadcast (slot 7996) should route to shard2",
+        );
+        assert_eq!(
+            topo.shard_for("sockudo_adapter::#responses"),
+            &NodeAddr::new("10.0.0.3", 6379),
+            "#responses (slot 11538) should route to shard3",
+        );
+    }
+
+    #[test]
+    fn parse_cluster_shards_empty_returns_error() {
+        let raw = redis::Value::Array(vec![]);
+        assert!(
+            parse_cluster_shards(raw).is_err(),
+            "empty CLUSTER SHARDS response should be an error",
+        );
+    }
+
+    #[test]
+    fn parse_cluster_shards_elasticache_endpoint_field() {
+        // ElastiCache returns "endpoint", not "ip".
+        let shard = redis::Value::Array(vec![
+            redis::Value::BulkString(b"slots".to_vec()),
+            redis::Value::Array(vec![redis::Value::Int(0), redis::Value::Int(16383)]),
+            redis::Value::BulkString(b"nodes".to_vec()),
+            redis::Value::Array(vec![redis::Value::Array(vec![
+                redis::Value::BulkString(b"endpoint".to_vec()),
+                redis::Value::BulkString(b"shard-001.cluster.usw2.cache.amazonaws.com".to_vec()),
+                redis::Value::BulkString(b"tls-port".to_vec()),
+                redis::Value::Int(6379),
+                redis::Value::BulkString(b"role".to_vec()),
+                redis::Value::BulkString(b"primary".to_vec()),
+            ])]),
+        ]);
+        let raw = redis::Value::Array(vec![shard]);
+        let topo =
+            parse_cluster_shards(raw).expect("parse_cluster_shards with endpoint field failed");
+        assert_eq!(topo.masters.len(), 1);
+        assert_eq!(
+            topo.masters[0],
+            NodeAddr::new("shard-001.cluster.usw2.cache.amazonaws.com", 6379)
+        );
+    }
+
+    #[test]
+    fn parse_cluster_shards_node_with_tls_port_field() {
+        let shard = redis::Value::Array(vec![
+            redis::Value::BulkString(b"slots".to_vec()),
+            redis::Value::Array(vec![redis::Value::Int(0), redis::Value::Int(16383)]),
+            redis::Value::BulkString(b"nodes".to_vec()),
+            redis::Value::Array(vec![redis::Value::Array(vec![
+                redis::Value::BulkString(b"endpoint".to_vec()),
+                redis::Value::BulkString(b"10.0.0.5".to_vec()),
+                redis::Value::BulkString(b"port".to_vec()),
+                redis::Value::Int(6379),
+                redis::Value::BulkString(b"tls-port".to_vec()),
+                redis::Value::Int(6380),
+                redis::Value::BulkString(b"role".to_vec()),
+                redis::Value::BulkString(b"master".to_vec()),
+            ])]),
+        ]);
+        let raw = redis::Value::Array(vec![shard]);
+        let topo =
+            parse_cluster_shards(raw).expect("parse_cluster_shards with tls-port field failed");
+        assert_eq!(topo.masters.len(), 1);
+        // tls-port (6380) is non-zero so it takes precedence over port (6379).
+        assert_eq!(topo.masters[0], NodeAddr::new("10.0.0.5", 6380));
+    }
+
+    #[test]
+    fn parse_cluster_shards_replica_not_counted_as_master() {
+        // A shard whose only node has role "replica" must not contribute a master.
+        let shard = redis::Value::Array(vec![
+            redis::Value::BulkString(b"slots".to_vec()),
+            redis::Value::Array(vec![redis::Value::Int(0), redis::Value::Int(16383)]),
+            redis::Value::BulkString(b"nodes".to_vec()),
+            redis::Value::Array(vec![redis::Value::Array(vec![
+                redis::Value::BulkString(b"ip".to_vec()),
+                redis::Value::BulkString(b"10.0.0.9".to_vec()),
+                redis::Value::BulkString(b"port".to_vec()),
+                redis::Value::Int(6379),
+                redis::Value::BulkString(b"role".to_vec()),
+                redis::Value::BulkString(b"replica".to_vec()),
+            ])]),
+        ]);
+        let raw = redis::Value::Array(vec![shard]);
+        assert!(
+            parse_cluster_shards(raw).is_err(),
+            "replica-only response should return an error",
+        );
+    }
+
+    #[test]
+    fn node_addr_to_url_tls_scheme_no_password() {
+        let addr = NodeAddr::new("10.0.0.1", 6380);
+        assert_eq!(
+            addr.to_url("rediss", None),
+            "rediss://10.0.0.1:6380/?protocol=resp3",
+        );
+    }
+
+    #[test]
+    fn parse_node_entry_ip_and_port() {
+        let fields = vec![
+            redis::Value::BulkString(b"ip".to_vec()),
+            redis::Value::BulkString(b"10.0.0.1".to_vec()),
+            redis::Value::BulkString(b"port".to_vec()),
+            redis::Value::Int(6379),
+            redis::Value::BulkString(b"role".to_vec()),
+            redis::Value::BulkString(b"master".to_vec()),
+        ];
+        let (addr, role) = parse_node_entry(&fields).unwrap();
+        assert_eq!(addr, NodeAddr::new("10.0.0.1", 6379));
+        assert_eq!(role, "master");
+    }
+
+    #[test]
+    fn parse_node_entry_endpoint_overrides_ip() {
+        let fields = vec![
+            redis::Value::BulkString(b"ip".to_vec()),
+            redis::Value::BulkString(b"10.0.0.1".to_vec()),
+            redis::Value::BulkString(b"endpoint".to_vec()),
+            redis::Value::BulkString(b"my-cluster.cache.amazonaws.com".to_vec()),
+            redis::Value::BulkString(b"port".to_vec()),
+            redis::Value::Int(6379),
+            redis::Value::BulkString(b"role".to_vec()),
+            redis::Value::BulkString(b"master".to_vec()),
+        ];
+        let (addr, _) = parse_node_entry(&fields).unwrap();
+        assert_eq!(addr.host, "my-cluster.cache.amazonaws.com");
+    }
+
+    #[test]
+    fn parse_node_entry_tls_port_overrides_port() {
+        let fields = vec![
+            redis::Value::BulkString(b"ip".to_vec()),
+            redis::Value::BulkString(b"10.0.0.1".to_vec()),
+            redis::Value::BulkString(b"port".to_vec()),
+            redis::Value::Int(6379),
+            redis::Value::BulkString(b"tls-port".to_vec()),
+            redis::Value::Int(6380),
+            redis::Value::BulkString(b"role".to_vec()),
+            redis::Value::BulkString(b"master".to_vec()),
+        ];
+        let (addr, _) = parse_node_entry(&fields).unwrap();
+        assert_eq!(addr.port, 6380);
+    }
+
+    #[test]
+    fn parse_node_entry_tls_port_zero_falls_back_to_port() {
+        let fields = vec![
+            redis::Value::BulkString(b"ip".to_vec()),
+            redis::Value::BulkString(b"10.0.0.1".to_vec()),
+            redis::Value::BulkString(b"tls-port".to_vec()),
+            redis::Value::Int(0),
+            redis::Value::BulkString(b"port".to_vec()),
+            redis::Value::Int(6379),
+            redis::Value::BulkString(b"role".to_vec()),
+            redis::Value::BulkString(b"master".to_vec()),
+        ];
+        let (addr, _) = parse_node_entry(&fields).unwrap();
+        assert_eq!(addr.port, 6379);
+    }
+
+    #[test]
+    fn parse_node_entry_missing_host_returns_none() {
+        let fields = vec![
+            redis::Value::BulkString(b"port".to_vec()),
+            redis::Value::Int(6379),
+            redis::Value::BulkString(b"role".to_vec()),
+            redis::Value::BulkString(b"master".to_vec()),
+        ];
+        assert!(parse_node_entry(&fields).is_none());
+    }
+
+    #[test]
+    fn parse_node_entry_missing_role_returns_none() {
+        let fields = vec![
+            redis::Value::BulkString(b"ip".to_vec()),
+            redis::Value::BulkString(b"10.0.0.1".to_vec()),
+            redis::Value::BulkString(b"port".to_vec()),
+            redis::Value::Int(6379),
+        ];
+        assert!(parse_node_entry(&fields).is_none());
+    }
+
+    #[test]
+    fn parse_node_entry_empty_fields_returns_none() {
+        assert!(parse_node_entry(&[]).is_none());
+    }
+
+    #[test]
+    fn shard_for_unknown_slot_returns_fallback() {
+        // Build a topology with only slot 0 mapped
+        let mut slot_owners = HashMap::new();
+        slot_owners.insert(Slot::new(0).unwrap(), NodeAddr::new("10.0.0.1", 6379));
+        let fallback = NodeAddr::new("10.0.0.99", 6379);
+        let topo = Topology {
+            slot_owners,
+            fallback: fallback.clone(),
+            masters: vec![NodeAddr::new("10.0.0.1", 6379), fallback],
+        };
+        // "sockudo_adapter::#broadcast" hashes to slot 7996, which is not in our map
+        let result = topo.shard_for("sockudo_adapter::#broadcast");
+        assert_eq!(result, &NodeAddr::new("10.0.0.99", 6379));
+    }
+
+    #[test]
+    fn parse_cluster_slots_skips_malformed_entries() {
+        let raw = redis::Value::Array(vec![
+            // Valid entry
+            redis::Value::Array(vec![
+                redis::Value::Int(0),
+                redis::Value::Int(16383),
+                redis::Value::Array(vec![
+                    redis::Value::BulkString(b"10.0.0.1".to_vec()),
+                    redis::Value::Int(6379),
+                ]),
+            ]),
+            // Malformed: too short
+            redis::Value::Array(vec![redis::Value::Int(0)]),
+            // Malformed: not an array
+            redis::Value::Int(42),
+        ]);
+        let topo = parse_cluster_slots(raw).expect("should skip malformed and succeed");
+        assert_eq!(topo.masters.len(), 1);
+    }
+
+    #[test]
+    fn parse_cluster_shards_skips_malformed_shard_entries() {
+        let raw = redis::Value::Array(vec![
+            // Valid shard
+            make_shard_value(0, 16383, "10.0.0.1", 6379),
+            // Malformed: not an array
+            redis::Value::Int(42),
+        ]);
+        let topo = parse_cluster_shards(raw).expect("should skip malformed and succeed");
+        assert_eq!(topo.masters.len(), 1);
+    }
+}

--- a/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
+++ b/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
@@ -17,9 +17,18 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, warn};
+use uuid::Uuid;
 
 type RedisPushChannelFlavor = mpsc::List<redis::PushInfo>;
 type RedisPushReceiver = crossfire::AsyncRx<RedisPushChannelFlavor>;
+
+use crate::transports::redis_cluster_sharded_pubsub::ShardedPushReceiver;
+use futures::future::Either as FutureEither;
+
+enum UnifiedRx {
+    Unbounded(RedisPushReceiver),
+    Bounded(ShardedPushReceiver),
+}
 
 /// Helper function to borrow a string view from redis::Value when possible.
 fn value_to_str(v: &redis::Value) -> Option<&str> {
@@ -61,6 +70,8 @@ pub struct RedisClusterTransport {
     response_channel: String,
     config: RedisClusterAdapterConfig,
     use_sharded_pubsub: bool,
+    prefix: String,
+    reply_channel: String,
     metrics: Arc<OnceLock<Arc<dyn MetricsInterface + Send + Sync>>>,
     shutdown: Arc<Notify>,
     is_running: Arc<AtomicBool>,
@@ -97,6 +108,9 @@ impl HorizontalTransport for RedisClusterTransport {
         let broadcast_channel = format!("{}:#broadcast", config.prefix);
         let request_channel = format!("{}:#requests", config.prefix);
         let response_channel = format!("{}:#responses", config.prefix);
+        let prefix = config.prefix.clone();
+        let uuid = Uuid::new_v4();
+        let reply_channel = format!("{}:#reply:{}", prefix, uuid.as_simple());
 
         let use_sharded_pubsub = config.use_sharded_pubsub;
 
@@ -121,6 +135,8 @@ impl HorizontalTransport for RedisClusterTransport {
             response_channel,
             config,
             use_sharded_pubsub,
+            prefix,
+            reply_channel,
             metrics: Arc::new(OnceLock::new()),
             shutdown: Arc::new(Notify::new()),
             is_running: Arc::new(AtomicBool::new(true)),
@@ -142,10 +158,7 @@ impl HorizontalTransport for RedisClusterTransport {
 
             // Use SPUBLISH for sharded pub/sub if enabled, otherwise standard PUBLISH
             let publish_result: redis::RedisResult<()> = if self.use_sharded_pubsub {
-                redis::cmd("SPUBLISH")
-                    .arg(&self.broadcast_channel)
-                    .arg(&broadcast_json)
-                    .query_async(&mut conn)
+                conn.spublish(&self.broadcast_channel, &broadcast_json)
                     .await
             } else {
                 conn.publish(&self.broadcast_channel, &broadcast_json).await
@@ -194,11 +207,7 @@ impl HorizontalTransport for RedisClusterTransport {
 
             // Use SPUBLISH for sharded pub/sub if enabled, otherwise standard PUBLISH
             let publish_result: redis::RedisResult<i32> = if self.use_sharded_pubsub {
-                redis::cmd("SPUBLISH")
-                    .arg(&self.request_channel)
-                    .arg(&request_json)
-                    .query_async(&mut conn)
-                    .await
+                conn.spublish(&self.request_channel, &request_json).await
             } else {
                 conn.publish(&self.request_channel, &request_json).await
             };
@@ -246,11 +255,7 @@ impl HorizontalTransport for RedisClusterTransport {
 
             // Use SPUBLISH for sharded pub/sub if enabled, otherwise standard PUBLISH
             let publish_result: redis::RedisResult<()> = if self.use_sharded_pubsub {
-                redis::cmd("SPUBLISH")
-                    .arg(&self.response_channel)
-                    .arg(&response_json)
-                    .query_async(&mut conn)
-                    .await
+                conn.spublish(&self.response_channel, &response_json).await
             } else {
                 conn.publish(&self.response_channel, &response_json).await
             };
@@ -283,6 +288,46 @@ impl HorizontalTransport for RedisClusterTransport {
         unreachable!("Retry loop should have returned");
     }
 
+    fn new_inbox(&self) -> Option<String> {
+        Some(self.reply_channel.clone())
+    }
+
+    async fn publish_request_with_reply(
+        &self,
+        request: &RequestBody,
+        reply_to: &str,
+    ) -> Result<()> {
+        let mut request = request.clone();
+        request.reply_to = Some(reply_to.to_string());
+        self.publish_request(&request).await
+    }
+
+    async fn publish_request_to_node(
+        &self,
+        request: &RequestBody,
+        target_node_id: &str,
+    ) -> Result<()> {
+        let target_channel = format!("{}:#node:{}", self.prefix, target_node_id);
+        let request_json = sonic_rs::to_string(request)
+            .map_err(|e| Error::Other(format!("Failed to serialize request: {e}")))?;
+        let mut conn = self.publish_connection.clone();
+
+        let publish_result: redis::RedisResult<()> = if self.use_sharded_pubsub {
+            conn.spublish(&target_channel, &request_json).await
+        } else {
+            conn.publish(&target_channel, &request_json).await
+        };
+
+        publish_result.map_err(|e| {
+            Error::Redis(format!("Failed to publish to node {target_node_id}: {e}"))
+        })?;
+        debug!(
+            "Published request {} to node {} via Redis Cluster",
+            request.request_id, target_node_id
+        );
+        Ok(())
+    }
+
     async fn start_listeners(&self, handlers: TransportHandlers) -> Result<()> {
         // Clone needed values for the async task
         let broadcast_channel = self.broadcast_channel.clone();
@@ -295,6 +340,8 @@ impl HorizontalTransport for RedisClusterTransport {
         let metrics = self.metrics.clone();
         let shutdown = self.shutdown.clone();
         let is_running = self.is_running.clone();
+        let node_channel = format!("{}:#node:{}", self.prefix, handlers.node_id);
+        let reply_channel = self.reply_channel.clone();
 
         // Spawn the main listener task with reconnection logic
         tokio::spawn(async move {
@@ -306,22 +353,127 @@ impl HorizontalTransport for RedisClusterTransport {
                 if !is_running.load(Ordering::Relaxed) {
                     break;
                 }
-                // Create a new channel and client for each connection attempt
-                // This is necessary because the push_sender moves tx into the client,
-                // and when the channel closes, we need a fresh one for reconnection
-                let (tx, rx): (crossfire::MTx<RedisPushChannelFlavor>, RedisPushReceiver) =
-                    mpsc::unbounded_async();
-                let push_sender = move |msg| tx.send(msg).map_err(|_| redis::aio::SendError);
+                let rx: UnifiedRx = if use_sharded_pubsub {
+                    use crate::transports::redis_cluster_sharded_pubsub::ShardedSubscriber;
 
-                let sub_client = match ClusterClientBuilder::new(nodes.clone())
-                    .use_protocol(redis::ProtocolVersion::RESP3)
-                    .push_sender(push_sender)
-                    .build()
-                {
-                    Ok(client) => client,
-                    Err(e) => {
+                    let channels_owned = vec![
+                        broadcast_channel.clone(),
+                        request_channel.clone(),
+                        response_channel.clone(),
+                        node_channel.clone(),
+                        reply_channel.clone(),
+                    ];
+
+                    let subscriber = ShardedSubscriber::new(
+                        channels_owned,
+                        nodes.clone(),
+                        metrics.clone(),
+                        is_running.clone(),
+                        shutdown.clone(),
+                    );
+
+                    match subscriber.start().await {
+                        Ok(sharded_rx) => {
+                            retry_delay = 500;
+                            if reconnection_count > 0 {
+                                debug!(
+                                    "Redis Cluster ShardedSubscriber reconnected after {} attempt(s)",
+                                    reconnection_count
+                                );
+                            }
+                            UnifiedRx::Bounded(sharded_rx)
+                        }
+                        Err(e) => {
+                            reconnection_count += 1;
+                            if let Some(metrics) = metrics.get() {
+                                metrics.mark_horizontal_transport_reconnection("redis_cluster");
+                            }
+                            error!(
+                                "ShardedSubscriber start failed: {e}, retrying in {retry_delay}ms"
+                            );
+                            tokio::select! {
+                                _ = shutdown.notified() => break,
+                                _ = tokio::time::sleep(Duration::from_millis(retry_delay)) => {}
+                            }
+                            retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
+                            continue;
+                        }
+                    }
+                } else {
+                    // Create a new channel and client for each connection attempt.
+                    // This is necessary because the push_sender moves tx into the client,
+                    // and when the channel closes, we need a fresh one for reconnection.
+                    let (tx, rx): (crossfire::MTx<RedisPushChannelFlavor>, RedisPushReceiver) =
+                        mpsc::unbounded_async();
+                    let push_sender = move |msg| tx.send(msg).map_err(|_| redis::aio::SendError);
+
+                    let sub_client = match ClusterClientBuilder::new(nodes.clone())
+                        .use_protocol(redis::ProtocolVersion::RESP3)
+                        .push_sender(push_sender)
+                        .build()
+                    {
+                        Ok(client) => client,
+                        Err(e) => {
+                            error!(
+                                "Failed to create PubSub client: {}, retrying in {}ms",
+                                e, retry_delay
+                            );
+                            tokio::select! {
+                                _ = shutdown.notified() => break,
+                                _ = tokio::time::sleep(Duration::from_millis(retry_delay)) => {}
+                            }
+                            retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
+                            continue;
+                        }
+                    };
+
+                    // Create a connection for PubSub with retry logic
+                    let mut pubsub = match sub_client.get_async_connection().await {
+                        Ok(conn) => {
+                            retry_delay = 500; // Reset retry delay on success
+                            if reconnection_count > 0 {
+                                debug!(
+                                    "Redis Cluster PubSub reconnected successfully after {} attempts",
+                                    reconnection_count
+                                );
+                            }
+                            conn
+                        }
+                        Err(e) => {
+                            reconnection_count += 1;
+                            if let Some(metrics) = metrics.get() {
+                                metrics.mark_horizontal_transport_reconnection("redis_cluster");
+                            }
+                            error!(
+                                "Failed to get pubsub connection: {}, retrying in {}ms (attempt {})",
+                                e, retry_delay, reconnection_count
+                            );
+                            tokio::select! {
+                                _ = shutdown.notified() => break,
+                                _ = tokio::time::sleep(Duration::from_millis(retry_delay)) => {}
+                            }
+                            retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
+                            continue;
+                        }
+                    };
+
+                    // Subscribe to all channels with retry logic
+                    let subscribe_result = pubsub
+                        .subscribe(&[
+                            &broadcast_channel,
+                            &request_channel,
+                            &response_channel,
+                            &node_channel,
+                            &reply_channel,
+                        ])
+                        .await;
+
+                    if let Err(e) = subscribe_result {
+                        if let Some(metrics) = metrics.get() {
+                            metrics.mark_horizontal_transport_reconnection("redis_cluster");
+                        }
                         error!(
-                            "Failed to create PubSub client: {}, retrying in {}ms",
+                            "Failed to subscribe to channels: {}, retrying in {}ms",
                             e, retry_delay
                         );
                         tokio::select! {
@@ -331,72 +483,17 @@ impl HorizontalTransport for RedisClusterTransport {
                         retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
                         continue;
                     }
-                };
 
-                // Create a connection for PubSub with retry logic
-                let mut pubsub = match sub_client.get_async_connection().await {
-                    Ok(conn) => {
-                        retry_delay = 500; // Reset retry delay on success
-                        if reconnection_count > 0 {
-                            debug!(
-                                "Redis Cluster PubSub reconnected successfully after {} attempts",
-                                reconnection_count
-                            );
-                        }
-                        conn
-                    }
-                    Err(e) => {
-                        reconnection_count += 1;
-                        if let Some(metrics) = metrics.get() {
-                            metrics.mark_horizontal_transport_reconnection("redis_cluster");
-                        }
-                        error!(
-                            "Failed to get pubsub connection: {}, retrying in {}ms (attempt {})",
-                            e, retry_delay, reconnection_count
-                        );
-                        tokio::select! {
-                            _ = shutdown.notified() => break,
-                            _ = tokio::time::sleep(Duration::from_millis(retry_delay)) => {}
-                        }
-                        retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
-                        continue;
-                    }
+                    UnifiedRx::Unbounded(rx)
                 };
-
-                // Subscribe to all channels with retry logic
-                // Use SSUBSCRIBE for sharded pub/sub if enabled, otherwise standard SUBSCRIBE
-                let subscribe_result: redis::RedisResult<()> = if use_sharded_pubsub {
-                    redis::cmd("SSUBSCRIBE")
-                        .arg(&broadcast_channel)
-                        .arg(&request_channel)
-                        .arg(&response_channel)
-                        .query_async(&mut pubsub)
-                        .await
-                } else {
-                    pubsub
-                        .subscribe(&[&broadcast_channel, &request_channel, &response_channel])
-                        .await
-                };
-
-                if let Err(e) = subscribe_result {
-                    if let Some(metrics) = metrics.get() {
-                        metrics.mark_horizontal_transport_reconnection("redis_cluster");
-                    }
-                    error!(
-                        "Failed to subscribe to channels: {}, retrying in {}ms",
-                        e, retry_delay
-                    );
-                    tokio::select! {
-                        _ = shutdown.notified() => break,
-                        _ = tokio::time::sleep(Duration::from_millis(retry_delay)) => {}
-                    }
-                    retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
-                    continue;
-                }
 
                 debug!(
-                    "Redis Cluster transport listening on channels: {}, {}, {}",
-                    broadcast_channel, request_channel, response_channel
+                    "Redis Cluster transport listening on channels: {}, {}, {}, {}, {}",
+                    broadcast_channel,
+                    request_channel,
+                    response_channel,
+                    node_channel,
+                    reply_channel
                 );
 
                 // Reset reconnection count on successful subscription
@@ -407,9 +504,13 @@ impl HorizontalTransport for RedisClusterTransport {
                     if !is_running.load(Ordering::Relaxed) {
                         break;
                     }
+                    let recv_future = match &rx {
+                        UnifiedRx::Unbounded(r) => FutureEither::Left(r.recv()),
+                        UnifiedRx::Bounded(r) => FutureEither::Right(r.recv()),
+                    };
                     let recv_result = tokio::select! {
                         _ = shutdown.notified() => break,
-                        result = tokio::time::timeout(Duration::from_millis(100), rx.recv()) => result,
+                        result = tokio::time::timeout(Duration::from_millis(100), recv_future) => result,
                     };
                     let Ok(Ok(push_info)) = recv_result else {
                         if matches!(recv_result, Ok(Err(_))) {
@@ -451,6 +552,8 @@ impl HorizontalTransport for RedisClusterTransport {
                         Broadcast,
                         Request,
                         Response,
+                        NodeRequest,
+                        Reply,
                     }
 
                     let channel_kind = if channel == broadcast_channel.as_str() {
@@ -459,6 +562,10 @@ impl HorizontalTransport for RedisClusterTransport {
                         ChannelKind::Request
                     } else if channel == response_channel.as_str() {
                         ChannelKind::Response
+                    } else if channel == node_channel.as_str() {
+                        ChannelKind::NodeRequest
+                    } else if channel == reply_channel.as_str() {
+                        ChannelKind::Reply
                     } else {
                         continue;
                     };
@@ -490,27 +597,30 @@ impl HorizontalTransport for RedisClusterTransport {
                                 }
                             });
                         }
-                        ChannelKind::Request => {
+                        ChannelKind::Request | ChannelKind::NodeRequest => {
                             let request_handler = handlers.on_request.clone();
                             let publish_conn = publish_connection.clone();
                             let response_channel_clone = response_channel.clone();
                             let metrics_clone = metrics.clone();
+                            let sharded = use_sharded_pubsub;
 
                             tokio::spawn(async move {
                                 if let Ok(request) = sonic_rs::from_str::<RequestBody>(&payload) {
+                                    let reply_to = request.reply_to.clone();
                                     let response_result = request_handler(request).await;
 
                                     if let Ok(response) = response_result
                                         && let Ok(response_json) = sonic_rs::to_string(&response)
                                     {
-                                        // Clone connection (cheap) instead of creating new one
+                                        let target = reply_to.unwrap_or(response_channel_clone);
+                                        // Clone connection (cheap, thread-safe per redis-rs docs)
                                         let mut conn = publish_conn.clone();
-                                        let _ = conn
-                                            .publish::<_, _, ()>(
-                                                &response_channel_clone,
-                                                response_json,
-                                            )
-                                            .await;
+
+                                        let _: redis::RedisResult<()> = if sharded {
+                                            conn.spublish(&target, &response_json).await
+                                        } else {
+                                            conn.publish(&target, response_json).await
+                                        };
                                     }
                                 } else if let Some(metrics) = metrics_clone.get() {
                                     metrics
@@ -519,6 +629,19 @@ impl HorizontalTransport for RedisClusterTransport {
                             });
                         }
                         ChannelKind::Response => {
+                            let response_handler = handlers.on_response.clone();
+                            let metrics_clone = metrics.clone();
+
+                            tokio::spawn(async move {
+                                if let Ok(response) = sonic_rs::from_str::<ResponseBody>(&payload) {
+                                    response_handler(response).await;
+                                } else if let Some(metrics) = metrics_clone.get() {
+                                    metrics
+                                        .mark_horizontal_transport_message_dropped("redis_cluster");
+                                }
+                            });
+                        }
+                        ChannelKind::Reply => {
                             let response_handler = handlers.on_response.clone();
                             let metrics_clone = metrics.clone();
 
@@ -551,36 +674,45 @@ impl HorizontalTransport for RedisClusterTransport {
     }
 
     async fn get_node_count(&self) -> Result<usize> {
+        if !self.use_sharded_pubsub {
+            return Ok(1);
+        }
+
+        use redis::cluster_routing::{Route, RoutingInfo, SingleNodeRoutingInfo, Slot, SlotAddr};
+
+        // PUBSUB SHARDNUMSUB must target the shard master that owns the
+        // request channel's slot. redis-rs routes this command to AllNodes
+        // by default, so we force SpecificNode routing via route_command.
+        let slot = Slot::for_key(&self.request_channel);
+        let routing = RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(
+            Route::with_slot(slot, SlotAddr::Master),
+        ));
+
+        let mut cmd = redis::cmd("PUBSUB");
+        cmd.arg("SHARDNUMSUB").arg(&self.request_channel);
+
         // Clone connection (cheap, thread-safe per redis-rs docs)
         let mut conn = self.publish_connection.clone();
-
-        let result: redis::RedisResult<Vec<redis::Value>> = redis::cmd("PUBSUB")
-            .arg("NUMSUB")
-            .arg(&self.request_channel)
-            .query_async(&mut conn)
-            .await;
+        let result = conn.route_command(cmd, routing).await;
 
         match result {
-            Ok(values) => {
-                if values.len() >= 2 {
-                    if let redis::Value::Int(count) = values[1] {
-                        Ok((count as usize).max(1))
-                    } else {
-                        Ok(1)
-                    }
+            Ok(redis::Value::Array(values)) if values.len() >= 2 => {
+                if let redis::Value::Int(count) = values[1] {
+                    Ok((count as usize).max(1))
                 } else {
                     Ok(1)
                 }
             }
+            Ok(_) => Ok(1),
             Err(e) => {
-                error!("Failed to execute PUBSUB NUMSUB: {}", e);
+                error!("get_node_count: SHARDNUMSUB on shard master failed: {e}");
                 Ok(1)
             }
         }
     }
 
     fn node_count_is_real_time(&self) -> bool {
-        true
+        self.use_sharded_pubsub
     }
 
     async fn check_health(&self) -> Result<()> {
@@ -628,6 +760,8 @@ impl Clone for RedisClusterTransport {
             response_channel: self.response_channel.clone(),
             config: self.config.clone(),
             use_sharded_pubsub: self.use_sharded_pubsub,
+            prefix: self.prefix.clone(),
+            reply_channel: self.reply_channel.clone(),
             metrics: self.metrics.clone(),
             shutdown: self.shutdown.clone(),
             is_running: self.is_running.clone(),

--- a/crates/sockudo-adapter/src/transports/redis_transport.rs
+++ b/crates/sockudo-adapter/src/transports/redis_transport.rs
@@ -10,6 +10,7 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::sync::Notify;
 use tracing::{debug, error, warn};
+use uuid::Uuid;
 
 /// Redis adapter configuration
 #[derive(Debug, Clone)]
@@ -49,6 +50,8 @@ pub struct RedisTransport {
     broadcast_channel: String,
     request_channel: String,
     response_channel: String,
+    prefix: String,
+    reply_channel: String,
     metrics: Arc<OnceLock<Arc<dyn MetricsInterface + Send + Sync>>>,
     shutdown: Arc<Notify>,
     is_running: Arc<AtomicBool>,
@@ -87,6 +90,7 @@ impl HorizontalTransport for RedisTransport {
         let broadcast_channel = format!("{}:#broadcast", config.prefix);
         let request_channel = format!("{}:#requests", config.prefix);
         let response_channel = format!("{}:#responses", config.prefix);
+        let reply_channel = format!("{}:#reply:{}", config.prefix, Uuid::new_v4().as_simple());
 
         Ok(Self {
             client,
@@ -95,6 +99,8 @@ impl HorizontalTransport for RedisTransport {
             broadcast_channel,
             request_channel,
             response_channel,
+            prefix: config.prefix.clone(),
+            reply_channel,
             metrics: Arc::new(OnceLock::new()),
             shutdown: Arc::new(Notify::new()),
             is_running: Arc::new(AtomicBool::new(true)),
@@ -179,12 +185,50 @@ impl HorizontalTransport for RedisTransport {
         Ok(())
     }
 
+    fn new_inbox(&self) -> Option<String> {
+        Some(self.reply_channel.clone())
+    }
+
+    async fn publish_request_with_reply(
+        &self,
+        request: &RequestBody,
+        reply_to: &str,
+    ) -> Result<()> {
+        let mut request = request.clone();
+        request.reply_to = Some(reply_to.to_string());
+        self.publish_request(&request).await
+    }
+
+    async fn publish_request_to_node(
+        &self,
+        request: &RequestBody,
+        target_node_id: &str,
+    ) -> Result<()> {
+        let target_channel = format!("{}:#node:{}", self.prefix, target_node_id);
+        let request_json = sonic_rs::to_string(request)
+            .map_err(|e| Error::Other(format!("Failed to serialize request: {e}")))?;
+        let mut conn = self.connection.clone();
+        let _: i32 = conn
+            .publish(&target_channel, &request_json)
+            .await
+            .map_err(|e| {
+                Error::Redis(format!("Failed to publish to node {target_node_id}: {e}"))
+            })?;
+        debug!(
+            "Published request {} to node {} via Redis",
+            request.request_id, target_node_id
+        );
+        Ok(())
+    }
+
     async fn start_listeners(&self, handlers: TransportHandlers) -> Result<()> {
         let sub_client = self.client.clone();
         let pub_connection = self.connection.clone();
         let broadcast_channel = self.broadcast_channel.clone();
         let request_channel = self.request_channel.clone();
         let response_channel = self.response_channel.clone();
+        let node_channel = format!("{}:#node:{}", self.prefix, handlers.node_id);
+        let reply_channel = self.reply_channel.clone();
         let metrics = self.metrics.clone();
         let shutdown = self.shutdown.clone();
         let is_running = self.is_running.clone();
@@ -220,7 +264,13 @@ impl HorizontalTransport for RedisTransport {
                 };
 
                 if let Err(e) = pubsub
-                    .subscribe(&[&broadcast_channel, &request_channel, &response_channel])
+                    .subscribe(&[
+                        &broadcast_channel,
+                        &request_channel,
+                        &response_channel,
+                        &node_channel,
+                        &reply_channel,
+                    ])
                     .await
                 {
                     error!(
@@ -236,8 +286,12 @@ impl HorizontalTransport for RedisTransport {
                 }
 
                 debug!(
-                    "Redis transport listening on channels: {}, {}, {}",
-                    broadcast_channel, request_channel, response_channel
+                    "Redis transport listening on channels: {}, {}, {}, {}, {}",
+                    broadcast_channel,
+                    request_channel,
+                    response_channel,
+                    node_channel,
+                    reply_channel
                 );
 
                 let mut message_stream = pubsub.on_message();
@@ -271,7 +325,9 @@ impl HorizontalTransport for RedisTransport {
                                     metrics.mark_horizontal_transport_message_dropped("redis");
                                 }
                             });
-                        } else if channel == request_channel.as_str() {
+                        } else if channel == request_channel.as_str()
+                            || channel == node_channel.as_str()
+                        {
                             let request_handler = handlers.on_request.clone();
                             let pub_connection_clone = pub_connection.clone();
                             let response_channel_clone = response_channel.clone();
@@ -279,24 +335,25 @@ impl HorizontalTransport for RedisTransport {
 
                             tokio::spawn(async move {
                                 if let Ok(request) = sonic_rs::from_str::<RequestBody>(&payload) {
+                                    let reply_to = request.reply_to.clone();
                                     let response_result = request_handler(request).await;
 
                                     if let Ok(response) = response_result
                                         && let Ok(response_json) = sonic_rs::to_string(&response)
                                     {
+                                        let target =
+                                            reply_to.unwrap_or(response_channel_clone.clone());
                                         let mut conn = pub_connection_clone.clone();
-                                        let _ = conn
-                                            .publish::<_, _, ()>(
-                                                &response_channel_clone,
-                                                response_json,
-                                            )
-                                            .await;
+                                        let _ =
+                                            conn.publish::<_, _, ()>(&target, response_json).await;
                                     }
                                 } else if let Some(metrics) = metrics_clone.get() {
                                     metrics.mark_horizontal_transport_message_dropped("redis");
                                 }
                             });
-                        } else if channel == response_channel.as_str() {
+                        } else if channel == response_channel.as_str()
+                            || channel == reply_channel.as_str()
+                        {
                             let response_handler = handlers.on_response.clone();
                             let metrics_clone = metrics.clone();
 
@@ -430,6 +487,8 @@ impl Clone for RedisTransport {
             broadcast_channel: self.broadcast_channel.clone(),
             request_channel: self.request_channel.clone(),
             response_channel: self.response_channel.clone(),
+            prefix: self.prefix.clone(),
+            reply_channel: self.reply_channel.clone(),
             metrics: self.metrics.clone(),
             shutdown: self.shutdown.clone(),
             is_running: self.is_running.clone(),

--- a/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
@@ -35,6 +35,7 @@ async fn test_heartbeat_tracking_updates_node_registry() {
         timestamp: Some(1234567890),
         dead_node_id: None,
         target_node_id: None,
+        reply_to: None,
         channels: None,
     };
 
@@ -384,6 +385,7 @@ async fn test_follower_cleanup_only_removes_registry_data() {
         timestamp: Some(1234567890),
         dead_node_id: Some(dead_node_id.to_string()),
         target_node_id: None,
+        reply_to: None,
         channels: None,
     };
 

--- a/crates/sockudo-adapter/tests/adapter/graceful_departure_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/graceful_departure_tests.rs
@@ -66,6 +66,7 @@ async fn test_receiving_node_dead_prunes_peer_heartbeat() {
         timestamp: Some(current_timestamp()),
         dead_node_id: Some("peer-node".to_string()),
         target_node_id: None,
+        reply_to: None,
         channels: None,
     };
 

--- a/crates/sockudo-adapter/tests/adapter/presence_state_consistency_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_state_consistency_tests.rs
@@ -110,6 +110,7 @@ async fn test_presence_state_with_clock_skew() {
         timestamp: Some(1000), // Earlier timestamp
         dead_node_id: None,
         target_node_id: None,
+        reply_to: None,
         channels: None,
     };
 
@@ -125,6 +126,7 @@ async fn test_presence_state_with_clock_skew() {
         timestamp: Some(2000), // Later timestamp
         dead_node_id: None,
         target_node_id: None,
+        reply_to: None,
         channels: None,
     };
 

--- a/crates/sockudo-adapter/tests/adapter/transports/redis_cluster_transport_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/redis_cluster_transport_test.rs
@@ -356,3 +356,155 @@ async fn test_cluster_sharding() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_redis_cluster_new_inbox_returns_reply_channel() {
+    let config = get_redis_cluster_config();
+    let Ok(transport) = RedisClusterTransport::new(config).await else {
+        return; // Skip if Redis Cluster not available
+    };
+
+    let inbox = transport.new_inbox();
+    assert!(inbox.is_some(), "new_inbox() should return Some");
+    let channel = inbox.unwrap();
+    assert!(
+        channel.contains(":#reply:"),
+        "Channel name should contain ':#reply:', got: {channel}"
+    );
+
+    let inbox2 = transport.new_inbox();
+    assert_eq!(
+        inbox2,
+        Some(channel),
+        "new_inbox() should return the same value on repeated calls"
+    );
+}
+
+#[tokio::test]
+async fn test_redis_cluster_publish_request_to_node() {
+    let config = get_redis_cluster_config();
+    let Ok(transport) = RedisClusterTransport::new(config).await else {
+        return; // Skip if Redis Cluster not available
+    };
+
+    let request = create_test_request();
+    let result = transport
+        .publish_request_to_node(&request, "test-target-node")
+        .await;
+    assert!(
+        result.is_ok(),
+        "publish_request_to_node should return Ok, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_redis_cluster_node_count_is_real_time_conditional() {
+    let config_sharded = RedisClusterAdapterConfig {
+        nodes: vec![
+            "redis://127.0.0.1:7003".to_string(),
+            "redis://127.0.0.1:7001".to_string(),
+            "redis://127.0.0.1:7002".to_string(),
+        ],
+        prefix: "test_sharded_rt".to_string(),
+        request_timeout_ms: 1000,
+        use_connection_manager: false,
+        use_sharded_pubsub: true,
+    };
+    let Ok(transport_sharded) = RedisClusterTransport::new(config_sharded).await else {
+        return; // Skip if Redis Cluster not available
+    };
+    assert!(
+        transport_sharded.node_count_is_real_time(),
+        "node_count_is_real_time() should return true when use_sharded_pubsub is true"
+    );
+
+    let config_standard = get_redis_cluster_config();
+    let Ok(transport_standard) = RedisClusterTransport::new(config_standard).await else {
+        return;
+    };
+    assert!(
+        !transport_standard.node_count_is_real_time(),
+        "node_count_is_real_time() should return false when use_sharded_pubsub is false"
+    );
+}
+
+#[tokio::test]
+async fn test_redis_cluster_two_transports_have_different_reply_channels() {
+    let config = get_redis_cluster_config();
+    let Ok(transport1) = RedisClusterTransport::new(config.clone()).await else {
+        return; // Skip if Redis Cluster not available
+    };
+    let Ok(transport2) = RedisClusterTransport::new(config).await else {
+        return;
+    };
+
+    let channel1 = transport1.new_inbox();
+    let channel2 = transport2.new_inbox();
+
+    assert!(
+        channel1.is_some(),
+        "transport1 new_inbox() should return Some"
+    );
+    assert!(
+        channel2.is_some(),
+        "transport2 new_inbox() should return Some"
+    );
+    assert_ne!(
+        channel1, channel2,
+        "Two transport instances should have different reply channels"
+    );
+}
+
+#[tokio::test]
+async fn test_redis_cluster_reply_channel_format() {
+    let known_prefix = "test_reply_format_prefix";
+    let config = RedisClusterAdapterConfig {
+        nodes: vec![
+            "redis://127.0.0.1:7003".to_string(),
+            "redis://127.0.0.1:7001".to_string(),
+            "redis://127.0.0.1:7002".to_string(),
+        ],
+        prefix: known_prefix.to_string(),
+        request_timeout_ms: 1000,
+        use_connection_manager: false,
+        use_sharded_pubsub: false,
+    };
+    let Ok(transport) = RedisClusterTransport::new(config).await else {
+        return; // Skip if Redis Cluster not available
+    };
+
+    let inbox = transport.new_inbox();
+    assert!(inbox.is_some(), "new_inbox() should return Some");
+    let channel = inbox.unwrap();
+
+    assert!(
+        channel.starts_with(known_prefix),
+        "Reply channel should start with prefix '{known_prefix}', got: {channel}"
+    );
+    assert!(
+        channel.contains(":#reply:"),
+        "Reply channel should contain ':#reply:', got: {channel}"
+    );
+}
+
+#[tokio::test]
+async fn test_redis_cluster_publish_request_with_reply() {
+    let config = get_redis_cluster_config();
+    let Ok(transport) = RedisClusterTransport::new(config).await else {
+        return;
+    };
+
+    let inbox = transport.new_inbox().expect("new_inbox() must return Some");
+    let request = create_test_request();
+    assert!(
+        request.reply_to.is_none(),
+        "request must start with reply_to: None"
+    );
+
+    let result = transport.publish_request_with_reply(&request, &inbox).await;
+    assert!(
+        result.is_ok(),
+        "publish_request_with_reply should succeed: {:?}",
+        result.err()
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/transports/redis_transport_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/redis_transport_test.rs
@@ -388,3 +388,182 @@ async fn test_request_response_flow() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_redis_new_inbox_returns_reply_channel() -> Result<()> {
+    let config = get_redis_config();
+    let transport = match RedisTransport::new(config).await {
+        Ok(t) => t,
+        Err(_) => {
+            println!("Skipping test_redis_new_inbox_returns_reply_channel: Redis not available");
+            return Ok(());
+        }
+    };
+
+    let inbox = transport.new_inbox();
+    assert!(inbox.is_some(), "new_inbox() should return Some");
+
+    let channel = inbox.unwrap();
+    assert!(
+        channel.contains(":#reply:"),
+        "reply channel must contain ':#reply:', got: {channel}"
+    );
+
+    let inbox2 = transport.new_inbox();
+    assert_eq!(
+        inbox2.as_deref(),
+        Some(channel.as_str()),
+        "new_inbox() should return the same channel on every call for the same instance"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_redis_publish_request_with_reply_sets_reply_to() -> Result<()> {
+    let config = get_redis_config();
+    let transport = match RedisTransport::new(config).await {
+        Ok(t) => t,
+        Err(_) => {
+            println!(
+                "Skipping test_redis_publish_request_with_reply_sets_reply_to: Redis not available"
+            );
+            return Ok(());
+        }
+    };
+
+    let inbox = transport.new_inbox();
+    assert!(
+        inbox.is_some(),
+        "new_inbox() must be Some before publishing"
+    );
+    let inbox_channel = inbox.unwrap();
+    assert!(!inbox_channel.is_empty());
+
+    let request = create_test_request();
+    assert!(
+        request.reply_to.is_none(),
+        "request must start with reply_to: None"
+    );
+
+    let result = transport
+        .publish_request_with_reply(&request, &inbox_channel)
+        .await;
+    assert!(
+        result.is_ok(),
+        "publish_request_with_reply should succeed: {:?}",
+        result.err()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_redis_publish_request_to_node_uses_correct_channel() -> Result<()> {
+    let config = get_redis_config();
+    let transport = match RedisTransport::new(config).await {
+        Ok(t) => t,
+        Err(_) => {
+            println!(
+                "Skipping test_redis_publish_request_to_node_uses_correct_channel: Redis not available"
+            );
+            return Ok(());
+        }
+    };
+
+    let request = create_test_request();
+
+    let result = transport
+        .publish_request_to_node(&request, "test-target-node")
+        .await;
+    assert!(
+        result.is_ok(),
+        "publish_request_to_node should succeed: {:?}",
+        result.err()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_redis_two_transports_have_different_reply_channels() -> Result<()> {
+    let config = get_redis_config();
+
+    let transport_a = match RedisTransport::new(config.clone()).await {
+        Ok(t) => t,
+        Err(_) => {
+            println!(
+                "Skipping test_redis_two_transports_have_different_reply_channels: Redis not available"
+            );
+            return Ok(());
+        }
+    };
+    let transport_b = match RedisTransport::new(config).await {
+        Ok(t) => t,
+        Err(_) => {
+            println!(
+                "Skipping test_redis_two_transports_have_different_reply_channels: Redis not available"
+            );
+            return Ok(());
+        }
+    };
+
+    let inbox_a = transport_a
+        .new_inbox()
+        .expect("transport_a must have an inbox");
+    let inbox_b = transport_b
+        .new_inbox()
+        .expect("transport_b must have an inbox");
+
+    assert_ne!(
+        inbox_a, inbox_b,
+        "Each transport instance must have a unique reply channel (different UUIDs)"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_redis_reply_channel_format() -> Result<()> {
+    let config = get_redis_config();
+    let prefix = config.prefix.clone();
+
+    let transport = match RedisTransport::new(config).await {
+        Ok(t) => t,
+        Err(_) => {
+            println!("Skipping test_redis_reply_channel_format: Redis not available");
+            return Ok(());
+        }
+    };
+
+    let channel = transport
+        .new_inbox()
+        .expect("new_inbox() should return Some");
+
+    assert!(
+        channel.starts_with(&prefix),
+        "reply channel must start with prefix '{prefix}', got: {channel}"
+    );
+
+    assert!(
+        channel.contains(":#reply:"),
+        "reply channel must contain ':#reply:', got: {channel}"
+    );
+
+    let suffix = channel
+        .split(":#reply:")
+        .nth(1)
+        .expect("channel must have a suffix after ':#reply:'");
+    assert!(
+        suffix.len() >= 32,
+        "UUID suffix must be at least 32 chars, got '{}' (len {})",
+        suffix,
+        suffix.len()
+    );
+    assert!(
+        suffix.chars().all(|c| c.is_ascii_hexdigit()),
+        "UUID suffix must be lowercase hex, got: '{suffix}'"
+    );
+
+    Ok(())
+}

--- a/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
@@ -93,6 +93,7 @@ pub fn create_test_request() -> RequestBody {
         timestamp: None,
         dead_node_id: None,
         target_node_id: None,
+        reply_to: None,
         channels: None,
     }
 }


### PR DESCRIPTION
Introduce per-node response routing so broadcast replies reach only the requesting node instead of all subscribers. Add a dedicated sharded pub/sub transport for Redis Cluster that distributes channels across slots, and fix dynamic node counting in sharded mode.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->