### PR TITLE
perf(server): replace mimalloc with jemalloc as default allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,16 +4742,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5008,15 +4998,6 @@ dependencies = [
  "rand_xoshiro",
  "rapidhash",
  "sketches-ddsketch",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -8044,7 +8025,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jsonwebtoken",
- "mimalloc",
  "num_cpus",
  "redis",
  "rustls",
@@ -8072,6 +8052,7 @@ dependencies = [
  "surrealdb-types",
  "sysinfo",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tower",
@@ -9173,6 +9154,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ hyper-util = "^0.1.17"
 libc = "0.2"
 md5 = "0.8.0"
 memchr = "2.7"
-mimalloc = { version = "0.1.48", features = ["v3"] }
+tikv-jemallocator = "0.7"
 mockall = "0.13.1"
 moka = { version = "0.12.11", features = ["future", "sync"] }
 lapin = { version = "4.3.0", default-features = false, features = ["rustls", "tokio"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,10 @@ RUN test -f Cargo.lock || cargo generate-lockfile
 
 ARG SOCKUDO_FEATURES=full
 
+# Set jemalloc's page size to 4KB (use 16 for 64KB-page hosts)
+ARG JEMALLOC_SYS_WITH_LG_PAGE=12
+ENV JEMALLOC_SYS_WITH_LG_PAGE=${JEMALLOC_SYS_WITH_LG_PAGE}
+
 # Build dependencies only (this layer is cached unless Cargo.toml files change)
 RUN cargo build -p sockudo --release --features "${SOCKUDO_FEATURES}" || true
 # Clean up dummy sources but keep compiled deps

--- a/crates/sockudo-server/Cargo.toml
+++ b/crates/sockudo-server/Cargo.toml
@@ -114,7 +114,6 @@ http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
-mimalloc = { workspace = true }
 num_cpus = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
@@ -142,6 +141,9 @@ aws-sdk-dynamodb = { workspace = true, optional = true }
 jsonwebtoken = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }
 
 [dev-dependencies]
 redis = { workspace = true }

--- a/crates/sockudo-server/src/main.rs
+++ b/crates/sockudo-server/src/main.rs
@@ -34,7 +34,6 @@ use clap::Parser;
 use futures_util::future::join_all;
 #[cfg(all(feature = "push", feature = "monolith", feature = "push-apns"))]
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
-use mimalloc::MiMalloc;
 use sockudo_core::error::Error;
 #[cfg(all(feature = "push", feature = "monolith"))]
 use std::env;
@@ -4016,8 +4015,10 @@ mod tests {
     }
 }
 
+// jemalloc is the default allocator, Windows MSVC falls back to the system allocator
+#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
tikv-jemallocator 0.7 replaces mimalloc on all Unix targets (Linux gnu/musl, macOS). Windows MSVC is unsupported by jemalloc and falls back to the system allocator via cfg(not(target_env = "msvc")) on both the dep and the static.

The Dockerfile exposes JEMALLOC_SYS_WITH_LG_PAGE as a build arg (default 12 → 4 KB pages) so images can be rebuilt with --build-arg JEMALLOC_SYS_WITH_LG_PAGE=16 for 64 KB-page aarch64 hosts.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->