### PR TITLE
Fix Redis sliding-window rate limiter accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8336,6 +8336,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "hyper",
+ "rand 0.9.4",
  "redis",
  "sockudo-core",
  "sockudo-metrics",

--- a/crates/sockudo-rate-limiter/Cargo.toml
+++ b/crates/sockudo-rate-limiter/Cargo.toml
@@ -11,7 +11,7 @@ license-file.workspace = true
 default = ["local"]
 local = []
 full = ["redis", "redis-cluster"]
-redis = ["sockudo-core/redis", "dep:redis"]
+redis = ["sockudo-core/redis", "dep:redis", "dep:rand"]
 redis-cluster = ["redis", "sockudo-core/redis-cluster"]
 
 [dependencies]
@@ -26,6 +26,7 @@ futures-util = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true }
 redis = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
 sonic-rs = { workspace = true }
 tokio = { workspace = true }
 tower-layer = { workspace = true }

--- a/crates/sockudo-rate-limiter/src/lib.rs
+++ b/crates/sockudo-rate-limiter/src/lib.rs
@@ -5,6 +5,8 @@ pub mod middleware;
 pub mod redis_cluster_limiter;
 #[cfg(feature = "redis")]
 pub mod redis_limiter;
+#[cfg(any(feature = "redis", feature = "redis-cluster"))]
+mod redis_window;
 
 pub use sockudo_core::rate_limiter::{RateLimitConfig, RateLimitResult, RateLimiter};
 

