### PR TITLE
fix(metrics): count uncomplete promises only on resolve timeout

### DIFF
--- a/crates/sockudo-adapter/src/horizontal_adapter.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter.rs
@@ -592,13 +592,14 @@ impl HorizontalAdapter {
         Ok(())
     }
 
+    /// Returns the responses and whether the wait timed out.
     async fn wait_for_request_responses(
         &self,
         request_id: &str,
         start: Instant,
         timeout_duration: Duration,
         max_expected_responses: usize,
-    ) -> Vec<ResponseBody> {
+    ) -> (Vec<ResponseBody>, bool) {
         let deadline = start + timeout_duration;
 
         loop {
@@ -607,7 +608,7 @@ impl HorizontalAdapter {
                 .get(request_id)
                 .map(|request| Arc::clone(&request.notify))
             else {
-                return Vec::new();
+                return (Vec::new(), false);
             };
             let notified = notify.notified();
             tokio::pin!(notified);
@@ -626,14 +627,15 @@ impl HorizontalAdapter {
                         max_expected_responses,
                         start.elapsed().as_millis()
                     );
-                    return self
+                    let responses = self
                         .pending_requests
                         .remove(request_id)
                         .map(|(_, req)| req.responses)
                         .unwrap_or_default();
+                    return (responses, false);
                 }
                 Some(_) => {}
-                None => return Vec::new(),
+                None => return (Vec::new(), false),
             }
 
             let now = Instant::now();
@@ -650,11 +652,12 @@ impl HorizontalAdapter {
                     current_responses,
                     max_expected_responses
                 );
-                return self
+                let responses = self
                     .pending_requests
                     .remove(request_id)
                     .map(|(_, req)| req.responses)
                     .unwrap_or_default();
+                return (responses, true);
             }
 
             let remaining = deadline.saturating_duration_since(now);
@@ -674,11 +677,12 @@ impl HorizontalAdapter {
                     current_responses,
                     max_expected_responses
                 );
-                return self
+                let responses = self
                     .pending_requests
                     .remove(request_id)
                     .map(|(_, req)| req.responses)
                     .unwrap_or_default();
+                return (responses, true);
             }
         }
     }
@@ -767,7 +771,7 @@ impl HorizontalAdapter {
             });
         }
 
-        let responses = self
+        let (responses, timed_out) = self
             .wait_for_request_responses(
                 &request_id,
                 start,
@@ -806,15 +810,8 @@ impl HorizontalAdapter {
 
             metrics.track_horizontal_adapter_resolve_time(app_id, duration_ms);
 
-            let resolved = combined_response.sockets_count > 0
-                || !combined_response.members.is_empty()
-                || combined_response.exists
-                || !combined_response.channels.is_empty()
-                || combined_response.members_count > 0
-                || !combined_response.channels_with_sockets_count.is_empty()
-                || max_expected_responses == 0;
-
-            metrics.track_horizontal_adapter_resolved_promises(app_id, resolved);
+            // Empty results are still resolved — only a timeout is uncomplete
+            metrics.track_horizontal_adapter_resolved_promises(app_id, !timed_out);
         }
 
         Ok(combined_response)
@@ -1303,9 +1300,11 @@ mod tests {
             .await
             .unwrap();
 
-        let responses = timeout(Duration::from_millis(20), waiter)
+        let result = timeout(Duration::from_millis(20), waiter)
             .await
             .expect("notify should wake waiter before timeout");
-        assert_eq!(responses.unwrap().len(), 1);
+        let (responses, timed_out) = result.unwrap();
+        assert_eq!(responses.len(), 1);
+        assert!(!timed_out, "waiter should complete via notify, not timeout");
     }
 }

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -365,7 +365,7 @@ where
                 ))
             })?;
 
-        let responses = loop {
+        let (responses, timed_out) = loop {
             // Wait for notification or timeout
             let result = tokio::select! {
                 _ = notify.notified() => {
@@ -404,7 +404,7 @@ where
                             }
                             // Extract responses without removing the entry yet to avoid race condition
                             let responses = pending_request.responses.clone();
-                            Some(responses)
+                            Some((responses, false))
                         } else {
                             None // Continue waiting
                         }
@@ -426,12 +426,12 @@ where
                     } else {
                         Vec::new()
                     };
-                    Some(responses)
+                    Some((responses, true))
                 }
             };
 
-            if let Some(responses) = result {
-                break responses;
+            if let Some(outcome) = result {
+                break outcome;
             }
             // If result is None, continue waiting (notification came but not enough responses yet)
         };
@@ -461,14 +461,8 @@ where
             let duration_ms = start.elapsed().as_micros() as f64 / 1000.0; // Convert to milliseconds with 3 decimal places
             metrics.track_horizontal_adapter_resolve_time(&app_id, duration_ms);
 
-            let resolved = combined_response.sockets_count > 0
-                || !combined_response.members.is_empty()
-                || combined_response.exists
-                || !combined_response.channels.is_empty()
-                || combined_response.members_count > 0
-                || !combined_response.channels_with_sockets_count.is_empty();
-
-            metrics.track_horizontal_adapter_resolved_promises(&app_id, resolved);
+            // Empty results are still resolved — only a timeout is uncomplete
+            metrics.track_horizontal_adapter_resolved_promises(&app_id, !timed_out);
         }
 
         Ok(combined_response)

