### PR TITLE
fix(metrics): count active_channels by local node transitions

### DIFF
--- a/crates/sockudo-adapter/src/channel_manager.rs
+++ b/crates/sockudo-adapter/src/channel_manager.rs
@@ -33,6 +33,10 @@ pub struct JoinResponse {
     pub(crate) success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel_connections: Option<usize>,
+    /// This subscribe took the channel from 0 to 1 on the local node. Drives the
+    /// per-pod active-channels gauge.
+    #[serde(default)]
+    pub activated_locally: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,11 +83,13 @@ impl ChannelManager {
 
     fn create_success_join_response(
         channel_connections: usize,
+        activated_locally: bool,
         member: Option<PresenceMember>,
     ) -> JoinResponse {
         JoinResponse {
             success: true,
             channel_connections: Some(channel_connections),
+            activated_locally,
             member,
             auth_error: None,
             error_message: None,
@@ -136,7 +142,7 @@ impl ChannelManager {
 
         // Single lock acquisition for check and add (reduces lock contention)
         let t_before_lock = t_start.elapsed().as_micros();
-        let (is_already_in_channel, total_connections) = {
+        let (is_already_in_channel, total_connections, activated_locally) = {
             // Check if already in channel
             let already_in = connection_manager
                 .is_in_channel(app_id, channel_name, &socket_id_owned)
@@ -147,7 +153,7 @@ impl ChannelManager {
                 let count = connection_manager
                     .get_channel_socket_count(app_id, channel_name)
                     .await;
-                (true, count)
+                (true, count, false)
             } else {
                 // Need to add to channel
                 connection_manager
@@ -156,7 +162,11 @@ impl ChannelManager {
                 let count = connection_manager
                     .get_channel_socket_count(app_id, channel_name)
                     .await;
-                (false, count)
+                // Local count drives the per-pod gauge: activate on the first local subscriber.
+                let local = connection_manager
+                    .get_local_channel_socket_count(app_id, channel_name)
+                    .await;
+                (false, count, local == 1)
             }
         };
         let t_after_lock = t_start.elapsed().as_micros();
@@ -172,6 +182,7 @@ impl ChannelManager {
             return Ok(JoinResponse {
                 success: true,
                 channel_connections: Some(total_connections),
+                activated_locally,
                 member: None,
                 auth_error: None,
                 error_message: None,
@@ -192,6 +203,7 @@ impl ChannelManager {
 
         Ok(Self::create_success_join_response(
             total_connections,
+            activated_locally,
             member,
         ))
     }
@@ -454,13 +466,17 @@ impl ChannelManager {
             .await
     }
 
-    /// Batch unsubscribe operation for multiple channels
+    /// Batch unsubscribe operation for multiple channels.
     /// Returns results with channel names for explicit correlation.
     /// Uses a single batched cross-node query instead of one per channel.
+    ///
+    /// Each result is `(was_removed, total_remaining, local_vacated)`.
+    /// `total_remaining` is cluster-wide (for webhooks and subscription_count).
+    /// `local_vacated` is true when the channel became empty on the local node.
     pub async fn batch_unsubscribe(
         connection_manager: &Arc<dyn ConnectionManager + Send + Sync>,
         operations: Vec<(String, String, String)>, // (socket_id, channel_name, app_id)
-    ) -> Result<Vec<(String, Result<(bool, usize), Error>)>, Error> {
+    ) -> Result<Vec<(String, Result<(bool, usize, bool), Error>)>, Error> {
         if operations.is_empty() {
             return Ok(Vec::new());
         }
@@ -559,7 +575,8 @@ impl ChannelManager {
                     if total == 0 {
                         channels_to_cleanup.push((app_id, channel_name.clone()));
                     }
-                    results.push((channel_name, Ok((was_removed, total))));
+                    let local_vacated = was_removed && local_remaining == 0;
+                    results.push((channel_name, Ok((was_removed, total, local_vacated))));
                 }
                 Err((channel_name, e)) => {
                     results.push((channel_name, Err(e)));

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -67,7 +67,7 @@ impl ConnectionHandler {
             .clear_channel_state(socket_id, &channel_name);
 
         // Perform unsubscription through channel manager
-        ChannelManager::unsubscribe(
+        let leave_response = ChannelManager::unsubscribe(
             &self.connection_manager,
             &socket_id.to_string(),
             &channel_name,
@@ -80,7 +80,8 @@ impl ConnectionHandler {
         self.update_connection_unsubscribe_state(socket_id, app_config, &channel_name)
             .await?;
 
-        // Get current subscription count after unsubscribe
+        // Get current subscription count after unsubscribe (cluster-wide, used
+        // for subscription_count / channel_vacated events and webhooks below).
         let current_sub_count = self
             .connection_manager
             .get_channel_socket_count(&app_config.id, &channel_name)
@@ -96,8 +97,12 @@ impl ConnectionHandler {
                 metrics.mark_channel_unsubscription(&app_config.id, channel_type_str);
             }
 
-            // Update active channel count if this was the last connection to the channel
-            if current_sub_count == 0 {
+            // Per-pod gauge: deactivate when the channel empties on this node, not cluster-wide.
+            let local_sub_count = self
+                .connection_manager
+                .get_local_channel_socket_count(&app_config.id, &channel_name)
+                .await;
+            if leave_response.left && local_sub_count == 0 {
                 metrics.mark_channel_deactivated(&app_config.id, channel_type_str);
             }
         }
@@ -601,10 +606,9 @@ impl ConnectionHandler {
                 // Process webhook events for each successful unsubscribe
                 for (channel_name, result) in &results {
                     match result {
-                        Ok((was_removed, remaining_connections)) => {
-                            if *remaining_connections == 0
-                                && let Some(ref metrics) = self.metrics
-                            {
+                        Ok((was_removed, remaining_connections, local_vacated)) => {
+                            // Per-pod gauge: decrement when the channel empties on this node.
+                            if *local_vacated && let Some(ref metrics) = self.metrics {
                                 let channel_type =
                                     sockudo_core::channel::ChannelType::from_name(channel_name)
                                         .as_str();

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -104,7 +104,7 @@ impl ConnectionHandler {
                 }
 
                 match fast_result {
-                    Some(channel_connections) => {
+                    Some((channel_connections, newly_subscribed)) => {
                         let t_after_fast = t_start.elapsed().as_micros();
                         tracing::debug!(
                             "PERF[FAST_PATH] socket_id={} channel={} total={}μs channel_type={}μs",
@@ -116,6 +116,8 @@ impl ConnectionHandler {
                         JoinResponse {
                             success: true,
                             channel_connections: Some(channel_connections),
+                            // Fast path is local-only, so this is the local count.
+                            activated_locally: newly_subscribed && channel_connections == 1,
                             member: None,
                             auth_error: None,
                             error_message: None,
@@ -212,8 +214,8 @@ impl ConnectionHandler {
                 metrics.mark_channel_subscription(&app_config.id, channel_type_str);
             }
 
-            // Sync active channel gauge if this is the first connection to the channel
-            if subscription_result.channel_connections == Some(1) {
+            // Per-pod gauge: count this channel only on the first local subscriber.
+            if subscription_result.activated_locally {
                 metrics.mark_channel_activated(&app_config.id, channel_type_str);
             }
         }

--- a/crates/sockudo-adapter/src/local_adapter.rs
+++ b/crates/sockudo-adapter/src/local_adapter.rs
@@ -1319,12 +1319,16 @@ impl LocalAdapter {
 
     /// Fast-path channel join for LocalAdapter - atomic operation without locks
     /// Returns Some(connection_count) if successful, None if socket not found or already in channel
+    /// Fast-path channel join for the local adapter.
+    ///
+    /// Returns `(socket_count, newly_subscribed)`, where `newly_subscribed` is
+    /// `false` when the socket was already in the channel.
     pub fn join_channel_fast(
         &self,
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Option<usize> {
+    ) -> Option<(usize, bool)> {
         let t_start = std::time::Instant::now();
 
         // Get namespace (read-only operation on DashMap)
@@ -1360,13 +1364,13 @@ impl LocalAdapter {
                 t_before_count - t_before_chan_check,
                 t_after_count - t_before_count
             );
-            return Some(count);
+            return Some((count, false));
         }
         let t_after_chan_check = t_start.elapsed().as_nanos();
 
         // Atomically add socket to channel
         let t_before_add = t_start.elapsed().as_nanos();
-        namespace.add_channel_to_socket(channel, socket_id);
+        let newly_subscribed = namespace.add_channel_to_socket(channel, socket_id);
         let t_after_add = t_start.elapsed().as_nanos();
 
         // Return the new connection count
@@ -1386,7 +1390,7 @@ impl LocalAdapter {
             t_after_count - t_before_count
         );
 
-        Some(count)
+        Some((count, newly_subscribed))
     }
 }
 

--- a/crates/sockudo-adapter/tests/adapter/active_channels_gauge_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/active_channels_gauge_tests.rs
@@ -1,0 +1,99 @@
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::local_adapter::LocalAdapter;
+use sockudo_app::memory_app_manager::MemoryAppManager;
+use sockudo_core::app::{App, AppManager, AppPolicy};
+use sockudo_core::websocket::{SocketId, WebSocketBufferConfig};
+use sockudo_protocol::{ProtocolVersion, WireFormat};
+use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, Stream as WsStream, WebSocketStream};
+use std::sync::Arc;
+use tokio::net::{TcpListener, TcpStream};
+
+const APP_ID: &str = "gauge-app";
+
+async fn make_writer() -> WebSocketWriter {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (_client_ws, _): (WebSocketStream<WsStream<Http1>>, _) = client
+        .connect(client_stream, &addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    server.await.unwrap()
+}
+
+async fn register_socket(adapter: &LocalAdapter, app_manager: Arc<MemoryAppManager>) -> SocketId {
+    let socket_id = SocketId::new();
+    adapter
+        .add_socket(
+            socket_id,
+            make_writer().await,
+            APP_ID,
+            app_manager as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V2,
+            WireFormat::Json,
+            true,
+        )
+        .await
+        .unwrap();
+    socket_id
+}
+
+/// join_channel_fast flags the join as new only the first time. A re-subscribe
+/// by the same socket reports false.
+#[tokio::test]
+async fn join_channel_fast_reports_transition_only_on_first_join() {
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager
+        .create_app(App::from_policy(
+            APP_ID.to_string(),
+            "key".to_string(),
+            "secret".to_string(),
+            true,
+            AppPolicy::default(),
+        ))
+        .await
+        .unwrap();
+
+    let adapter = LocalAdapter::new();
+    adapter.init().await;
+    let socket_id = register_socket(&adapter, app_manager).await;
+
+    let channel = "public-room";
+
+    let first = adapter.join_channel_fast(APP_ID, channel, &socket_id);
+    assert_eq!(
+        first,
+        Some((1, true)),
+        "first join is a genuine 0->1 transition"
+    );
+
+    let second = adapter.join_channel_fast(APP_ID, channel, &socket_id);
+    assert_eq!(
+        second,
+        Some((1, false)),
+        "re-subscribe must not report a new transition"
+    );
+
+    let third = adapter.join_channel_fast(APP_ID, channel, &socket_id);
+    assert_eq!(
+        third,
+        Some((1, false)),
+        "repeated re-subscribes stay non-transitional"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/clustered_active_channels_gauge_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/clustered_active_channels_gauge_tests.rs
@@ -1,0 +1,106 @@
+//! Per-pod `active_channels` gauge in a clustered (horizontal) deployment,
+//! where the local node count can differ from the cluster-wide count.
+
+use crate::adapter::horizontal_adapter_helpers::MockConfig;
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::channel_manager::ChannelManager;
+use sockudo_core::websocket::SocketId;
+use sockudo_protocol::messages::PusherMessage;
+use std::sync::Arc;
+
+const APP_ID: &str = "test-app";
+// Seeded on both remote mock nodes, so its cluster-wide count exceeds the local.
+const SHARED_CHANNEL: &str = "channel-1";
+
+async fn multi_node() -> Arc<dyn ConnectionManager + Send + Sync> {
+    let adapter = MockConfig::create_multi_node_adapter().await.unwrap();
+    // Wire response handlers, else cross-node count queries time out to 0.
+    adapter.start_listeners().await.unwrap();
+    Arc::new(adapter)
+}
+
+/// First local subscriber activates the gauge even when the channel already
+/// exists cluster-wide.
+#[tokio::test]
+async fn subscribe_activates_on_local_transition_not_cluster_count() {
+    let cm = multi_node().await;
+    let socket = SocketId::new();
+    let msg = PusherMessage::channel_event("pusher:subscribe", SHARED_CHANNEL, sonic_rs::json!({}));
+
+    let resp = ChannelManager::subscribe(
+        &cm,
+        &socket.to_string(),
+        &msg,
+        SHARED_CHANNEL,
+        false,
+        APP_ID,
+    )
+    .await
+    .unwrap();
+
+    let local = cm
+        .get_local_channel_socket_count(APP_ID, SHARED_CHANNEL)
+        .await;
+    let cluster = cm.get_channel_socket_count(APP_ID, SHARED_CHANNEL).await;
+
+    assert_eq!(local, 1);
+    assert!(cluster > local, "cluster={cluster}, local={local}");
+    assert!(resp.activated_locally);
+}
+
+/// A re-subscribe by an already-present socket does not activate again.
+#[tokio::test]
+async fn resubscribe_does_not_activate_again() {
+    let cm = multi_node().await;
+    let socket = SocketId::new();
+    let msg = PusherMessage::channel_event("pusher:subscribe", SHARED_CHANNEL, sonic_rs::json!({}));
+
+    let first = ChannelManager::subscribe(
+        &cm,
+        &socket.to_string(),
+        &msg,
+        SHARED_CHANNEL,
+        false,
+        APP_ID,
+    )
+    .await
+    .unwrap();
+    assert!(first.activated_locally);
+
+    let second = ChannelManager::subscribe(
+        &cm,
+        &socket.to_string(),
+        &msg,
+        SHARED_CHANNEL,
+        false,
+        APP_ID,
+    )
+    .await
+    .unwrap();
+    assert!(!second.activated_locally);
+}
+
+/// The last local subscriber leaving deactivates locally even while remote nodes
+/// still hold the channel.
+#[tokio::test]
+async fn unsubscribe_empties_local_while_cluster_still_holds_channel() {
+    let cm = multi_node().await;
+    let socket = SocketId::new();
+
+    cm.add_to_channel(APP_ID, SHARED_CHANNEL, &socket)
+        .await
+        .unwrap();
+
+    let leave = ChannelManager::unsubscribe(&cm, &socket.to_string(), SHARED_CHANNEL, APP_ID, None)
+        .await
+        .unwrap();
+
+    let local = cm
+        .get_local_channel_socket_count(APP_ID, SHARED_CHANNEL)
+        .await;
+    let cluster = cm.get_channel_socket_count(APP_ID, SHARED_CHANNEL).await;
+
+    assert_eq!(local, 0);
+    assert!(cluster > 0, "cluster={cluster}");
+    assert!(leave.remaining_connections.unwrap() > 0);
+}

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -63,3 +63,9 @@ mod user_has_connections_tests;
 
 #[cfg(test)]
 mod presence_state_sync_default_test;
+
+#[cfg(test)]
+mod active_channels_gauge_tests;
+
+#[cfg(test)]
+mod clustered_active_channels_gauge_tests;

--- a/crates/sockudo-server/src/cleanup/worker.rs
+++ b/crates/sockudo-server/src/cleanup/worker.rs
@@ -197,11 +197,10 @@ impl CleanupWorker {
                 Ok(results) => {
                     for (channel_name, result) in &results {
                         match result {
-                            Ok((_, remaining_connections)) => {
+                            Ok((_was_removed, _remaining_connections, local_vacated)) => {
                                 total_success += 1;
-                                if *remaining_connections == 0
-                                    && let Some(ref metrics) = self.metrics
-                                {
+                                // Per-pod gauge: decrement when the channel empties on this node.
+                                if *local_vacated && let Some(ref metrics) = self.metrics {
                                     let channel_type =
                                         ChannelType::from_name(channel_name).as_str();
                                     metrics.mark_channel_deactivated(&app_id, channel_type);


### PR DESCRIPTION
The per-pod gauge incremented on a local 0->1 transition but decremented on a cluster-wide 1->0, so a channel held on N nodes leaked N-1 increments — the gauge ramped into the millions until restart (regression from 759fe08).

Gate inc/dec on per-node local transitions (JoinResponse.activated_locally, batch_unsubscribe's local_vacated); keep cluster-wide counts for webhooks and subscription_count events. Also stops a re-subscribe from re-incrementing.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->