--- a/crates/sockudo-rate-limiter/src/redis_cluster_limiter.rs
+++ b/crates/sockudo-rate-limiter/src/redis_cluster_limiter.rs
@@ -8,7 +8,6 @@ use redis::cluster::ClusterClient;
 use redis::cluster_async::ClusterConnection;
 use sockudo_core::error::{Error, Result};
 use sockudo_core::rate_limiter::{RateLimitConfig, RateLimitResult, RateLimiter};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Redis Cluster-based rate limiter implementation
 pub struct RedisClusterRateLimiter {
@@ -66,14 +65,6 @@ impl RedisClusterRateLimiter {
         format!("{}:rl:{}", self.prefix, key)
     }
 
-    /// Get the Unix timestamp for the current time
-    fn get_current_time() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_else(|_| Duration::from_secs(0))
-            .as_secs()
-    }
-
     /// Run sliding window rate limiting using Redis
     async fn run_sliding_window_check(
         &self,
@@ -81,13 +72,13 @@ impl RedisClusterRateLimiter {
         increment: bool,
     ) -> Result<RateLimitResult> {
         let redis_key = self.get_key(key);
-        let now = Self::get_current_time();
-        let window_start = now - self.config.window_secs;
+        let now_ms = crate::redis_window::current_time_ms();
+        let window_start_ms = crate::redis_window::window_start_ms(now_ms, self.config.window_secs);
 
         let mut conn = self.connection.clone();
 
-        let _: () = conn
-            .zrevrangebyscore(&redis_key, 0, window_start as i64)
+        let _: usize = conn
+            .zrembyscore(&redis_key, 0, window_start_ms)
             .await
             .map_err(|e| Error::Redis(format!("Failed to clean up Redis sorted set: {e}")))?;
 
@@ -105,8 +96,9 @@ impl RedisClusterRateLimiter {
         let allowed = remaining > 0;
 
         if increment && allowed {
-            let _: () = conn
-                .zadd(&redis_key, now, now)
+            let member = crate::redis_window::entry_member(now_ms);
+            let _: usize = conn
+                .zadd(&redis_key, member, now_ms)
                 .await
                 .map_err(|e| Error::Redis(format!("Failed to increment Redis counter: {e}")))?;
 

--- a/crates/sockudo-rate-limiter/src/redis_limiter.rs
+++ b/crates/sockudo-rate-limiter/src/redis_limiter.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use redis::{AsyncCommands, Client};
 use sockudo_core::error::{Error, Result};
 use sockudo_core::rate_limiter::{RateLimitConfig, RateLimitResult, RateLimiter};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Redis-based rate limiter implementation
 pub struct RedisRateLimiter {
@@ -81,14 +80,6 @@ impl RedisRateLimiter {
         format!("{}:rl:{}", self.prefix, key)
     }
 
-    /// Get the Unix timestamp for the current time
-    fn get_current_time() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_else(|_| Duration::from_secs(0))
-            .as_secs()
-    }
-
     /// Run sliding window rate limiting using Redis
     async fn run_sliding_window_check(
         &self,
@@ -96,13 +87,13 @@ impl RedisRateLimiter {
         increment: bool,
     ) -> Result<RateLimitResult> {
         let redis_key = self.get_key(key);
-        let now = Self::get_current_time();
-        let window_start = now - self.config.window_secs;
+        let now_ms = crate::redis_window::current_time_ms();
+        let window_start_ms = crate::redis_window::window_start_ms(now_ms, self.config.window_secs);
 
         let mut conn = self.connection.clone();
 
-        let _: () = conn
-            .zrevrangebyscore(&redis_key, 0, window_start as i64)
+        let _: usize = conn
+            .zrembyscore(&redis_key, 0, window_start_ms)
             .await
             .map_err(|e| Error::Redis(format!("Failed to clean up Redis sorted set: {e}")))?;
 
@@ -120,8 +111,9 @@ impl RedisRateLimiter {
         let allowed = remaining > 0;
 
         if increment && allowed {
-            let _: () = conn
-                .zadd(&redis_key, now, now)
+            let member = crate::redis_window::entry_member(now_ms);
+            let _: usize = conn
+                .zadd(&redis_key, member, now_ms)
                 .await
                 .map_err(|e| Error::Redis(format!("Failed to increment Redis counter: {e}")))?;
 

--- a/crates/sockudo-rate-limiter/src/redis_window.rs
+++ b/crates/sockudo-rate-limiter/src/redis_window.rs
@@ -1,0 +1,47 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+static MEMBER_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_millis() as u64
+}
+
+pub(crate) fn window_start_ms(now_ms: u64, window_secs: u64) -> u64 {
+    now_ms.saturating_sub(window_secs.saturating_mul(1_000))
+}
+
+pub(crate) fn entry_member(now_ms: u64) -> String {
+    let sequence = MEMBER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("{}:{}:{}", now_ms, rand::random::<u64>(), sequence)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn window_start_uses_milliseconds() {
+        assert_eq!(window_start_ms(10_000, 3), 7_000);
+    }
+
+    #[test]
+    fn window_start_saturates() {
+        assert_eq!(window_start_ms(500, 3), 0);
+    }
+
+    #[test]
+    fn entry_members_are_unique_for_same_timestamp() {
+        let now_ms = 42;
+
+        let first = entry_member(now_ms);
+        let second = entry_member(now_ms);
+
+        assert_ne!(first, second);
+        assert!(first.starts_with("42:"));
+        assert!(second.starts_with("42:"));
+    }
+}

--- a/crates/sockudo-rate-limiter/tests/redis_limiter_live.rs
+++ b/crates/sockudo-rate-limiter/tests/redis_limiter_live.rs
@@ -1,0 +1,89 @@
+#![cfg(feature = "redis")]
+
+use redis::AsyncCommands;
+use sockudo_rate_limiter::RateLimiter;
+use sockudo_rate_limiter::redis_limiter::RedisRateLimiter;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn redis_url() -> String {
+    std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379/".to_string())
+}
+
+fn unique_prefix(test_name: &str) -> String {
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_millis();
+
+    format!("sockudo-rate-limiter-live:{test_name}:{now_ms}")
+}
+
+#[tokio::test]
+#[ignore = "requires a live Redis-compatible server, such as Valkey, on REDIS_URL or localhost:6379"]
+async fn redis_limiter_counts_each_request_in_same_second() {
+    let client = redis::Client::open(redis_url()).expect("valid Redis URL");
+    let prefix = unique_prefix("burst");
+    let redis_key = format!("{prefix}:rl:ip-1");
+    let limiter = RedisRateLimiter::new(client.clone(), prefix, 3, 60)
+        .await
+        .expect("Redis limiter should connect");
+
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("direct Redis connection should connect");
+    let _: usize = conn.del(&redis_key).await.expect("test key cleanup");
+
+    let first = limiter.increment("ip-1").await.expect("first increment");
+    let second = limiter.increment("ip-1").await.expect("second increment");
+    let third = limiter.increment("ip-1").await.expect("third increment");
+    let fourth = limiter.increment("ip-1").await.expect("fourth increment");
+
+    let count: usize = conn
+        .zcard(&redis_key)
+        .await
+        .expect("read limiter zset size");
+    let _: usize = conn.del(&redis_key).await.expect("test key cleanup");
+
+    assert!(first.allowed);
+    assert!(second.allowed);
+    assert!(third.allowed);
+    assert!(!fourth.allowed);
+    assert_eq!(third.remaining, 0);
+    assert_eq!(fourth.remaining, 0);
+    assert_eq!(count, 3);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Redis-compatible server, such as Valkey, on REDIS_URL or localhost:6379"]
+async fn redis_limiter_removes_expired_window_entries() {
+    let client = redis::Client::open(redis_url()).expect("valid Redis URL");
+    let prefix = unique_prefix("cleanup");
+    let redis_key = format!("{prefix}:rl:ip-1");
+    let limiter = RedisRateLimiter::new(client.clone(), prefix, 5, 1)
+        .await
+        .expect("Redis limiter should connect");
+
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("direct Redis connection should connect");
+    let _: usize = conn.del(&redis_key).await.expect("test key cleanup");
+    let _: usize = conn
+        .zadd(&redis_key, "expired-member", 0_u64)
+        .await
+        .expect("insert expired limiter member");
+
+    let before: usize = conn.zcard(&redis_key).await.expect("read seeded zset size");
+    let result = limiter.check("ip-1").await.expect("check cleans window");
+    let after: usize = conn
+        .zcard(&redis_key)
+        .await
+        .expect("read cleaned zset size");
+    let _: usize = conn.del(&redis_key).await.expect("test key cleanup");
+
+    assert_eq!(before, 1);
+    assert!(result.allowed);
+    assert_eq!(result.remaining, 5);
+    assert_eq!(after, 0);
+}


### PR DESCRIPTION
## Summary

- replace Redis limiter cleanup with `ZREMRANGEBYSCORE` via redis-rs `zrembyscore`
- switch Redis sorted-set scores from seconds to milliseconds for cleanup precision
- store unique per-request sorted-set members instead of reusing the timestamp as the member
- share Redis window timestamp/member helpers across standalone and cluster limiters
- add ignored live Redis/Valkey integration coverage for burst counting and stale-entry cleanup

Closes #250.
Closes #251.

## Verification

- `cargo fmt --all --check`
- `cargo test -p sockudo-rate-limiter`
- `cargo test -p sockudo-rate-limiter --features redis`
- `cargo test -p sockudo-rate-limiter --features redis-cluster`
- `REDIS_URL=redis://127.0.0.1:6379/ cargo test -p sockudo-rate-limiter --features redis --test redis_limiter_live -- --ignored --nocapture`
- `cargo clippy -p sockudo-rate-limiter --features redis --all-targets -- -D warnings`
- `cargo clippy -p sockudo-rate-limiter --features redis-cluster --all-targets -- -D warnings`
