### PR TITLE
fix(adapter): clean filter index on disconnect to stop subscription leak

### DIFF
--- a/crates/sockudo-adapter/src/filter_index.rs
+++ b/crates/sockudo-adapter/src/filter_index.rs
@@ -205,6 +205,24 @@ impl FilterIndex {
         // 3. The socket won't receive messages anyway since it's unsubscribed from the channel
     }
 
+    /// Remove a socket from every index for `channel` without needing its filter.
+    /// eq_index is swept via the channel's tracked composite keys.
+    pub fn remove_socket_all_filters(&self, channel: &str, socket_id: SocketId) {
+        if let Some(set) = self.no_filter.get(channel) {
+            set.remove(&socket_id);
+        }
+        if let Some(set) = self.complex_filters.get(channel) {
+            set.remove(&socket_id);
+        }
+        if let Some(hashes) = self.channel_keys.get(channel) {
+            for hash in hashes.iter() {
+                if let Some(set) = self.eq_index.get(&hash) {
+                    set.remove(&socket_id);
+                }
+            }
+        }
+    }
+
     /// Look up sockets that should receive a message with the given tags.
     ///
     /// Returns categorized results for efficient processing.

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -592,9 +592,12 @@ impl ConnectionHandler {
                     .await;
             }
 
-            // Register with filter index for O(1) message routing (if local adapter is available)
+            // Register with filter index for O(1) message routing (if local adapter is available).
+            // Skip when tag filtering is off, since the index is never read on the broadcast path.
             #[cfg(feature = "tag-filtering")]
-            if let Some(ref local_adapter) = self.local_adapter {
+            if let Some(ref local_adapter) = self.local_adapter
+                && local_adapter.is_tag_filtering_enabled()
+            {
                 let filter_index = local_adapter.get_filter_index();
                 // Get the filter we just stored on the socket
                 let filter_node = conn_arc.get_channel_filter_sync(&request.channel);

--- a/crates/sockudo-adapter/src/local_adapter.rs
+++ b/crates/sockudo-adapter/src/local_adapter.rs
@@ -1846,15 +1846,15 @@ impl ConnectionManager for LocalAdapter {
     ) -> Result<bool> {
         let namespace = self.get_or_create_namespace(app_id).await;
 
-        // MEMORY LEAK FIX: Clean up filter index BEFORE removing from channel
-        // Get the socket's filter for this channel so we can remove it from the index
+        // Clean the filter index unconditionally. On disconnect the socket is
+        // already gone from the namespace and its filter can no longer be read.
         #[cfg(feature = "tag-filtering")]
-        if let Some(socket_ref) = namespace.sockets.get(socket_id) {
-            let filter_node = socket_ref.get_channel_filter_sync(channel);
+        {
             self.filter_index
-                .remove_socket_filter(channel, *socket_id, filter_node.as_deref());
-            // Also remove from the socket's channel_filters map
-            socket_ref.channel_filters.remove(channel);
+                .remove_socket_all_filters(channel, *socket_id);
+            if let Some(socket_ref) = namespace.sockets.get(socket_id) {
+                socket_ref.channel_filters.remove(channel);
+            }
         }
 
         Ok(namespace.remove_channel_from_socket(channel, socket_id))

--- a/crates/sockudo-adapter/tests/adapter/filter_index_disconnect_cleanup_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/filter_index_disconnect_cleanup_tests.rs
@@ -1,0 +1,34 @@
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::local_adapter::LocalAdapter;
+use sockudo_core::websocket::SocketId;
+use std::collections::BTreeMap;
+
+// remove_from_channel must clean the filter index even when the socket is no
+// longer in the namespace, as happens on the disconnect path.
+#[tokio::test]
+async fn remove_from_channel_cleans_filter_index_when_socket_already_gone() {
+    let adapter = LocalAdapter::new();
+    let app_id = "app-1";
+    let channel = "my-channel";
+    let socket_id = SocketId::from_string("1.1").unwrap();
+
+    // A subscribe with no client filter registers the socket in no_filter
+    adapter
+        .get_filter_index()
+        .add_socket_filter(channel, socket_id, None);
+
+    let before = adapter.get_filter_index().lookup(channel, &BTreeMap::new());
+    assert!(before.no_filter.contains(&socket_id));
+
+    // Socket absent from the namespace, mirroring the disconnect path
+    adapter
+        .remove_from_channel(app_id, channel, &socket_id)
+        .await
+        .unwrap();
+
+    let after = adapter.get_filter_index().lookup(channel, &BTreeMap::new());
+    assert!(
+        !after.no_filter.contains(&socket_id),
+        "filter index leaked socket {socket_id} after disconnect"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -69,3 +69,6 @@ mod active_channels_gauge_tests;
 
 #[cfg(test)]
 mod clustered_active_channels_gauge_tests;
+
+#[cfg(test)]
+mod filter_index_disconnect_cleanup_tests;


### PR DESCRIPTION
add_socket_filter runs on every subscribe gated only by the tag-filtering cfg, not the runtime flag, registering the socket in the filter index. On disconnect cleanup_connection removes the socket from the namespace before the unsubscribe path runs, so remove_from_channel's cleanup, guarded by namespace.sockets.get, was skipped and every subscription leaked one index entry, growing RSS with connection churn until restart.

remove_from_channel now sweeps the index via remove_socket_all_filters (no_filter, complex_filters, eq_index via channel_keys), independent of namespace presence. add_socket_filter is also gated on is_tag_filtering_enabled so the index stays empty when tag filtering is off.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->