### PR TITLE
fix(metrics): replace active_channels cross-node recount with local inc/dec

### DIFF
--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -98,13 +98,7 @@ impl ConnectionHandler {
 
             // Update active channel count if this was the last connection to the channel
             if current_sub_count == 0 {
-                super::sync_active_channel_count(
-                    &self.connection_manager,
-                    metrics,
-                    &app_config.id,
-                    channel_type_str,
-                )
-                .await;
+                metrics.mark_channel_deactivated(&app_config.id, channel_type_str);
             }
         }
 
@@ -604,19 +598,17 @@ impl ConnectionHandler {
 
         match ChannelManager::batch_unsubscribe(&self.connection_manager, operations).await {
             Ok(results) => {
-                // Collect channel types that became empty so we can sync the gauge once per type
-                let mut types_to_sync: HashSet<String> = HashSet::new();
-
                 // Process webhook events for each successful unsubscribe
                 for (channel_name, result) in &results {
                     match result {
                         Ok((was_removed, remaining_connections)) => {
-                            if *remaining_connections == 0 {
-                                types_to_sync.insert(
+                            if *remaining_connections == 0
+                                && let Some(ref metrics) = self.metrics
+                            {
+                                let channel_type =
                                     sockudo_core::channel::ChannelType::from_name(channel_name)
-                                        .as_str()
-                                        .to_string(),
-                                );
+                                        .as_str();
+                                metrics.mark_channel_deactivated(&app_config.id, channel_type);
                             }
                             if *was_removed {
                                 self.handle_post_unsubscribe_webhooks(
@@ -635,18 +627,6 @@ impl ConnectionHandler {
                                 socket_id, channel_name, e
                             );
                         }
-                    }
-                }
-
-                if let Some(ref metrics) = self.metrics {
-                    for channel_type in &types_to_sync {
-                        super::sync_active_channel_count(
-                            &self.connection_manager,
-                            metrics,
-                            &app_config.id,
-                            channel_type,
-                        )
-                        .await;
                     }
                 }
             }

--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -824,33 +824,3 @@ impl ConnectionHandler {
         debug!("Socket {} cleanup completed", socket_id);
     }
 }
-
-/// Sync the active channel gauge for a given channel type by recounting live channels
-/// from the DashMap.
-pub async fn sync_active_channel_count(
-    connection_manager: &Arc<dyn ConnectionManager + Send + Sync>,
-    metrics: &Arc<dyn MetricsInterface + Send + Sync>,
-    app_id: &str,
-    channel_type: &str,
-) {
-    let channels_map = match connection_manager
-        .get_channels_with_socket_count(app_id)
-        .await
-    {
-        Ok(map) => map,
-        Err(e) => {
-            error!("Failed to get channels for metrics sync: {}", e);
-            return;
-        }
-    };
-
-    let count = channels_map
-        .iter()
-        .filter(|(name, cnt)| {
-            **cnt > 0
-                && sockudo_core::channel::ChannelType::from_name(name).as_str() == channel_type
-        })
-        .count() as i64;
-
-    metrics.update_active_channels(app_id, channel_type, count);
-}

--- a/crates/sockudo-adapter/src/handler/recovery.rs
+++ b/crates/sockudo-adapter/src/handler/recovery.rs
@@ -742,7 +742,7 @@ mod tests {
         }
         fn mark_channel_subscription(&self, _app_id: &str, _channel_type: &str) {}
         fn mark_channel_unsubscription(&self, _app_id: &str, _channel_type: &str) {}
-        fn update_active_channels(&self, _app_id: &str, _channel_type: &str, _count: i64) {}
+
         fn mark_api_message(
             &self,
             _app_id: &str,

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -214,13 +214,7 @@ impl ConnectionHandler {
 
             // Sync active channel gauge if this is the first connection to the channel
             if subscription_result.channel_connections == Some(1) {
-                super::sync_active_channel_count(
-                    &self.connection_manager,
-                    metrics,
-                    &app_config.id,
-                    channel_type_str,
-                )
-                .await;
+                metrics.mark_channel_activated(&app_config.id, channel_type_str);
             }
         }
         let t_after_metrics = t_start.elapsed().as_micros();

--- a/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
+++ b/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
@@ -362,7 +362,7 @@ impl MetricsInterface for MockMetricsInterface {
     }
     fn mark_channel_subscription(&self, _app_id: &str, _channel_type: &str) {}
     fn mark_channel_unsubscription(&self, _app_id: &str, _channel_type: &str) {}
-    fn update_active_channels(&self, _app_id: &str, _channel_type: &str, _count: i64) {}
+
     fn mark_api_message(
         &self,
         _app_id: &str,

--- a/crates/sockudo-core/src/metrics.rs
+++ b/crates/sockudo-core/src/metrics.rs
@@ -45,8 +45,11 @@ pub trait MetricsInterface: Send + Sync {
     /// Track a channel unsubscription
     fn mark_channel_unsubscription(&self, app_id: &str, channel_type: &str);
 
-    /// Update the count of active channels
-    fn update_active_channels(&self, app_id: &str, channel_type: &str, count: i64);
+    /// Track a channel activation
+    fn mark_channel_activated(&self, _app_id: &str, _channel_type: &str) {}
+
+    /// Track a channel deactivation
+    fn mark_channel_deactivated(&self, _app_id: &str, _channel_type: &str) {}
 
     /// Handle a new API message event being received and sent out
     fn mark_api_message(

--- a/crates/sockudo-metrics/src/prometheus.rs
+++ b/crates/sockudo-metrics/src/prometheus.rs
@@ -1681,20 +1681,18 @@ impl MetricsInterface for PrometheusMetricsDriver {
         );
     }
 
-    fn update_active_channels(&self, app_id: &str, channel_type: &str, count: i64) {
-        let tags = vec![
-            app_id.to_string(),
-            self.port.to_string(),
-            channel_type.to_string(),
-        ];
+    fn mark_channel_activated(&self, app_id: &str, channel_type: &str) {
+        let port = self.port.to_string();
         self.active_channels
-            .with_label_values(&tags)
-            .set(count as f64);
+            .with_label_values(&[app_id, &port, channel_type])
+            .inc();
+    }
 
-        debug!(
-            "Metrics: Active channels updated for app {}, channel type: {}, count: {}",
-            app_id, channel_type, count
-        );
+    fn mark_channel_deactivated(&self, app_id: &str, channel_type: &str) {
+        let port = self.port.to_string();
+        self.active_channels
+            .with_label_values(&[app_id, &port, channel_type])
+            .dec();
     }
 
     fn mark_api_message(

--- a/crates/sockudo-server/src/cleanup/worker.rs
+++ b/crates/sockudo-server/src/cleanup/worker.rs
@@ -2,7 +2,6 @@ use super::{CleanupConfig, ConnectionCleanupInfo, DisconnectTask, WebhookEvent};
 use ahash::AHashMap;
 use sockudo_adapter::channel_manager::ChannelManager;
 use sockudo_adapter::connection_manager::ConnectionManager;
-use sockudo_adapter::handler::sync_active_channel_count;
 use sockudo_adapter::presence::global_presence_manager;
 use sockudo_core::app::AppManager;
 use sockudo_core::channel::ChannelType;
@@ -11,7 +10,6 @@ use sockudo_core::options::PresenceHistoryConfig;
 use sockudo_core::presence_history::{PresenceHistoryEventCause, PresenceHistoryStore};
 use sockudo_core::websocket::SocketId;
 use sockudo_webhook::WebhookIntegration;
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::timeout;
@@ -197,16 +195,16 @@ impl CleanupWorker {
 
             match ChannelManager::batch_unsubscribe(&self.connection_manager, operations).await {
                 Ok(results) => {
-                    let mut types_to_sync: HashSet<String> = HashSet::new();
-
                     for (channel_name, result) in &results {
                         match result {
                             Ok((_, remaining_connections)) => {
                                 total_success += 1;
-                                if *remaining_connections == 0 {
-                                    types_to_sync.insert(
-                                        ChannelType::from_name(channel_name).as_str().to_string(),
-                                    );
+                                if *remaining_connections == 0
+                                    && let Some(ref metrics) = self.metrics
+                                {
+                                    let channel_type =
+                                        ChannelType::from_name(channel_name).as_str();
+                                    metrics.mark_channel_deactivated(&app_id, channel_type);
                                 }
                             }
                             Err(e) => {
@@ -216,18 +214,6 @@ impl CleanupWorker {
                                     app_id, e
                                 );
                             }
-                        }
-                    }
-
-                    if let Some(ref metrics) = self.metrics {
-                        for channel_type in &types_to_sync {
-                            sync_active_channel_count(
-                                &self.connection_manager,
-                                metrics,
-                                &app_id,
-                                channel_type,
-                            )
-                            .await;
                         }
                     }
                 }


### PR DESCRIPTION
sync_active_channel_count() queried ALL nodes for their FULL channel lists every time any channel hit 0 subscribers during cleanup — just to compute a single gauge integer. This created significant cross-node pub/sub fan-out traffic proportional to cluster size × channel count.

Each pod now maintains its own local active_channels gauge via atomic inc/dec at subscribe/unsubscribe boundaries. No cross-node communication for metric updates.

BREAKING: use sum(sockudo_active_channels) instead of max() to get total active channels across the cluster.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->