### PR TITLE
Reduce hot-path broadcast allocation work

### DIFF
--- a/crates/sockudo-adapter/src/channel_manager.rs
+++ b/crates/sockudo-adapter/src/channel_manager.rs
@@ -326,7 +326,7 @@ impl ChannelManager {
     }
 
     pub fn signature_is_valid(
-        app_config: App,
+        app_config: &App,
         socket_id: &SocketId,
         signature: &str,
         message: PusherMessage,
@@ -336,11 +336,11 @@ impl ChannelManager {
     }
 
     pub fn get_expected_signature(
-        app_config: App,
+        app_config: &App,
         socket_id: &SocketId,
         message: PusherMessage,
     ) -> String {
-        let token = Token::new(app_config.key.clone(), app_config.secret);
+        let token = Token::new(app_config.key.clone(), app_config.secret.clone());
         format!(
             "{}:{}",
             app_config.key,

--- a/crates/sockudo-adapter/src/handler/authentication.rs
+++ b/crates/sockudo-adapter/src/handler/authentication.rs
@@ -49,12 +49,8 @@ impl ConnectionHandler {
             delta_conflation_key: None,
         };
 
-        let is_valid = ChannelManager::signature_is_valid(
-            app_config.clone(),
-            socket_id,
-            signature,
-            temp_message,
-        );
+        let is_valid =
+            ChannelManager::signature_is_valid(app_config, socket_id, signature, temp_message);
 
         Ok(is_valid)
     }

--- a/crates/sockudo-adapter/src/local_adapter.rs
+++ b/crates/sockudo-adapter/src/local_adapter.rs
@@ -192,7 +192,7 @@ impl LocalAdapter {
 struct SocketMessageParams<'a> {
     socket_ref: WebSocketRef,
     base_message: PusherMessage,
-    base_message_bytes: Vec<u8>,
+    base_message_bytes: Bytes,
     channel: &'a str,
     event_name: &'a str,
     delta_compression: Arc<sockudo_delta::DeltaCompressionManager>,
@@ -206,7 +206,7 @@ struct SocketMessageParams<'a> {
 struct PrecomputedDeltaParams<'a> {
     socket_ref: WebSocketRef,
     base_message: PusherMessage,
-    base_message_bytes: Vec<u8>,
+    base_message_bytes: Bytes,
     channel: &'a str,
     event_name: &'a str,
     delta_compression: Arc<sockudo_delta::DeltaCompressionManager>,
@@ -332,7 +332,7 @@ impl LocalAdapter {
         &self,
         target_socket_refs: Vec<WebSocketRef>,
         base_message: PusherMessage,
-        base_message_bytes: Vec<u8>,
+        base_message_bytes: Bytes,
         channel: &str,
         event_name: &str,
         compression: crate::connection_manager::CompressionParams<'_>,
@@ -775,7 +775,7 @@ impl LocalAdapter {
                         result.push_str(&format!(",\"__conflation_key\":\"{}\"", conflation_key));
                     }
                     result.push('}');
-                    result.into_bytes()
+                    Bytes::from(result.into_bytes())
                 } else {
                     base_message_bytes.clone()
                 }
@@ -815,7 +815,7 @@ impl LocalAdapter {
                         socket_id,
                         channel,
                         event_name,
-                        base_message_bytes.clone(),
+                        base_message_bytes.to_vec(),
                         true,
                         channel_settings,
                     )
@@ -901,7 +901,7 @@ impl LocalAdapter {
                         socket_id,
                         channel,
                         event_name,
-                        base_message_bytes.clone(),
+                        base_message_bytes.to_vec(),
                         false,
                         channel_settings,
                     )
@@ -1065,7 +1065,7 @@ impl LocalAdapter {
                     socket_id,
                     channel,
                     event_name,
-                    base_message_bytes.clone(),
+                    base_message_bytes.to_vec(),
                     false,
                     channel_settings,
                 )
@@ -1102,7 +1102,7 @@ impl LocalAdapter {
                         result.push_str(&format!(",\"__conflation_key\":\"{}\"", conflation_key));
                     }
                     result.push('}');
-                    result.into_bytes()
+                    Bytes::from(result.into_bytes())
                 } else {
                     base_message_bytes.clone()
                 }
@@ -1121,7 +1121,7 @@ impl LocalAdapter {
                     socket_id,
                     channel,
                     event_name,
-                    base_message_bytes.clone(),
+                    base_message_bytes.to_vec(),
                     true,
                     channel_settings,
                 )
@@ -1594,11 +1594,21 @@ impl ConnectionManager for LocalAdapter {
 
         // Send to filtered V2 sockets (Sockudo-native: sockudo: prefix, serial + message_id)
         if !filtered_socket_refs.is_empty() {
-            let (v2_message, _v2_bytes) = crate::v2_broadcast::prepare_v2_message(message)?;
+            let (v2_message, v2_bytes) = crate::v2_broadcast::prepare_v2_message(message)?;
+            let (json_socket_refs, binary_socket_refs): (Vec<_>, Vec<_>) = filtered_socket_refs
+                .into_iter()
+                .partition(|socket| socket.wire_format == sockudo_protocol::WireFormat::Json);
+
             Self::log_send_errors(
-                self.send_protocol_messages_concurrent(filtered_socket_refs, v2_message)
+                self.send_messages_concurrent(json_socket_refs, v2_bytes)
                     .await,
             );
+            if !binary_socket_refs.is_empty() {
+                Self::log_send_errors(
+                    self.send_protocol_messages_concurrent(binary_socket_refs, v2_message)
+                        .await,
+                );
+            }
         }
 
         Ok(())
@@ -1674,8 +1684,10 @@ impl ConnectionManager for LocalAdapter {
             v2_message.rewrite_prefix(sockudo_protocol::ProtocolVersion::V2);
             v2_message.idempotency_key = None;
             let v2_event_name = v2_message.event.as_deref().unwrap_or("").to_string();
-            let v2_bytes = sonic_rs::to_vec(&v2_message)
-                .map_err(|e| Error::InvalidMessageFormat(format!("Serialization failed: {e}")))?;
+            let v2_bytes =
+                Bytes::from(sonic_rs::to_vec(&v2_message).map_err(|e| {
+                    Error::InvalidMessageFormat(format!("Serialization failed: {e}"))
+                })?);
             Self::log_send_errors(
                 self.send_messages_with_compression(
                     filtered_socket_refs,

--- a/crates/sockudo-adapter/src/transports/redis_cluster_sharded_pubsub.rs
+++ b/crates/sockudo-adapter/src/transports/redis_cluster_sharded_pubsub.rs
@@ -360,6 +360,7 @@ pub(crate) struct ShardListenerParams {
     channels: Vec<String>,
     mode: PubSubMode,
     fan_in_tx: ShardedPushSender,
+    ready_tx: Option<tokio::sync::oneshot::Sender<()>>,
     is_running: Arc<AtomicBool>,
     shutdown: Arc<Notify>,
     shard_addr: String,
@@ -373,7 +374,7 @@ pub(crate) struct ShardListenerParams {
 /// subscription command for each assigned channel, and forwards Pub/Sub pushes
 /// to the bounded fan-in sender. Reconnects with exponential back-off
 /// (500 ms to 10 s) on any failure.
-pub(crate) async fn shard_listener_loop(params: ShardListenerParams) {
+pub(crate) async fn shard_listener_loop(mut params: ShardListenerParams) {
     // Unbounded because push_sender must not block the redis runtime;
     // backpressure is applied at the bounded fan-in boundary.
     type InternalFlavor = mpsc::List<redis::PushInfo>;
@@ -493,6 +494,9 @@ pub(crate) async fn shard_listener_loop(params: ShardListenerParams) {
             params.mode.label(),
             params.channels.len()
         );
+        if let Some(ready_tx) = params.ready_tx.take() {
+            let _ = ready_tx.send(());
+        }
         reconnection_count = 0;
 
         loop {
@@ -667,17 +671,20 @@ impl ShardedSubscriber {
 
         {
             let mut shard_map = shard_handles.lock().await;
+            let mut ready_receivers = Vec::new();
             for (shard_addr, shard_channels) in by_shard {
                 if shard_channels.is_empty() {
                     continue;
                 }
                 let url = shard_addr.to_url(scheme, password.as_deref());
                 let shard_addr_str = format!("{}:{}", shard_addr.host, shard_addr.port);
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let params = ShardListenerParams {
                     url,
                     channels: shard_channels,
                     mode: self.mode,
                     fan_in_tx: fan_tx.clone(),
+                    ready_tx: Some(ready_tx),
                     is_running: self.is_running.clone(),
                     shutdown: self.shutdown.clone(),
                     shard_addr: shard_addr_str.clone(),
@@ -685,6 +692,20 @@ impl ShardedSubscriber {
                     refresh_notify: self.refresh_notify.clone(),
                 };
                 shard_map.insert(shard_addr_str, tokio::spawn(shard_listener_loop(params)));
+                ready_receivers.push(ready_rx);
+            }
+            drop(shard_map);
+
+            let readiness = ready_receivers
+                .into_iter()
+                .map(|ready_rx| tokio::time::timeout(Duration::from_secs(5), ready_rx));
+            for result in futures::future::join_all(readiness).await {
+                if !matches!(result, Ok(Ok(()))) {
+                    warn!(
+                        "ShardedSubscriber: timed out waiting for initial {} subscription readiness",
+                        self.mode.label()
+                    );
+                }
             }
         }
 
@@ -761,6 +782,7 @@ impl ShardedSubscriber {
                         channels,
                         mode,
                         fan_in_tx: fan_tx_for_refresh.clone(),
+                        ready_tx: None,
                         is_running: is_running_clone.clone(),
                         shutdown: shutdown_clone.clone(),
                         shard_addr: new_str.clone(),

--- a/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
+++ b/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
@@ -28,6 +28,15 @@ fn value_to_str(v: &redis::Value) -> Option<&str> {
     }
 }
 
+fn value_to_bytes(v: &redis::Value) -> Option<&[u8]> {
+    match v {
+        redis::Value::BulkString(bytes) => Some(bytes),
+        redis::Value::SimpleString(s) => Some(s.as_bytes()),
+        redis::Value::VerbatimString { format: _, text } => Some(text.as_bytes()),
+        _ => None,
+    }
+}
+
 impl TransportConfig for RedisClusterAdapterConfig {
     fn request_timeout_ms(&self) -> u64 {
         self.request_timeout_ms
@@ -478,8 +487,8 @@ impl HorizontalTransport for RedisClusterTransport {
                         continue;
                     };
 
-                    let payload = match value_to_str(&push_info.data[1]).map(str::to_owned) {
-                        Some(s) => s,
+                    let payload = match value_to_bytes(&push_info.data[1]).map(<[u8]>::to_vec) {
+                        Some(bytes) => bytes,
                         None => {
                             if let Some(metrics) = metrics.get() {
                                 metrics.mark_horizontal_transport_message_dropped("redis_cluster");
@@ -496,7 +505,7 @@ impl HorizontalTransport for RedisClusterTransport {
 
                             tokio::spawn(async move {
                                 if let Ok(broadcast) =
-                                    sonic_rs::from_str::<BroadcastMessage>(&payload)
+                                    sonic_rs::from_slice::<BroadcastMessage>(&payload)
                                 {
                                     broadcast_handler(broadcast).await;
                                 } else if let Some(metrics) = metrics_clone.get() {
@@ -513,7 +522,7 @@ impl HorizontalTransport for RedisClusterTransport {
                             let sharded = use_sharded_pubsub;
 
                             tokio::spawn(async move {
-                                if let Ok(request) = sonic_rs::from_str::<RequestBody>(&payload) {
+                                if let Ok(request) = sonic_rs::from_slice::<RequestBody>(&payload) {
                                     let reply_to = request.reply_to.clone();
                                     let response_result = request_handler(request).await;
 
@@ -541,7 +550,8 @@ impl HorizontalTransport for RedisClusterTransport {
                             let metrics_clone = metrics.clone();
 
                             tokio::spawn(async move {
-                                if let Ok(response) = sonic_rs::from_str::<ResponseBody>(&payload) {
+                                if let Ok(response) = sonic_rs::from_slice::<ResponseBody>(&payload)
+                                {
                                     response_handler(response).await;
                                 } else if let Some(metrics) = metrics_clone.get() {
                                     metrics
@@ -554,7 +564,8 @@ impl HorizontalTransport for RedisClusterTransport {
                             let metrics_clone = metrics.clone();
 
                             tokio::spawn(async move {
-                                if let Ok(response) = sonic_rs::from_str::<ResponseBody>(&payload) {
+                                if let Ok(response) = sonic_rs::from_slice::<ResponseBody>(&payload)
+                                {
                                     response_handler(response).await;
                                 } else if let Some(metrics) = metrics_clone.get() {
                                     metrics

--- a/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
+++ b/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
@@ -339,12 +339,14 @@ impl HorizontalTransport for RedisClusterTransport {
         let is_running = self.is_running.clone();
         let node_channel = format!("{}:#node:{}", self.prefix, handlers.node_id);
         let reply_channel = self.reply_channel.clone();
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
 
         // Spawn the main listener task with reconnection logic
         tokio::spawn(async move {
             let mut retry_delay = 500u64; // Start with 500ms delay
             const MAX_RETRY_DELAY: u64 = 10_000; // Max 10 seconds
             let mut reconnection_count = 0u64;
+            let mut ready_tx = Some(ready_tx);
 
             loop {
                 if !is_running.load(Ordering::Relaxed) {
@@ -388,6 +390,9 @@ impl HorizontalTransport for RedisClusterTransport {
                                 "Redis Cluster PubSub reconnected successfully after {} attempt(s)",
                                 reconnection_count
                             );
+                        }
+                        if let Some(ready_tx) = ready_tx.take() {
+                            let _ = ready_tx.send(());
                         }
                         rx
                     }
@@ -588,6 +593,15 @@ impl HorizontalTransport for RedisClusterTransport {
                 retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
             }
         });
+
+        tokio::time::timeout(Duration::from_secs(5), ready_rx)
+            .await
+            .map_err(|_| {
+                Error::Redis("Redis Cluster PubSub initial subscription timed out".to_string())
+            })?
+            .map_err(|_| {
+                Error::Redis("Redis Cluster PubSub listener stopped before subscribing".to_string())
+            })?;
 
         Ok(())
     }

--- a/crates/sockudo-adapter/src/transports/redis_transport.rs
+++ b/crates/sockudo-adapter/src/transports/redis_transport.rs
@@ -309,7 +309,7 @@ impl HorizontalTransport for RedisTransport {
                         break;
                     };
                     let channel = msg.get_channel_name();
-                    let payload_result: redis::RedisResult<String> = msg.get_payload();
+                    let payload_result: redis::RedisResult<Vec<u8>> = msg.get_payload();
 
                     if let Ok(payload) = payload_result {
                         if channel == broadcast_channel.as_str() {
@@ -318,7 +318,7 @@ impl HorizontalTransport for RedisTransport {
 
                             tokio::spawn(async move {
                                 if let Ok(broadcast) =
-                                    sonic_rs::from_str::<BroadcastMessage>(&payload)
+                                    sonic_rs::from_slice::<BroadcastMessage>(&payload)
                                 {
                                     broadcast_handler(broadcast).await;
                                 } else if let Some(metrics) = metrics_clone.get() {
@@ -334,7 +334,7 @@ impl HorizontalTransport for RedisTransport {
                             let metrics_clone = metrics.clone();
 
                             tokio::spawn(async move {
-                                if let Ok(request) = sonic_rs::from_str::<RequestBody>(&payload) {
+                                if let Ok(request) = sonic_rs::from_slice::<RequestBody>(&payload) {
                                     let reply_to = request.reply_to.clone();
                                     let response_result = request_handler(request).await;
 
@@ -358,13 +358,17 @@ impl HorizontalTransport for RedisTransport {
                             let metrics_clone = metrics.clone();
 
                             tokio::spawn(async move {
-                                if let Ok(response) = sonic_rs::from_str::<ResponseBody>(&payload) {
+                                if let Ok(response) = sonic_rs::from_slice::<ResponseBody>(&payload)
+                                {
                                     response_handler(response).await;
                                 } else {
                                     if let Some(metrics) = metrics_clone.get() {
                                         metrics.mark_horizontal_transport_message_dropped("redis");
                                     }
-                                    warn!("Failed to parse response message: {}", payload);
+                                    warn!(
+                                        "Failed to parse response message: {}",
+                                        String::from_utf8_lossy(&payload)
+                                    );
                                 }
                             });
                         }

--- a/crates/sockudo-adapter/src/v2_broadcast.rs
+++ b/crates/sockudo-adapter/src/v2_broadcast.rs
@@ -108,13 +108,8 @@ pub(crate) fn apply_tag_filter_in_place(
     }
 
     let _ = (filter_index, except, namespace);
-    let tags_btree = message.tags.as_ref().map(|tags| {
-        tags.iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect::<std::collections::BTreeMap<String, String>>()
-    });
 
-    v2_sockets.retain(|socket| should_deliver_for_tags(socket, channel, tags_btree.as_ref()));
+    v2_sockets.retain(|socket| should_deliver_for_tags(socket, channel, message.tags.as_ref()));
 }
 
 #[cfg(feature = "tag-filtering")]
@@ -132,15 +127,9 @@ pub(crate) fn apply_tag_filter_v2_only_in_place(
     }
 
     let _ = (filter_index, except, namespace);
-    let tags_btree = message.tags.as_ref().map(|tags| {
-        tags.iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect::<std::collections::BTreeMap<String, String>>()
-    });
-
     v2_sockets.retain(|socket| {
         socket.protocol_version == sockudo_protocol::ProtocolVersion::V2
-            && should_deliver_for_tags(socket, channel, tags_btree.as_ref())
+            && should_deliver_for_tags(socket, channel, message.tags.as_ref())
     });
 }
 

--- a/crates/sockudo-server/src/http_handler.rs
+++ b/crates/sockudo-server/src/http_handler.rs
@@ -1246,6 +1246,7 @@ async fn process_single_event_parallel(
         .as_deref()
         .ok_or_else(|| AppError::InvalidInput("Event name is required".to_string()))?;
     tracing::Span::current().record("event_name", event_name_str);
+    let event_name_owned = event_name_str.to_string();
 
     let max_event_name_len = app
         .event_name_limit()
@@ -1300,41 +1301,41 @@ async fn process_single_event_parallel(
         }
     };
 
+    let message_name = Arc::new(name);
+    let message_data = Arc::new(match event_payload_data {
+        Some(ApiMessageData::String(s)) => MessageData::String(s),
+        Some(ApiMessageData::Json(j_val)) => MessageData::String(j_val.to_string()),
+        None => MessageData::String("null".to_string()),
+    });
+    let message_tags: Arc<Option<std::collections::BTreeMap<String, String>>> =
+        Arc::new(tags.map(|h| h.into_iter().collect()));
+    let message_idempotency_key = Arc::new(idempotency_key);
+    let message_extras = Arc::new(extras);
+
     let channel_processing_futures = target_channels.into_iter().map(|target_channel_str| {
         let handler_clone = Arc::clone(handler);
-        let name_for_task = name.clone();
-        let payload_for_task = event_payload_data.clone();
+        let name_for_task = Arc::clone(&message_name);
+        let payload_for_task = Arc::clone(&message_data);
         let socket_id_for_task = mapped_socket_id;
         let info_for_task = info.clone();
-        let event_name_for_task = event_name_str.to_string();
-        let tags_for_task: Option<std::collections::BTreeMap<String, String>> = tags
-            .clone()
-            .map(|h| h.into_iter().collect());
+        let event_name_for_task = event_name_owned.clone();
+        let tags_for_task = Arc::clone(&message_tags);
         let delta_flag_for_task = delta_flag;
-        let idempotency_key_for_task = idempotency_key.clone();
-        let extras_for_task = extras.clone();
+        let idempotency_key_for_task = Arc::clone(&message_idempotency_key);
+        let extras_for_task = Arc::clone(&message_extras);
 
         async move {
             debug!(channel = %target_channel_str, "Processing channel for event (parallel task)");
 
             validate_channel_name(app, &target_channel_str).await?;
 
-            let message_data = match payload_for_task {
-                Some(ApiMessageData::String(s)) => {
-                    MessageData::String(s)
-                },
-                Some(ApiMessageData::Json(j_val)) => {
-                    MessageData::String(j_val.to_string())
-                },
-                None => MessageData::String("null".to_string()),
-            };
             let _message_to_send = PusherMessage {
                 channel: Some(target_channel_str.clone()),
                 name: None,
-                event: name_for_task,
-                data: Some(message_data.clone()),
+                event: (*name_for_task).clone(),
+                data: Some((*payload_for_task).clone()),
                 user_id: None,
-                tags: tags_for_task.clone(),
+                tags: (*tags_for_task).clone(),
                 sequence: None,
                 conflation_key: None,
                 message_id: if handler_clone.server_options().connection_recovery.enabled {
@@ -1344,8 +1345,8 @@ async fn process_single_event_parallel(
                 },
                 stream_id: None,
                 serial: None,
-                idempotency_key: idempotency_key_for_task.clone(),
-                extras: extras_for_task.clone(),
+                idempotency_key: (*idempotency_key_for_task).clone(),
+                extras: (*extras_for_task).clone(),
                 delta_sequence: None,
                 delta_conflation_key: None,
             };
@@ -1431,7 +1432,7 @@ async fn process_single_event_parallel(
 
             // Handle caching for cacheable channels.
             if utils::is_cache_channel(&target_channel_str) {
-                let message_data = sonic_rs::to_value(&message_data)
+                let message_data = sonic_rs::to_value(&*payload_for_task)
                     .map_err(AppError::SerializationError)?;
                 match build_cache_payload(&event_name_for_task, &message_data, &target_channel_str) {
                     Ok(cache_payload_str) => {


### PR DESCRIPTION
## Summary

Reduces allocation and serialization work in high-volume broadcast paths:

- reuse the prepared V2 JSON broadcast bytes for JSON sockets instead of reserializing once per socket
- keep V2 binary wire formats on the existing per-socket protocol serialization path
- remove duplicate tag map cloning during V2 tag filtering
- carry delta broadcast base bytes as `Bytes` inside the adapter path
- parse Redis and Redis Cluster transport messages from byte slices instead of stringifying first
- share HTTP publish payload inputs across per-channel tasks
- avoid cloning the full `App` during channel auth signature validation
- wait for initial Redis Cluster listener subscriptions before `start()` returns, closing a CI request/response race

## Root Cause

The V2 fanout path computed serialized JSON bytes in `prepare_v2_message`, discarded them, then called `send_message` per socket, which serialized the same payload again for every JSON subscriber. Adjacent hot paths also cloned tag maps and HTTP publish data per target, while Redis transport receive paths converted bytes to strings before parsing JSON.

The Redis Cluster CI failure was a startup race: `start_listeners` could return after spawning shard listener tasks but before subscriptions were active, allowing a request publish to happen before the request channel was subscribed.

## Validation

- `cargo fmt --all`
- `cargo check -p sockudo-adapter -p sockudo`
- `cargo check -p sockudo-adapter --features full`
- `cargo check -p sockudo-adapter`
- `cargo test -p sockudo-adapter`
- `cargo test -p sockudo`
- `cargo test -p sockudo-adapter transports::redis_cluster_sharded_pubsub::tests --features full`

Not run locally: live Redis Cluster request-response test, because no Redis Cluster is running on `127.0.0.1:7001-7003`.