--- a/crates/sockudo-adapter/tests/adapter/horizontal_adapter_base_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/horizontal_adapter_base_test.rs
@@ -1,4 +1,5 @@
 use super::horizontal_adapter_helpers::{MockConfig, MockTransport};
+use crate::mocks::connection_handler_mock::MockMetricsInterface;
 use sockudo_adapter::ConnectionManager;
 use sockudo_adapter::horizontal_adapter::RequestType;
 use sockudo_adapter::horizontal_adapter_base::HorizontalAdapterBase;
@@ -194,6 +195,70 @@ async fn test_send_request_timeout_with_partial_responses() -> Result<()> {
         response.socket_ids,
         vec![SocketId::from_string("socket-1").unwrap().to_string()]
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_completed_empty_resolve_counts_as_resolved_promise() -> Result<()> {
+    // channel-1 has sockets but no presence members: both nodes respond, answer empty
+    let config = MockConfig::default();
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config).await?;
+    adapter.start_listeners().await?;
+    let adapter = adapter
+        .with_discovered_nodes(vec!["node-1", "node-2"])
+        .await?;
+
+    let metrics = Arc::new(MockMetricsInterface::new());
+    adapter.set_metrics(metrics.clone()).await?;
+
+    let response = adapter
+        .send_request(
+            "test-app",
+            RequestType::ChannelMembersCount,
+            Some("channel-1"),
+            None,
+            None,
+        )
+        .await?;
+
+    assert_eq!(response.members_count, 0);
+
+    // Empty-but-complete counts as resolved, not uncomplete
+    assert_eq!(metrics.horizontal_resolved_promises(), 1);
+    assert_eq!(metrics.horizontal_uncomplete_promises(), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_timed_out_resolve_counts_as_uncomplete_promise() -> Result<()> {
+    // node-2 never responds, node-3 responds after the 500ms timeout: partial answer
+    let config = MockTransport::partial_failures();
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config).await?;
+    adapter.start_listeners().await?;
+    let adapter = adapter
+        .with_discovered_nodes(vec!["node-1", "node-2", "node-3"])
+        .await?;
+
+    let metrics = Arc::new(MockMetricsInterface::new());
+    adapter.set_metrics(metrics.clone()).await?;
+
+    let response = adapter
+        .send_request(
+            "test-app",
+            RequestType::ChannelSockets,
+            Some("test-channel"),
+            None,
+            None,
+        )
+        .await?;
+
+    assert_eq!(response.sockets_count, 1);
+
+    // Timeout counts as uncomplete even though partial data arrived
+    assert_eq!(metrics.horizontal_uncomplete_promises(), 1);
+    assert_eq!(metrics.horizontal_resolved_promises(), 0);
 
     Ok(())
 }

--- a/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
+++ b/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
@@ -311,6 +311,8 @@ impl CacheManager for MockCacheManager {
 pub struct MockMetricsInterface {
     annotation_projection_rebuilds: Arc<AtomicUsize>,
     annotation_projection_rebuild_durations: Arc<AtomicUsize>,
+    horizontal_resolved_promises: Arc<AtomicUsize>,
+    horizontal_uncomplete_promises: Arc<AtomicUsize>,
 }
 impl Default for MockMetricsInterface {
     fn default() -> Self {
@@ -323,6 +325,8 @@ impl MockMetricsInterface {
         Self {
             annotation_projection_rebuilds: Arc::new(AtomicUsize::new(0)),
             annotation_projection_rebuild_durations: Arc::new(AtomicUsize::new(0)),
+            horizontal_resolved_promises: Arc::new(AtomicUsize::new(0)),
+            horizontal_uncomplete_promises: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -333,6 +337,14 @@ impl MockMetricsInterface {
     pub fn annotation_projection_rebuild_durations(&self) -> usize {
         self.annotation_projection_rebuild_durations
             .load(Ordering::Relaxed)
+    }
+
+    pub fn horizontal_resolved_promises(&self) -> usize {
+        self.horizontal_resolved_promises.load(Ordering::Relaxed)
+    }
+
+    pub fn horizontal_uncomplete_promises(&self) -> usize {
+        self.horizontal_uncomplete_promises.load(Ordering::Relaxed)
     }
 }
 
@@ -375,7 +387,15 @@ impl MetricsInterface for MockMetricsInterface {
     }
     fn mark_ws_message_received(&self, _app_id: &str, _message_size: usize) {}
     fn track_horizontal_adapter_resolve_time(&self, _app_id: &str, _time_ms: f64) {}
-    fn track_horizontal_adapter_resolved_promises(&self, _app_id: &str, _resolved: bool) {}
+    fn track_horizontal_adapter_resolved_promises(&self, _app_id: &str, resolved: bool) {
+        if resolved {
+            self.horizontal_resolved_promises
+                .fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.horizontal_uncomplete_promises
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
     fn mark_horizontal_adapter_request_sent(&self, _app_id: &str) {}
     fn mark_horizontal_adapter_request_received(&self, _app_id: &str) {}
     fn mark_horizontal_adapter_response_received(&self, _app_id: &str) {}


### PR DESCRIPTION
The resolved/uncomplete promise metric was derived from whether the aggregated response held data, so a completed request returning empty (no remote members, socket absent, zero count) was recorded as uncomplete instead of as a timeout.

Thread the wait's timeout state out of both resolve paths (send_request_with_body, wait_for_request_responses) and report !timed_out, making a timeout the only uncomplete outcome.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->