### PR TITLE
Keep subscription churn off cluster-wide count fanout

### DIFF
--- a/benches/subscription-churn.js
+++ b/benches/subscription-churn.js
@@ -1,0 +1,168 @@
+import ws from 'k6/ws';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+/*
+ * Subscription churn benchmark.
+ *
+ * Churn rate is approximately VUS / (ROOM_SWITCH_INTERVAL_MS / 1000).
+ * The reported staging case, 10k users and 500 unsub+sub/sec, is:
+ *
+ *   k6 run \
+ *     -e WS_HOSTS=wss://example.com/app/swag-dev-key \
+ *     -e VUS=10000 -e CHANNEL_COUNT=4000 \
+ *     -e ROOM_SWITCH_INTERVAL_MS=20000 \
+ *     -e SOCKET_LIFETIME_MS=600000 -e DURATION=10m \
+ *     benches/subscription-churn.js
+ *
+ * To ramp instead of holding a constant user count:
+ *
+ *   k6 run \
+ *     -e STAGES='[{"duration":"10m","target":10000},{"duration":"20m","target":10000}]' \
+ *     -e WS_HOSTS=wss://example.com/app/swag-dev-key \
+ *     -e CHANNEL_COUNT=4000 -e ROOM_SWITCH_INTERVAL_MS=20000 \
+ *     -e SOCKET_LIFETIME_MS=900000 \
+ *     benches/subscription-churn.js
+ */
+
+const wsHosts = (__ENV.WS_HOSTS || __ENV.WS_HOST || 'ws://127.0.0.1:6001/app/app-key')
+    .split(',')
+    .map((host) => host.trim())
+    .filter(Boolean);
+const vus = Number(__ENV.VUS || 100);
+const duration = __ENV.DURATION || '2m';
+const stages = __ENV.STAGES ? JSON.parse(__ENV.STAGES) : null;
+const channelCount = Number(__ENV.CHANNEL_COUNT || 4000);
+const channelPrefix = __ENV.CHANNEL_PREFIX || 'load-room-';
+const switchIntervalMs = Number(__ENV.ROOM_SWITCH_INTERVAL_MS || 20000);
+const socketLifetimeMs = Number(__ENV.SOCKET_LIFETIME_MS || 120000);
+const initialJitterMs = Number(__ENV.INITIAL_JITTER_MS || switchIntervalMs);
+const pingIntervalMs = Number(__ENV.PING_INTERVAL_MS || 30000);
+
+const subscribeAttempts = new Counter('sockudo_churn_subscribe_attempts');
+const unsubscribeAttempts = new Counter('sockudo_churn_unsubscribe_attempts');
+const subscriptionSuccessRate = new Rate('sockudo_churn_subscription_success_rate');
+const socketConnectedRate = new Rate('sockudo_churn_socket_connected_rate');
+const socketErrorRate = new Rate('sockudo_churn_socket_error_rate');
+const subscribeAckMs = new Trend('sockudo_churn_subscribe_ack_ms');
+
+export const options = {
+    scenarios: {
+        churn: stages
+            ? {
+                executor: 'ramping-vus',
+                stages,
+                gracefulRampDown: __ENV.GRACEFUL_RAMP_DOWN || '30s',
+            }
+            : {
+                executor: 'constant-vus',
+                vus,
+                duration,
+                gracefulStop: __ENV.GRACEFUL_STOP || '30s',
+            },
+    },
+    thresholds: {
+        sockudo_churn_socket_connected_rate: ['rate>0.99'],
+        sockudo_churn_socket_error_rate: ['rate<0.01'],
+        sockudo_churn_subscription_success_rate: ['rate>0.99'],
+        sockudo_churn_subscribe_ack_ms: ['p(95)<1000'],
+    },
+};
+
+function hostForVu() {
+    return wsHosts[(__VU - 1) % wsHosts.length];
+}
+
+function channelFor(step) {
+    const index = ((__VU - 1) * 997 + step) % channelCount;
+    return `${channelPrefix}${index}`;
+}
+
+function safeJson(raw) {
+    try {
+        return JSON.parse(raw);
+    } catch (_) {
+        return null;
+    }
+}
+
+function isSubscriptionSucceeded(message) {
+    return typeof message.event === 'string' && message.event.endsWith(':subscription_succeeded');
+}
+
+export default function () {
+    const pendingSubscriptions = {};
+    let step = __ITER;
+    let currentChannel = null;
+
+    ws.connect(hostForVu(), null, (socket) => {
+        socket.setTimeout(() => socket.close(), socketLifetimeMs);
+
+        socket.on('open', () => {
+            socketConnectedRate.add(true);
+            socket.setInterval(() => {
+                socket.send(JSON.stringify({
+                    event: 'pusher:ping',
+                    data: JSON.stringify({}),
+                }));
+            }, pingIntervalMs);
+        });
+
+        socket.on('message', (raw) => {
+            const message = safeJson(raw);
+            if (!message) {
+                return;
+            }
+
+            if (message.event === 'pusher:connection_established') {
+                const initialDelay = Math.max(1, Math.floor(Math.random() * initialJitterMs));
+                socket.setTimeout(() => switchRoom(socket), initialDelay);
+                socket.setInterval(() => switchRoom(socket), switchIntervalMs);
+                return;
+            }
+
+            if (isSubscriptionSucceeded(message)) {
+                currentChannel = message.channel || currentChannel;
+                subscriptionSuccessRate.add(true);
+                const startedAt = pendingSubscriptions[currentChannel];
+                if (startedAt) {
+                    subscribeAckMs.add(Date.now() - startedAt);
+                    delete pendingSubscriptions[currentChannel];
+                }
+                return;
+            }
+
+            if (message.event === 'pusher:error' || message.event === 'sockudo:error') {
+                subscriptionSuccessRate.add(false);
+            }
+        });
+
+        socket.on('error', () => {
+            socketErrorRate.add(true);
+            subscriptionSuccessRate.add(false);
+        });
+
+        socket.on('close', () => {
+            socketErrorRate.add(false);
+        });
+
+        function switchRoom(activeSocket) {
+            if (currentChannel) {
+                activeSocket.send(JSON.stringify({
+                    event: 'pusher:unsubscribe',
+                    data: { channel: currentChannel },
+                }));
+                unsubscribeAttempts.add(1);
+            }
+
+            step += 1;
+            const nextChannel = channelFor(step);
+            pendingSubscriptions[nextChannel] = Date.now();
+            activeSocket.send(JSON.stringify({
+                event: 'pusher:subscribe',
+                data: { channel: nextChannel },
+            }));
+            subscribeAttempts.add(1);
+            currentChannel = nextChannel;
+        }
+    });
+}

--- a/crates/sockudo-adapter/src/channel_manager.rs
+++ b/crates/sockudo-adapter/src/channel_manager.rs
@@ -110,7 +110,7 @@ impl ChannelManager {
         }
     }
 
-    pub async fn subscribe(
+    pub async fn subscribe_local(
         connection_manager: &Arc<dyn ConnectionManager + Send + Sync>,
         socket_id: &str,
         data: &PusherMessage,
@@ -140,48 +140,29 @@ impl ChannelManager {
         };
         let t_after_parse = t_start.elapsed().as_micros();
 
-        // Single lock acquisition for check and add (reduces lock contention)
+        // Local transition only. Cluster-wide counts are intentionally kept out
+        // of the subscribe hot path; callers that need them can query after the
+        // client acknowledgement has been sent.
         let t_before_lock = t_start.elapsed().as_micros();
-        let (is_already_in_channel, total_connections, activated_locally) = {
-            // Check if already in channel
-            let already_in = connection_manager
-                .is_in_channel(app_id, channel_name, &socket_id_owned)
-                .await?;
-
-            if already_in {
-                // Already subscribed, just get count
-                let count = connection_manager
-                    .get_channel_socket_count(app_id, channel_name)
-                    .await;
-                (true, count, false)
-            } else {
-                // Need to add to channel
-                connection_manager
-                    .add_to_channel(app_id, channel_name, &socket_id_owned)
-                    .await?;
-                let count = connection_manager
-                    .get_channel_socket_count(app_id, channel_name)
-                    .await;
-                // Local count drives the per-pod gauge: activate on the first local subscriber.
-                let local = connection_manager
-                    .get_local_channel_socket_count(app_id, channel_name)
-                    .await;
-                (false, count, local == 1)
-            }
-        };
+        let (newly_subscribed, local_connections) = connection_manager
+            .add_to_channel_and_count_local(app_id, channel_name, &socket_id_owned)
+            .await?;
+        let is_already_in_channel = !newly_subscribed;
+        let activated_locally = newly_subscribed && local_connections == 1;
         let t_after_lock = t_start.elapsed().as_micros();
 
         if is_already_in_channel {
             tracing::debug!(
-                "PERF[CHAN_MGR_ALREADY] channel={} total={}μs single_lock={}μs",
+                "PERF[CHAN_MGR_ALREADY] channel={} local_count={} total={}μs local_update={}μs",
                 channel_name,
+                local_connections,
                 t_start.elapsed().as_micros(),
                 t_after_lock - t_before_lock
             );
 
             return Ok(JoinResponse {
                 success: true,
-                channel_connections: Some(total_connections),
+                channel_connections: Some(local_connections),
                 activated_locally,
                 member: None,
                 auth_error: None,
@@ -202,8 +183,81 @@ impl ChannelManager {
         );
 
         Ok(Self::create_success_join_response(
-            total_connections,
+            local_connections,
             activated_locally,
+            member,
+        ))
+    }
+
+    pub async fn subscribe(
+        connection_manager: &Arc<dyn ConnectionManager + Send + Sync>,
+        socket_id: &str,
+        data: &PusherMessage,
+        channel_name: &str,
+        is_authenticated: bool,
+        app_id: &str,
+    ) -> Result<JoinResponse, Error> {
+        let mut response = Self::subscribe_local(
+            connection_manager,
+            socket_id,
+            data,
+            channel_name,
+            is_authenticated,
+            app_id,
+        )
+        .await?;
+
+        if response.success {
+            response.channel_connections = Some(
+                connection_manager
+                    .get_channel_socket_count(app_id, channel_name)
+                    .await,
+            );
+        }
+
+        Ok(response)
+    }
+
+    pub async fn unsubscribe_local(
+        connection_manager: &Arc<dyn ConnectionManager + Send + Sync>,
+        socket_id: &str,
+        channel_name: &str,
+        app_id: &str,
+        user_id: Option<&str>,
+    ) -> Result<LeaveResponse, Error> {
+        let socket_id_owned = SocketId::from_string(socket_id).unwrap_or_else(|_| SocketId::new());
+        let channel_type = ChannelType::from_name(channel_name);
+
+        let member = if channel_type == ChannelType::Presence {
+            if let Some(user_id) = user_id {
+                connection_manager
+                    .get_presence_member(app_id, channel_name, &socket_id_owned)
+                    .await
+                    .map(|member| PresenceMember {
+                        user_id: user_id.to_string().into_boxed_str(),
+                        user_info: member.user_info.unwrap_or_default(),
+                        socket_id: None,
+                    })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let (socket_removed, local_remaining) = connection_manager
+            .remove_from_channel_and_count_local(app_id, channel_name, &socket_id_owned)
+            .await?;
+
+        if local_remaining == 0 {
+            connection_manager
+                .remove_channel(app_id, channel_name)
+                .await;
+        }
+
+        Ok(Self::create_leave_response(
+            socket_removed,
+            local_remaining,
             member,
         ))
     }

--- a/crates/sockudo-adapter/src/connection_manager.rs
+++ b/crates/sockudo-adapter/src/connection_manager.rs
@@ -147,12 +147,32 @@ pub trait ConnectionManager: Send + Sync {
         channel: &str,
         socket_id: &SocketId,
     ) -> Result<bool>;
+    async fn add_to_channel_and_count_local(
+        &self,
+        app_id: &str,
+        channel: &str,
+        socket_id: &SocketId,
+    ) -> Result<(bool, usize)> {
+        let added = self.add_to_channel(app_id, channel, socket_id).await?;
+        let count = self.get_local_channel_socket_count(app_id, channel).await;
+        Ok((added, count))
+    }
     async fn remove_from_channel(
         &self,
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
     ) -> Result<bool>;
+    async fn remove_from_channel_and_count_local(
+        &self,
+        app_id: &str,
+        channel: &str,
+        socket_id: &SocketId,
+    ) -> Result<(bool, usize)> {
+        let removed = self.remove_from_channel(app_id, channel, socket_id).await?;
+        let count = self.get_local_channel_socket_count(app_id, channel).await;
+        Ok((removed, count))
+    }
     async fn get_presence_member(
         &self,
         app_id: &str,

--- a/crates/sockudo-adapter/src/factory.rs
+++ b/crates/sockudo-adapter/src/factory.rs
@@ -241,6 +241,7 @@ impl AdapterFactory {
                     Ok(mut adapter) => {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
+                        adapter.set_aggregate_counts(config.aggregate_counts);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Redis(adapter.clone());
                         Ok((adapter, typed))
@@ -301,6 +302,7 @@ impl AdapterFactory {
                     Ok(mut adapter) => {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
+                        adapter.set_aggregate_counts(config.aggregate_counts);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::RedisCluster(adapter.clone());
                         Ok((adapter, typed))
@@ -345,6 +347,7 @@ impl AdapterFactory {
                     Ok(mut adapter) => {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
+                        adapter.set_aggregate_counts(config.aggregate_counts);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Nats(adapter.clone());
                         Ok((adapter, typed))
@@ -379,6 +382,7 @@ impl AdapterFactory {
                     Ok(mut adapter) => {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
+                        adapter.set_aggregate_counts(config.aggregate_counts);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Pulsar(adapter.clone());
                         Ok((adapter, typed))
@@ -413,6 +417,7 @@ impl AdapterFactory {
                     Ok(mut adapter) => {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
+                        adapter.set_aggregate_counts(config.aggregate_counts);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::RabbitMq(adapter.clone());
                         Ok((adapter, typed))
@@ -447,6 +452,7 @@ impl AdapterFactory {
                     Ok(mut adapter) => {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
+                        adapter.set_aggregate_counts(config.aggregate_counts);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::GooglePubSub(adapter.clone());
                         Ok((adapter, typed))
@@ -484,6 +490,7 @@ impl AdapterFactory {
                     Ok(mut adapter) => {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
+                        adapter.set_aggregate_counts(config.aggregate_counts);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Kafka(adapter.clone());
                         Ok((adapter, typed))
@@ -529,6 +536,7 @@ impl AdapterFactory {
                     Ok(mut adapter) => {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
+                        adapter.set_aggregate_counts(config.aggregate_counts);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Iggy(adapter.clone());
                         Ok((adapter, typed))

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -127,28 +127,17 @@ impl ConnectionHandler {
                 .await?;
         }
 
-        self.spawn_unsubscribe_count_notifications(app_config.clone(), channel_name.clone());
-
-        Ok(())
-    }
-
-    fn spawn_unsubscribe_count_notifications(&self, app_config: App, channel_name: String) {
-        if sockudo_core::utils::is_meta_channel(&channel_name) {
-            return;
+        if let Err(e) = self
+            .send_unsubscribe_count_notifications(app_config, &channel_name)
+            .await
+        {
+            warn!(
+                "Failed to emit unsubscribe count notifications for {}: {}",
+                channel_name, e
+            );
         }
 
-        let handler = self.clone();
-        tokio::spawn(async move {
-            if let Err(e) = handler
-                .send_unsubscribe_count_notifications(&app_config, &channel_name)
-                .await
-            {
-                warn!(
-                    "Failed to emit unsubscribe count notifications for {}: {}",
-                    channel_name, e
-                );
-            }
-        });
+        Ok(())
     }
 
     async fn send_unsubscribe_count_notifications(

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -149,6 +149,16 @@ impl ConnectionHandler {
             return Ok(());
         }
 
+        // Skip the cluster-wide count request/reply entirely when nothing consumes
+        // it. This is the room-switch hot path; a fanout here per unsubscribe is the
+        // dominant churn cost on multi-node clusters.
+        if !self
+            .subscription_count_has_consumer(app_config, channel_name)
+            .await
+        {
+            return Ok(());
+        }
+
         let current_sub_count = self
             .connection_manager
             .get_channel_socket_count(&app_config.id, channel_name)
@@ -182,6 +192,7 @@ impl ConnectionHandler {
 
         if current_sub_count == 0
             && let Some(webhook_integration) = &self.webhook_integration
+            && webhook_integration.webhook_configured(app_config, "channel_vacated")
         {
             let wi = Arc::clone(webhook_integration);
             let cm = Arc::clone(&self.connection_manager);
@@ -197,6 +208,38 @@ impl ConnectionHandler {
         }
 
         Ok(())
+    }
+
+    /// Returns true when the cluster-wide subscription count for `channel` is
+    /// actually consumed by something — a configured webhook (channel_occupied /
+    /// channel_vacated / subscription_count) or local subscribers on the channel's
+    /// meta-channel. When false, the subscribe/unsubscribe hot path skips the
+    /// cross-node count request/reply entirely.
+    ///
+    /// Trade-off: with no local consumer we also skip the subscription_count
+    /// meta-channel update for subscribers living on a *different* node than the
+    /// membership change. Exact cluster-wide counts for that case need the
+    /// aggregate-count path (gossiped deltas), not per-event request/reply.
+    pub(crate) async fn subscription_count_has_consumer(
+        &self,
+        app_config: &App,
+        channel: &str,
+    ) -> bool {
+        if let Some(webhook_integration) = &self.webhook_integration
+            && webhook_integration.wants_subscription_count(app_config)
+        {
+            return true;
+        }
+
+        match sockudo_core::utils::meta_channel_for(channel) {
+            Some(meta_channel) => {
+                self.connection_manager
+                    .get_local_channel_socket_count(&app_config.id, &meta_channel)
+                    .await
+                    > 0
+            }
+            None => false,
+        }
     }
 
     async fn should_use_async_cleanup(&self) -> bool {
@@ -706,6 +749,7 @@ impl ConnectionHandler {
         // Per Pusher spec: delay prevents spurious webhooks from momentary disconnects
         if current_sub_count == 0
             && let Some(webhook_integration) = &self.webhook_integration
+            && webhook_integration.webhook_configured(app_config, "channel_vacated")
         {
             let wi = Arc::clone(webhook_integration);
             let cm = Arc::clone(&self.connection_manager);

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -66,8 +66,10 @@ impl ConnectionHandler {
         self.delta_compression
             .clear_channel_state(socket_id, &channel_name);
 
-        // Perform unsubscription through channel manager
-        let leave_response = ChannelManager::unsubscribe(
+        // Perform the local unsubscription first. Cluster-wide count updates are
+        // emitted after the hot path so client room-switch churn does not block
+        // on horizontal request/reply fanout.
+        let leave_response = ChannelManager::unsubscribe_local(
             &self.connection_manager,
             &socket_id.to_string(),
             &channel_name,
@@ -79,13 +81,6 @@ impl ConnectionHandler {
         // Update connection state
         self.update_connection_unsubscribe_state(socket_id, app_config, &channel_name)
             .await?;
-
-        // Get current subscription count after unsubscribe (cluster-wide, used
-        // for subscription_count / channel_vacated events and webhooks below).
-        let current_sub_count = self
-            .connection_manager
-            .get_channel_socket_count(&app_config.id, &channel_name)
-            .await;
 
         // Track unsubscription metrics
         if let Some(ref metrics) = self.metrics {
@@ -108,71 +103,101 @@ impl ConnectionHandler {
         }
 
         // Handle presence channel member removal
-        if channel_name.starts_with("presence-") {
-            if let Some(user_id_str) = user_id {
-                let presence_history_policy = app_config.resolved_presence_history(
+        if channel_name.starts_with("presence-")
+            && let Some(user_id_str) = user_id
+        {
+            let presence_history_policy = app_config
+                .resolved_presence_history(&channel_name, &self.server_options().presence_history);
+            // Use centralized presence member removal logic (instance method for race safety)
+            self.presence_manager
+                .handle_member_removed(
+                    &self.connection_manager,
+                    Arc::clone(self.presence_history_store()),
+                    presence_history_policy.enabled,
+                    self.webhook_integration.as_ref(),
+                    self.metrics.as_ref(),
+                    app_config,
                     &channel_name,
-                    &self.server_options().presence_history,
-                );
-                // Use centralized presence member removal logic (instance method for race safety)
-                self.presence_manager
-                    .handle_member_removed(
-                        &self.connection_manager,
-                        Arc::clone(self.presence_history_store()),
-                        presence_history_policy.enabled,
-                        self.webhook_integration.as_ref(),
-                        self.metrics.as_ref(),
-                        app_config,
-                        &channel_name,
-                        &user_id_str,
-                        Some(socket_id),
-                        sockudo_core::presence_history::PresenceHistoryEventCause::Disconnect,
-                        None,
-                        Some(presence_history_policy.retention()),
-                    )
-                    .await?;
-            }
-        } else {
-            // Send subscription count webhook for non-presence channels
-            if !sockudo_core::utils::is_meta_channel(&channel_name)
-                && let Some(webhook_integration) = &self.webhook_integration
+                    &user_id_str,
+                    Some(socket_id),
+                    sockudo_core::presence_history::PresenceHistoryEventCause::Disconnect,
+                    None,
+                    Some(presence_history_policy.retention()),
+                )
+                .await?;
+        }
+
+        self.spawn_unsubscribe_count_notifications(app_config.clone(), channel_name.clone());
+
+        Ok(())
+    }
+
+    fn spawn_unsubscribe_count_notifications(&self, app_config: App, channel_name: String) {
+        if sockudo_core::utils::is_meta_channel(&channel_name) {
+            return;
+        }
+
+        let handler = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handler
+                .send_unsubscribe_count_notifications(&app_config, &channel_name)
+                .await
             {
-                webhook_integration
-                    .send_subscription_count_changed(app_config, &channel_name, current_sub_count)
-                    .await
-                    .ok();
+                warn!(
+                    "Failed to emit unsubscribe count notifications for {}: {}",
+                    channel_name, e
+                );
             }
+        });
+    }
+
+    async fn send_unsubscribe_count_notifications(
+        &self,
+        app_config: &App,
+        channel_name: &str,
+    ) -> Result<()> {
+        if sockudo_core::utils::is_meta_channel(channel_name) {
+            return Ok(());
         }
 
-        if !sockudo_core::utils::is_meta_channel(&channel_name) {
-            let event_name = if current_sub_count == 0 {
-                "channel_vacated"
-            } else {
-                "subscription_count"
-            };
-            self.broadcast_metachannel_event(
-                app_config,
-                &channel_name,
-                event_name,
-                sonic_rs::json!({
-                    "channel": channel_name,
-                    "subscription_count": current_sub_count,
-                }),
-            )
-            .await
-            .ok();
+        let current_sub_count = self
+            .connection_manager
+            .get_channel_socket_count(&app_config.id, channel_name)
+            .await;
+
+        if !channel_name.starts_with("presence-")
+            && let Some(webhook_integration) = &self.webhook_integration
+        {
+            webhook_integration
+                .send_subscription_count_changed(app_config, channel_name, current_sub_count)
+                .await
+                .ok();
         }
 
-        // Send channel_vacated webhook if no subscribers left (with 3-second delay)
-        // Per Pusher spec: delay prevents spurious webhooks from momentary disconnects
+        let event_name = if current_sub_count == 0 {
+            "channel_vacated"
+        } else {
+            "subscription_count"
+        };
+        self.broadcast_metachannel_event(
+            app_config,
+            channel_name,
+            event_name,
+            sonic_rs::json!({
+                "channel": channel_name,
+                "subscription_count": current_sub_count,
+            }),
+        )
+        .await
+        .ok();
+
         if current_sub_count == 0
-            && !sockudo_core::utils::is_meta_channel(&channel_name)
             && let Some(webhook_integration) = &self.webhook_integration
         {
             let wi = Arc::clone(webhook_integration);
             let cm = Arc::clone(&self.connection_manager);
             let app = app_config.clone();
-            let channel = channel_name.clone();
+            let channel = channel_name.to_string();
             tokio::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_secs(3)).await;
                 let count = cm.get_channel_socket_count(&app.id, &channel).await;

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -375,6 +375,16 @@ impl ConnectionHandler {
             return Ok(());
         }
 
+        // Skip the cluster-wide count request/reply entirely when nothing consumes
+        // it. This is the room-switch hot path; a fanout here per subscribe is the
+        // dominant churn cost on multi-node clusters.
+        if !self
+            .subscription_count_has_consumer(app_config, channel)
+            .await
+        {
+            return Ok(());
+        }
+
         let current_count = self
             .connection_manager
             .get_channel_socket_count(&app_config.id, channel)

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -346,7 +346,16 @@ impl ConnectionHandler {
             );
         }
 
-        self.spawn_subscription_count_notifications(app_config.clone(), request.channel.clone());
+        if let Err(e) = self
+            .send_subscription_count_notifications(app_config, &request.channel)
+            .await
+        {
+            tracing::warn!(
+                "Failed to emit subscription count notifications for {}: {}",
+                request.channel,
+                e
+            );
+        }
 
         // Handle cache channels
         if is_cache_channel(&request.channel) {
@@ -355,26 +364,6 @@ impl ConnectionHandler {
         }
 
         Ok(())
-    }
-
-    fn spawn_subscription_count_notifications(&self, app_config: App, channel: String) {
-        if sockudo_core::utils::is_meta_channel(&channel) {
-            return;
-        }
-
-        let handler = self.clone();
-        tokio::spawn(async move {
-            if let Err(e) = handler
-                .send_subscription_count_notifications(&app_config, &channel)
-                .await
-            {
-                tracing::warn!(
-                    "Failed to emit subscription count notifications for {}: {}",
-                    channel,
-                    e
-                );
-            }
-        });
     }
 
     async fn send_subscription_count_notifications(

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -134,7 +134,7 @@ impl ConnectionHandler {
                             request.channel,
                             t_before_fallback
                         );
-                        let result = ChannelManager::subscribe(
+                        let result = ChannelManager::subscribe_local(
                             &self.connection_manager,
                             &socket_id.to_string(),
                             &temp_message,
@@ -156,7 +156,7 @@ impl ConnectionHandler {
             } else {
                 // Can't use fast-path for presence channels, use normal path
                 let t_before_normal = t_start.elapsed().as_micros();
-                let result = ChannelManager::subscribe(
+                let result = ChannelManager::subscribe_local(
                     &self.connection_manager,
                     &socket_id.to_string(),
                     &temp_message,
@@ -177,7 +177,7 @@ impl ConnectionHandler {
         } else {
             // No LocalAdapter, use normal path (Redis, NATS, etc.)
             let t_before_redis = t_start.elapsed().as_micros();
-            let result = ChannelManager::subscribe(
+            let result = ChannelManager::subscribe_local(
                 &self.connection_manager,
                 &socket_id.to_string(),
                 &temp_message,
@@ -346,52 +346,70 @@ impl ConnectionHandler {
             );
         }
 
-        // Send webhooks after subscription success response (non-blocking for client)
-        if subscription_result.channel_connections == Some(1)
-            && let Some(webhook_integration) = self.webhook_integration.clone()
-        {
-            let app_config = app_config.clone();
-            let channel = request.channel.clone();
-            tokio::spawn(async move {
-                if let Err(e) = webhook_integration
-                    .send_channel_occupied(&app_config, &channel)
-                    .await
-                {
-                    tracing::warn!(
-                        "Failed to send channel_occupied webhook for {}: {}",
-                        channel,
-                        e
-                    );
-                }
-            });
+        self.spawn_subscription_count_notifications(app_config.clone(), request.channel.clone());
+
+        // Handle cache channels
+        if is_cache_channel(&request.channel) {
+            self.send_missed_cache_if_exists(&app_config.id, socket_id, &request.channel)
+                .await?;
         }
 
-        if !sockudo_core::utils::is_meta_channel(&request.channel) {
-            let current_count = self
-                .connection_manager
-                .get_channel_socket_count(&app_config.id, &request.channel)
-                .await;
+        Ok(())
+    }
 
-            if current_count == 1 {
-                self.broadcast_metachannel_event(
-                    app_config,
-                    &request.channel,
-                    "channel_occupied",
-                    sonic_rs::json!({
-                        "channel": request.channel,
-                        "subscription_count": current_count,
-                    }),
-                )
+    fn spawn_subscription_count_notifications(&self, app_config: App, channel: String) {
+        if sockudo_core::utils::is_meta_channel(&channel) {
+            return;
+        }
+
+        let handler = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handler
+                .send_subscription_count_notifications(&app_config, &channel)
                 .await
-                .ok();
+            {
+                tracing::warn!(
+                    "Failed to emit subscription count notifications for {}: {}",
+                    channel,
+                    e
+                );
+            }
+        });
+    }
+
+    async fn send_subscription_count_notifications(
+        &self,
+        app_config: &App,
+        channel: &str,
+    ) -> Result<()> {
+        if sockudo_core::utils::is_meta_channel(channel) {
+            return Ok(());
+        }
+
+        let current_count = self
+            .connection_manager
+            .get_channel_socket_count(&app_config.id, channel)
+            .await;
+
+        if current_count == 1 {
+            if let Some(webhook_integration) = &self.webhook_integration
+                && let Err(e) = webhook_integration
+                    .send_channel_occupied(app_config, channel)
+                    .await
+            {
+                tracing::warn!(
+                    "Failed to send channel_occupied webhook for {}: {}",
+                    channel,
+                    e
+                );
             }
 
             self.broadcast_metachannel_event(
                 app_config,
-                &request.channel,
-                "subscription_count",
+                channel,
+                "channel_occupied",
                 sonic_rs::json!({
-                    "channel": request.channel,
+                    "channel": channel,
                     "subscription_count": current_count,
                 }),
             )
@@ -399,26 +417,25 @@ impl ConnectionHandler {
             .ok();
         }
 
-        // Send subscription count webhook for non-presence channels
-        if !request.channel.starts_with("presence-")
-            && !sockudo_core::utils::is_meta_channel(&request.channel)
+        self.broadcast_metachannel_event(
+            app_config,
+            channel,
+            "subscription_count",
+            sonic_rs::json!({
+                "channel": channel,
+                "subscription_count": current_count,
+            }),
+        )
+        .await
+        .ok();
+
+        if !channel.starts_with("presence-")
             && let Some(webhook_integration) = &self.webhook_integration
         {
-            let current_count = self
-                .connection_manager
-                .get_channel_socket_count(&app_config.id, &request.channel)
-                .await;
-
             webhook_integration
-                .send_subscription_count_changed(app_config, &request.channel, current_count)
+                .send_subscription_count_changed(app_config, channel, current_count)
                 .await
                 .ok();
-        }
-
-        // Handle cache channels
-        if is_cache_channel(&request.channel) {
-            self.send_missed_cache_if_exists(&app_config.id, socket_id, &request.channel)
-                .await?;
         }
 
         Ok(())

--- a/crates/sockudo-adapter/src/horizontal_adapter.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter.rs
@@ -51,6 +51,10 @@ pub enum RequestType {
     // State synchronization
     PresenceStateSync,        // Send bulk presence state to a specific node
     BatchChannelSocketsCount, // Get socket counts for a list of channels in one round-trip
+
+    // Tier 1A: aggregate channel counts (gossip, fire-and-forget)
+    ChannelCountUpdate, // Peer's absolute local counts for changed channels
+    ChannelCountSync,   // Full snapshot of a peer's local channel counts (on join)
 }
 
 /// Request body for horizontal communication
@@ -214,6 +218,16 @@ pub struct HorizontalAdapter {
 
     /// Sequence counter for conflict resolution
     pub sequence_counter: Arc<AtomicU64>,
+
+    /// Tier 1A: cluster-wide per-channel socket counts contributed by *peer*
+    /// nodes. Keyed by (app_id, channel) -> {node_id -> local_count}. Global count
+    /// for a channel = local namespace count + sum of these. Lock-free (DashMap)
+    /// by design — this is a hot read path, never put it behind a coarse RwLock.
+    pub cluster_channel_counts: Arc<DashMap<(String, String), AHashMap<String, usize>>>,
+
+    /// Tier 1A: (app_id, channel) keys whose local count changed and must be
+    /// gossiped on the next flush tick. Coalesces churn into bounded broadcasts.
+    pub dirty_channel_counts: Arc<DashMap<(String, String), ()>>,
 }
 
 impl Default for HorizontalAdapter {
@@ -234,6 +248,8 @@ impl HorizontalAdapter {
             cluster_presence_registry: Arc::new(RwLock::new(AHashMap::new())),
             node_heartbeats: Arc::new(RwLock::new(AHashMap::new())),
             sequence_counter: Arc::new(AtomicU64::new(0)),
+            cluster_channel_counts: Arc::new(DashMap::new()),
+            dirty_channel_counts: Arc::new(DashMap::new()),
         }
     }
 
@@ -491,6 +507,8 @@ impl HorizontalAdapter {
 
                     // Clean up local presence registry only
                     self.cleanup_local_presence_registry(dead_node_id).await;
+                    // Tier 1A: drop the dead node's channel-count contributions
+                    self.purge_node_channel_counts(dead_node_id);
                 }
             }
             RequestType::BatchChannelSocketsCount => {
@@ -567,10 +585,126 @@ impl HorizontalAdapter {
                     }
                 }
             }
+            RequestType::ChannelCountUpdate | RequestType::ChannelCountSync => {
+                // Tier 1A: peer reported absolute local counts (Update = changed
+                // channels, Sync = full snapshot on join). Apply to the registry;
+                // fire-and-forget, no response produced.
+                if request.node_id != self.node_id
+                    && let Some(payload) = request.user_info.as_ref()
+                    && let Ok(counts) = sonic_rs::to_vec(payload)
+                        .and_then(|b| sonic_rs::from_slice::<AHashMap<String, usize>>(&b))
+                {
+                    let full_snapshot = request.request_type == RequestType::ChannelCountSync;
+                    self.apply_remote_channel_counts(
+                        &request.app_id,
+                        &request.node_id,
+                        counts,
+                        full_snapshot,
+                    );
+                }
+            }
         }
 
         // Return the response
         Ok(response)
+    }
+
+    // ---- Tier 1A: cluster channel-count registry (gossiped aggregate) ----
+
+    /// Apply a peer's reported absolute local counts. `full_snapshot` first drops
+    /// the node's existing entries for this app (join-time `ChannelCountSync`); a
+    /// per-channel count of 0 removes that node's contribution to the channel.
+    pub fn apply_remote_channel_counts(
+        &self,
+        app_id: &str,
+        node_id: &str,
+        counts: AHashMap<String, usize>,
+        full_snapshot: bool,
+    ) {
+        if node_id == self.node_id {
+            return;
+        }
+        if full_snapshot {
+            self.purge_node_channel_counts_for_app(app_id, node_id);
+        }
+        for (channel, count) in counts {
+            let key = (app_id.to_string(), channel);
+            if count == 0 {
+                if let Some(mut entry) = self.cluster_channel_counts.get_mut(&key) {
+                    entry.remove(node_id);
+                    let empty = entry.is_empty();
+                    drop(entry);
+                    if empty {
+                        self.cluster_channel_counts.remove(&key);
+                    }
+                }
+            } else {
+                self.cluster_channel_counts
+                    .entry(key)
+                    .or_default()
+                    .insert(node_id.to_string(), count);
+            }
+        }
+    }
+
+    /// Sum of *peer* contributions to a channel (excludes this node's local count).
+    pub fn remote_channel_count(&self, app_id: &str, channel: &str) -> usize {
+        self.cluster_channel_counts
+            .get(&(app_id.to_string(), channel.to_string()))
+            .map(|entry| entry.values().sum())
+            .unwrap_or(0)
+    }
+
+    /// All channels with peer contributions for an app, summed across peers.
+    pub fn remote_channels_with_counts(&self, app_id: &str) -> AHashMap<String, usize> {
+        let mut out = AHashMap::new();
+        for entry in self.cluster_channel_counts.iter() {
+            let (entry_app, channel) = entry.key();
+            if entry_app == app_id {
+                let sum: usize = entry.value().values().sum();
+                if sum > 0 {
+                    out.insert(channel.clone(), sum);
+                }
+            }
+        }
+        out
+    }
+
+    /// Remove a node's contributions for one app (snapshot replace).
+    fn purge_node_channel_counts_for_app(&self, app_id: &str, node_id: &str) {
+        self.cluster_channel_counts.retain(|key, entry| {
+            if key.0 == app_id {
+                entry.remove(node_id);
+            }
+            !entry.is_empty()
+        });
+    }
+
+    /// Remove a dead node's contributions across all apps/channels.
+    pub fn purge_node_channel_counts(&self, node_id: &str) {
+        self.cluster_channel_counts.retain(|_key, entry| {
+            entry.remove(node_id);
+            !entry.is_empty()
+        });
+    }
+
+    /// Mark (app, channel) as needing a gossip on the next flush tick.
+    pub fn mark_channel_count_dirty(&self, app_id: &str, channel: &str) {
+        self.dirty_channel_counts
+            .insert((app_id.to_string(), channel.to_string()), ());
+    }
+
+    /// Drain the dirty set, returning the (app, channel) pairs to gossip.
+    pub fn drain_dirty_channel_counts(&self) -> Vec<(String, String)> {
+        let keys: Vec<(String, String)> = self
+            .dirty_channel_counts
+            .iter()
+            .map(|e| e.key().clone())
+            .collect();
+        for k in &keys {
+            self.dirty_channel_counts.remove(k);
+        }
+        keys
     }
 
     /// Process a response received from another node
@@ -940,6 +1074,9 @@ impl HorizontalAdapter {
                 }
                 RequestType::PresenceStateSync => {
                     // These are broadcast-only requests, no response aggregation needed
+                }
+                RequestType::ChannelCountUpdate | RequestType::ChannelCountSync => {
+                    // Tier 1A: gossip-only, no response aggregation needed
                 }
             }
         }

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -47,6 +47,9 @@ pub struct HorizontalAdapterBase<T: HorizontalTransport> {
     pub node_timeout_ms: u64,
     pub cleanup_interval_ms: u64,
     pub enable_socket_counting: bool,
+    /// Tier 1A: when true, channel counts are read from the gossiped registry
+    /// (local + peers) instead of cross-node request/reply.
+    pub aggregate_counts: bool,
     #[cfg(feature = "delta")]
     // Delta compression manager for bandwidth optimization
     delta_compression: Option<Arc<sockudo_delta::DeltaCompressionManager>>,
@@ -123,6 +126,7 @@ where
             node_timeout_ms: cluster_health_defaults.node_timeout_ms,
             cleanup_interval_ms: cluster_health_defaults.cleanup_interval_ms,
             enable_socket_counting: true, // Default to enabled
+            aggregate_counts: false,      // Tier 1A: opt-in via config
             #[cfg(feature = "delta")]
             delta_compression: None,
             #[cfg(feature = "delta")]
@@ -227,6 +231,11 @@ where
     /// Set socket counting configuration
     pub fn set_socket_counting(&mut self, enable: bool) {
         self.enable_socket_counting = enable;
+    }
+
+    /// Tier 1A: enable reading channel counts from the gossiped registry.
+    pub fn set_aggregate_counts(&mut self, enable: bool) {
+        self.aggregate_counts = enable;
     }
 
     /// Publish a pre-built RequestBody and collect responses from other nodes
@@ -786,6 +795,109 @@ where
 
         // Start dead node detection
         self.start_dead_node_detection().await;
+
+        // Tier 1A: gossip local channel counts so peers answer counts locally
+        if self.aggregate_counts {
+            self.start_count_gossip_loop().await;
+        }
+    }
+
+    /// Tier 1A: periodically gossip this node's local channel counts so every node
+    /// answers count queries locally. Per-tick diffs (ChannelCountUpdate) plus a
+    /// periodic full snapshot (ChannelCountSync) that seeds new nodes and heals drift.
+    async fn start_count_gossip_loop(&self) {
+        let transport = self.transport.clone();
+        let local_adapter = self.local_adapter.clone();
+        let horizontal = self.horizontal.clone();
+        let node_id = self.node_id.clone();
+        let is_running = self.is_running.clone();
+
+        tokio::spawn(async move {
+            const FLUSH_INTERVAL_MS: u64 = 100;
+            const FULL_SNAPSHOT_EVERY_TICKS: u64 = 50; // ~5s
+            let mut interval = tokio::time::interval(Duration::from_millis(FLUSH_INTERVAL_MS));
+            let mut last: std::collections::HashMap<String, ahash::AHashMap<String, usize>> =
+                std::collections::HashMap::new();
+            let mut tick: u64 = 0;
+
+            loop {
+                interval.tick().await;
+                if !is_running.load(Ordering::Relaxed) {
+                    break;
+                }
+                tick = tick.wrapping_add(1);
+                let full = tick % FULL_SNAPSHOT_EVERY_TICKS == 0;
+
+                // Only gossip when there are peers to receive it.
+                if horizontal.get_effective_node_count().await <= 1 {
+                    continue;
+                }
+
+                let namespaces = match local_adapter.get_namespaces().await {
+                    Ok(ns) => ns,
+                    Err(_) => continue,
+                };
+
+                let mut seen_apps = std::collections::HashSet::new();
+                for (app_id, namespace) in namespaces {
+                    seen_apps.insert(app_id.clone());
+                    let current = namespace
+                        .get_channels_with_socket_count()
+                        .await
+                        .unwrap_or_default();
+                    let prev = last.entry(app_id.clone()).or_default();
+
+                    let payload: ahash::AHashMap<String, usize> = if full {
+                        current.clone()
+                    } else {
+                        let mut changed = ahash::AHashMap::new();
+                        for (ch, cnt) in &current {
+                            if prev.get(ch) != Some(cnt) {
+                                changed.insert(ch.clone(), *cnt);
+                            }
+                        }
+                        for ch in prev.keys() {
+                            if !current.contains_key(ch) {
+                                changed.insert(ch.clone(), 0);
+                            }
+                        }
+                        changed
+                    };
+
+                    *prev = current;
+
+                    // Diff ticks skip when nothing changed; full ticks always send
+                    // (an empty full snapshot clears this node's contribution).
+                    if payload.is_empty() && !full {
+                        continue;
+                    }
+
+                    if let Ok(user_info) = sonic_rs::to_value(&payload) {
+                        let request = RequestBody {
+                            request_id: generate_request_id(),
+                            node_id: node_id.clone(),
+                            app_id,
+                            request_type: if full {
+                                RequestType::ChannelCountSync
+                            } else {
+                                RequestType::ChannelCountUpdate
+                            },
+                            channel: None,
+                            socket_id: None,
+                            user_id: None,
+                            user_info: Some(user_info),
+                            timestamp: Some(current_timestamp()),
+                            dead_node_id: None,
+                            target_node_id: None,
+                            reply_to: None,
+                            channels: None,
+                        };
+                        let _ = transport.publish_request(&request).await;
+                    }
+                }
+                last.retain(|app, _| seen_apps.contains(app));
+            }
+        });
     }
 
     /// Start heartbeat broadcasting loop
@@ -866,6 +978,8 @@ where
 
                             // 1. Remove from local heartbeat tracking
                             horizontal.remove_dead_node(&dead_node_id).await;
+                            // Tier 1A: drop the dead node's channel-count contributions
+                            horizontal.purge_node_channel_counts(&dead_node_id);
 
                             // 2. Get orphaned members and clean up local registry
                             let cleanup_tasks = match horizontal
@@ -1413,6 +1527,15 @@ where
             .get_channel_socket_count(app_id, channel)
             .await;
 
+        // Tier 1A: read peer contributions from the gossiped registry instead of a
+        // cross-node request/reply.
+        if self.aggregate_counts {
+            return crate::connection_manager::ChannelSocketCount {
+                count: local_count + self.horizontal.remote_channel_count(app_id, channel),
+                complete: true,
+            };
+        }
+
         // Get distributed count
         match self
             .send_request(
@@ -1650,6 +1773,14 @@ where
             .local_adapter
             .get_channels_with_socket_count(app_id)
             .await?;
+
+        // Tier 1A: merge peer counts from the gossiped registry, no fan-out.
+        if self.aggregate_counts {
+            for (channel, count) in self.horizontal.remote_channels_with_counts(app_id) {
+                *channels.entry(channel).or_insert(0) += count;
+            }
+            return Ok(channels);
+        }
 
         // Get distributed channels
         match self

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -1510,6 +1510,17 @@ where
             .await
     }
 
+    async fn add_to_channel_and_count_local(
+        &self,
+        app_id: &str,
+        channel: &str,
+        socket_id: &SocketId,
+    ) -> Result<(bool, usize)> {
+        self.local_adapter
+            .add_to_channel_and_count_local(app_id, channel, socket_id)
+            .await
+    }
+
     async fn remove_from_channel(
         &self,
         app_id: &str,
@@ -1519,6 +1530,17 @@ where
         // Fast path: direct local adapter access without locking horizontal
         self.local_adapter
             .remove_from_channel(app_id, channel, socket_id)
+            .await
+    }
+
+    async fn remove_from_channel_and_count_local(
+        &self,
+        app_id: &str,
+        channel: &str,
+        socket_id: &SocketId,
+    ) -> Result<(bool, usize)> {
+        self.local_adapter
+            .remove_from_channel_and_count_local(app_id, channel, socket_id)
             .await
     }
 

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -826,7 +826,7 @@ where
                     break;
                 }
                 tick = tick.wrapping_add(1);
-                let full = tick % FULL_SNAPSHOT_EVERY_TICKS == 0;
+                let full = tick.is_multiple_of(FULL_SNAPSHOT_EVERY_TICKS);
 
                 // Only gossip when there are peers to receive it.
                 if horizontal.get_effective_node_count().await <= 1 {

--- a/crates/sockudo-adapter/src/local_adapter.rs
+++ b/crates/sockudo-adapter/src/local_adapter.rs
@@ -1838,6 +1838,18 @@ impl ConnectionManager for LocalAdapter {
         Ok(result)
     }
 
+    async fn add_to_channel_and_count_local(
+        &self,
+        app_id: &str,
+        channel: &str,
+        socket_id: &SocketId,
+    ) -> Result<(bool, usize)> {
+        let namespace = self.get_or_create_namespace(app_id).await;
+        let added = namespace.add_channel_to_socket(channel, socket_id);
+        let count = namespace.get_channel_socket_count(channel);
+        Ok((added, count))
+    }
+
     async fn remove_from_channel(
         &self,
         app_id: &str,
@@ -1858,6 +1870,27 @@ impl ConnectionManager for LocalAdapter {
         }
 
         Ok(namespace.remove_channel_from_socket(channel, socket_id))
+    }
+
+    async fn remove_from_channel_and_count_local(
+        &self,
+        app_id: &str,
+        channel: &str,
+        socket_id: &SocketId,
+    ) -> Result<(bool, usize)> {
+        let namespace = self.get_or_create_namespace(app_id).await;
+
+        #[cfg(feature = "tag-filtering")]
+        if let Some(socket_ref) = namespace.sockets.get(socket_id) {
+            let filter_node = socket_ref.get_channel_filter_sync(channel);
+            self.filter_index
+                .remove_socket_filter(channel, *socket_id, filter_node.as_deref());
+            socket_ref.channel_filters.remove(channel);
+        }
+
+        let removed = namespace.remove_channel_from_socket(channel, socket_id);
+        let count = namespace.get_channel_socket_count(channel);
+        Ok((removed, count))
     }
 
     async fn get_presence_member(

--- a/crates/sockudo-adapter/tests/adapter/clustered_active_channels_gauge_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/clustered_active_channels_gauge_tests.rs
@@ -4,6 +4,7 @@
 use crate::adapter::horizontal_adapter_helpers::MockConfig;
 use sockudo_adapter::ConnectionManager;
 use sockudo_adapter::channel_manager::ChannelManager;
+use sockudo_adapter::horizontal_adapter::RequestType;
 use sockudo_core::websocket::SocketId;
 use sockudo_protocol::messages::PusherMessage;
 use std::sync::Arc;
@@ -103,4 +104,63 @@ async fn unsubscribe_empties_local_while_cluster_still_holds_channel() {
     assert_eq!(local, 0);
     assert!(cluster > 0, "cluster={cluster}");
     assert!(leave.remaining_connections.unwrap() > 0);
+}
+
+/// Churn-path subscribe only needs the local transition. Cluster-wide counts are
+/// emitted later by handler notification code, not inside ChannelManager.
+#[tokio::test]
+async fn subscribe_does_not_fan_out_for_cluster_count() {
+    let adapter = Arc::new(MockConfig::create_multi_node_adapter().await.unwrap());
+    adapter.start_listeners().await.unwrap();
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = adapter.clone();
+    let socket = SocketId::new();
+    let msg = PusherMessage::channel_event("pusher:subscribe", SHARED_CHANNEL, sonic_rs::json!({}));
+
+    let resp = ChannelManager::subscribe_local(
+        &cm,
+        &socket.to_string(),
+        &msg,
+        SHARED_CHANNEL,
+        false,
+        APP_ID,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(resp.channel_connections, Some(1));
+    assert!(resp.activated_locally);
+    assert!(
+        adapter.transport.get_published_requests().await.is_empty(),
+        "subscribe should not publish horizontal count/existence requests"
+    );
+}
+
+/// Manual unsubscribe uses the same local transition path; callers that need a
+/// cluster count perform one post-ack count query.
+#[tokio::test]
+async fn unsubscribe_local_does_not_fan_out_for_cluster_count() {
+    let adapter = Arc::new(MockConfig::create_multi_node_adapter().await.unwrap());
+    adapter.start_listeners().await.unwrap();
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = adapter.clone();
+    let socket = SocketId::new();
+
+    cm.add_to_channel(APP_ID, SHARED_CHANNEL, &socket)
+        .await
+        .unwrap();
+
+    let leave =
+        ChannelManager::unsubscribe_local(&cm, &socket.to_string(), SHARED_CHANNEL, APP_ID, None)
+            .await
+            .unwrap();
+
+    assert_eq!(leave.remaining_connections, Some(0));
+    assert!(
+        adapter
+            .transport
+            .get_published_requests()
+            .await
+            .iter()
+            .all(|request| request.request_type != RequestType::ChannelSocketsCount),
+        "unsubscribe_local should not publish horizontal count requests"
+    );
 }

--- a/crates/sockudo-adapter/tests/adapter/single_node_optimization_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/single_node_optimization_tests.rs
@@ -1,6 +1,7 @@
 use sockudo_adapter::connection_manager::{ConnectionManager, HorizontalAdapterInterface};
 use sockudo_adapter::horizontal_adapter::RequestType;
 use sockudo_adapter::horizontal_adapter_base::HorizontalAdapterBase;
+use sockudo_adapter::horizontal_transport::HorizontalTransport;
 use sockudo_core::error::Result;
 use sockudo_protocol::messages::{MessageData, PusherMessage};
 use std::time::Duration;
@@ -190,6 +191,40 @@ async fn test_multi_node_sends_requests() -> Result<()> {
     let request = &published_requests[0];
     assert_eq!(request.app_id, "test-app");
     assert!(matches!(request.request_type, RequestType::Sockets));
+
+    Ok(())
+}
+
+/// Test that cluster health determines request fanout expectations for transports whose
+/// node-count fallback can describe infrastructure rather than Sockudo peers.
+#[tokio::test]
+async fn test_cluster_health_node_count_overrides_transport_hint_for_requests() -> Result<()> {
+    let config = MockConfig {
+        node_states: vec![
+            MockNodeState::new("node-1"),
+            MockNodeState::new("node-2"),
+            MockNodeState::new("node-3"),
+        ],
+        ..Default::default()
+    };
+
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(config.clone()).await?;
+    adapter.start_listeners().await?;
+
+    let transport_node_count = adapter.transport.get_node_count().await?;
+    assert_eq!(transport_node_count, 4);
+
+    let adapter = adapter.with_discovered_nodes(vec!["node-1"]).await?;
+    assert_eq!(adapter.horizontal.get_effective_node_count().await, 2);
+
+    let response = adapter
+        .send_request("test-app", RequestType::Sockets, None, None, None)
+        .await?;
+
+    assert_eq!(
+        response.expected_responses, 1,
+        "request aggregation should follow discovered Sockudo peers, not the transport node-count hint"
+    );
 
     Ok(())
 }

--- a/crates/sockudo-core/src/options.rs
+++ b/crates/sockudo-core/src/options.rs
@@ -477,6 +477,15 @@ pub struct AdapterConfig {
     pub enable_socket_counting: bool,
     #[serde(default = "default_fallback_to_local")]
     pub fallback_to_local: bool,
+    /// Tier 1A: maintain cluster-wide channel counts locally via gossip so count
+    /// reads (subscription_count, /channels, occupancy) become local with zero
+    /// cross-node fan-out. Off by default; falls back to request/reply when off.
+    #[serde(default = "default_aggregate_counts")]
+    pub aggregate_counts: bool,
+}
+
+fn default_aggregate_counts() -> bool {
+    false
 }
 
 fn default_enable_socket_counting() -> bool {
@@ -507,6 +516,7 @@ impl Default for AdapterConfig {
             cluster_health: ClusterHealthConfig::default(),
             enable_socket_counting: default_enable_socket_counting(),
             fallback_to_local: default_fallback_to_local(),
+            aggregate_counts: default_aggregate_counts(),
         }
     }
 }

--- a/crates/sockudo-core/src/options.rs
+++ b/crates/sockudo-core/src/options.rs
@@ -3051,6 +3051,8 @@ impl ServerOptions {
             "ADAPTER_ENABLE_SOCKET_COUNTING",
             self.adapter.enable_socket_counting,
         );
+        self.adapter.aggregate_counts =
+            parse_env::<bool>("ADAPTER_AGGREGATE_COUNTS", self.adapter.aggregate_counts);
         self.adapter.fallback_to_local =
             parse_env::<bool>("ADAPTER_FALLBACK_TO_LOCAL", self.adapter.fallback_to_local);
         if let Ok(driver_str) = std::env::var("CACHE_DRIVER") {

--- a/crates/sockudo-metrics/src/prometheus.rs
+++ b/crates/sockudo-metrics/src/prometheus.rs
@@ -2200,13 +2200,16 @@ impl MetricsInterface for PrometheusMetricsDriver {
 
     fn track_horizontal_delta_compression(&self, app_id: &str, channel_name: &str, enabled: bool) {
         if enabled {
+            // Preserve the historical label key for dashboards while bounding
+            // cardinality by recording channel type instead of raw channel name.
+            let channel_type = ChannelType::from_name(channel_name).as_str();
             self.horizontal_delta_compression_enabled
-                .with_label_values(&[app_id, &self.port.to_string(), channel_name])
+                .with_label_values(&[app_id, &self.port.to_string(), channel_type])
                 .inc();
 
             debug!(
-                "Metrics: Horizontal delta compression enabled for app {}, channel: {}",
-                app_id, channel_name
+                "Metrics: Horizontal delta compression enabled for app {}, channel: {} ({})",
+                app_id, channel_name, channel_type
             );
         }
     }

--- a/crates/sockudo-server/src/http_handler.rs
+++ b/crates/sockudo-server/src/http_handler.rs
@@ -2777,6 +2777,11 @@ pub async fn channel(
     Ok((StatusCode::OK, Json(response_payload)))
 }
 
+/// How long a `/channels` listing is cached to collapse repeated polls into a
+/// single cluster-wide aggregation. The underlying count is best-effort and
+/// eventually-consistent across nodes, so brief staleness is acceptable.
+const CHANNELS_LIST_CACHE_TTL_SECS: u64 = 2;
+
 /// GET /apps/{app_id}/channels
 #[instrument(skip(handler), fields(app_id = %app_id))]
 pub async fn channels(
@@ -2786,7 +2791,7 @@ pub async fn channels(
     State(handler): State<Arc<ConnectionHandler>>,
     _uri: Uri,
     RawQuery(_raw_query_str_option): RawQuery,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<axum::response::Response, AppError> {
     debug!("Request for channels list for app_id: {}", app_id);
 
     let filter_prefix_str = query_params_specific
@@ -2798,6 +2803,24 @@ pub async fn channels(
         .info
         .as_ref()
         .wants_subscription_count();
+
+    // Collapse repeated /channels polls into a single cross-node aggregation per
+    // TTL window. get_channels_with_socket_count (and, for user_count, the
+    // per-presence-channel member fetch below) are cluster-wide request/reply
+    // fan-outs; polling this endpoint without a cache issues an N-node aggregation
+    // per request, saturating the request/reply path and starving the readiness
+    // probe. Cached per (app, prefix, info) since the response shape depends on them.
+    let info_key = query_params_specific.info.as_deref().unwrap_or("");
+    let channels_cache_key = format!("internal:channels:{app_id}:{filter_prefix_str}:{info_key}");
+    if let Ok(Some(cached)) = handler.cache_manager().get(&channels_cache_key).await {
+        record_api_metrics(&handler, &app_id, 0, cached.len()).await;
+        return Ok((
+            StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            cached,
+        )
+            .into_response());
+    }
 
     let channels_map = handler
         .connection_manager()
@@ -2841,9 +2864,19 @@ pub async fn channels(
 
     let response_payload = PusherMessage::channels_list(channels_info_response_map);
     let response_json_bytes = sonic_rs::to_vec(&response_payload)?;
+    let response_json = String::from_utf8_lossy(&response_json_bytes).into_owned();
+    // Best-effort cache; on failure the next poll simply recomputes.
+    let _ = handler
+        .cache_manager()
+        .set(
+            &channels_cache_key,
+            &response_json,
+            CHANNELS_LIST_CACHE_TTL_SECS,
+        )
+        .await;
     record_api_metrics(&handler, &app_id, 0, response_json_bytes.len()).await;
     debug!("Channels list for app '{}' retrieved successfully", app_id);
-    Ok((StatusCode::OK, Json(response_payload)))
+    Ok((StatusCode::OK, Json(response_payload)).into_response())
 }
 
 /// GET /apps/{app_id}/channels/{channel_name}/users

--- a/crates/sockudo-webhook/src/integration.rs
+++ b/crates/sockudo-webhook/src/integration.rs
@@ -333,6 +333,28 @@ impl WebhookIntegration {
         })
     }
 
+    /// Cheap synchronous check: is a webhook configured for `event_type` on this app?
+    /// Unlike [`Self::should_send_webhook`] this does not allocate, so it is safe to
+    /// call on the subscribe/unsubscribe hot path.
+    pub fn webhook_configured(&self, app: &App, event_type: &str) -> bool {
+        self.is_enabled()
+            && app.webhooks_ref().is_some_and(|webhooks| {
+                webhooks
+                    .iter()
+                    .any(|wh| wh.event_types.iter().any(|e| e.as_str() == event_type))
+            })
+    }
+
+    /// Whether any subscription-count-derived webhook (channel_occupied,
+    /// channel_vacated, subscription_count) is configured for this app. When this is
+    /// false — and no client subscribes to the channel's meta-channel — the
+    /// subscribe/unsubscribe hot path can skip the cluster-wide count fanout.
+    pub fn wants_subscription_count(&self, app: &App) -> bool {
+        self.webhook_configured(app, "channel_occupied")
+            || self.webhook_configured(app, "channel_vacated")
+            || self.webhook_configured(app, "subscription_count")
+    }
+
     pub async fn send_channel_occupied(&self, app: &App, channel: &str) -> Result<()> {
         if !self.should_send_webhook(app, "channel_occupied").await {
             return Ok(());

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -218,7 +218,7 @@ This page lists every runtime environment variable referenced by the server, cor
 | `NATS_REQUEST_TIMEOUT_MS` | NATS request timeout. |
 | `NATS_DISCOVERY_MAX_WAIT_MS` | NATS node discovery maximum wait. |
 | `NATS_DISCOVERY_IDLE_WAIT_MS` | NATS node discovery idle wait. |
-| `NATS_NODES_NUMBER` | Expected NATS node count. |
+| `NATS_NODES_NUMBER` | Expected Sockudo node count for horizontal request aggregation when cluster-health discovery is not used. |
 | `NATS_SUBSCRIPTION_CAPACITY` | NATS subscription channel capacity. |
 | `NATS_CLIENT_CAPACITY` | NATS client channel capacity. |
 | `NATS_MAX_RECONNECTS` | NATS reconnect limit. |

--- a/docs/content/docs/server/scaling.mdx
+++ b/docs/content/docs/server/scaling.mdx
@@ -33,6 +33,34 @@ At minimum, a production cluster has:
 | Google Pub/Sub | Managed GCP fanout. |
 | Apache Iggy | High-throughput persistent log workloads. |
 
+### NATS notes
+
+NATS is a good fit for lightweight cross-node fanout, but Sockudo clusters should avoid turning every client subscribe or unsubscribe into a distributed request/reply round trip. Keep room-switch churn on local channel state where possible, and reserve cluster-wide socket counts for post-ack meta events, webhooks, HTTP inspection, and operator views.
+
+For Kubernetes NATS clusters, prefer explicit StatefulSet pod DNS entries over a single headless service URL when you want better initial client spread:
+
+```json
+{
+  "adapter": {
+    "driver": "nats",
+    "nats": {
+      "servers": [
+        "nats://sockudo-nats-0.sockudo-nats-headless:4222",
+        "nats://sockudo-nats-1.sockudo-nats-headless:4222",
+        "nats://sockudo-nats-2.sockudo-nats-headless:4222"
+      ],
+      "request_timeout_ms": 5000,
+      "connection_timeout_ms": 5000,
+      "subscription_capacity": 131072,
+      "client_capacity": 131072,
+      "max_reconnects": 60
+    }
+  }
+}
+```
+
+If `nodes_number` is set, it means expected Sockudo nodes, not NATS server replicas. Use it only when the Sockudo replica count is fixed or injected from deployment automation; otherwise leave discovery enabled.
+
 ## Load balancing
 
 Sockudo does not require sticky sessions for basic pub/sub when the adapter is shared. Sticky sessions can still reduce reconnect churn and preserve local buffers during rolling updates.
@@ -44,6 +72,23 @@ Use:
 - health and readiness checks
 - draining before pod termination
 - disruption budgets for production clusters
+
+For Kubernetes probes, use `/live` for liveness and startup probes. `/up` checks configured apps and shared dependencies, so it is appropriate for readiness but too expensive for liveness under backend pressure. A slow app manager, cache, queue, or adapter should make the pod unready, not restart it.
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /live
+    port: http
+startupProbe:
+  httpGet:
+    path: /live
+    port: http
+readinessProbe:
+  httpGet:
+    path: /up/<app-id>
+    port: http
+```
 
 ## Duplicate delivery
 
@@ -110,3 +155,16 @@ Before increasing traffic, run a scenario that covers:
 - push burst admission
 - push provider throttling
 - webhook retry behavior
+
+For room-switch workloads, `benches/subscription-churn.js` models connected sockets that periodically unsubscribe and subscribe to a new room. Churn rate is approximately `VUS / (ROOM_SWITCH_INTERVAL_MS / 1000)`. For example, 10,000 users switching every 20 seconds produces about 500 unsubscribe+subscribe cycles per second:
+
+```bash
+k6 run \
+  -e WS_HOSTS=wss://example.com/app/app-key \
+  -e VUS=10000 \
+  -e CHANNEL_COUNT=4000 \
+  -e ROOM_SWITCH_INTERVAL_MS=20000 \
+  -e SOCKET_LIFETIME_MS=600000 \
+  -e DURATION=10m \
+  benches/subscription-churn.js
+```

--- a/loadtest/churn/ab_images.sh
+++ b/loadtest/churn/ab_images.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Definitive A/B: same churn workload + same app config (app "light", no count
+# consumer) against the pre-gate binary vs the gated binary. Isolates exactly the
+# Tier 1B change.
+set -uo pipefail
+cd "$(dirname "$0")"
+COMPOSE="docker compose -f docker-compose.yml"
+PORTS="9611 9612 9613"
+WS_PORTS="6011 6012 6013"
+DURATION="${DURATION:-40s}"; SECS="${DURATION%s}"
+VUS="${VUS:-120}"; CHURN_MS="${CHURN_MS:-400}"; ROOMS="${ROOMS:-300}"
+
+metric_sum () { # substring app_id
+  for p in $PORTS; do curl -s -m3 "http://localhost:$p/metrics"; done \
+    | grep "$1" | grep "app_id=\"$2\"" | awk '{s+=$NF} END{printf "%.3f\n", s+0}'
+}
+timeouts () { $COMPOSE logs --no-color 2>/dev/null | grep -c "timed out after"; }
+
+run_gen () { # label image
+  local label="$1" image="$2"
+  echo "############### GEN: $label  (image=$image) ###############"
+  SOCKUDO_IMAGE="$image" $COMPOSE down -v >/dev/null 2>&1
+  SOCKUDO_IMAGE="$image" $COMPOSE up -d >/dev/null 2>&1
+  echo "  warming cluster..."; sleep 10
+
+  local sent0 rsum0 rcnt0 to0
+  sent0=$(metric_sum horizontal_adapter_sent_requests light)
+  rsum0=$(metric_sum horizontal_adapter_resolve_time_sum light)
+  rcnt0=$(metric_sum horizontal_adapter_resolve_time_count light)
+  to0=$(timeouts)
+
+  ( upf=0; livef=0; n=0; end=$((SECONDS+SECS))
+    while [ $SECONDS -lt $end ]; do
+      for p in $WS_PORTS; do
+        n=$((n+1))
+        [ "$(curl -s -m2 -o /dev/null -w '%{http_code}' http://localhost:$p/up/light)" = "200" ] || upf=$((upf+1))
+        [ "$(curl -s -m2 -o /dev/null -w '%{http_code}' http://localhost:$p/live)" = "200" ] || livef=$((livef+1))
+      done; sleep 2
+    done
+    echo "  health during load: $n probes | /up failures=$upf | /live failures=$livef" ) &
+  local hp=$!
+
+  k6 run --quiet -e APP_KEY=lightkey -e VUS="$VUS" -e CHURN_MS="$CHURN_MS" \
+        -e ROOMS="$ROOMS" -e DURATION="$DURATION" churn.js > "/tmp/ab_$label.txt" 2>&1
+  wait $hp
+
+  local sent1 rsum1 rcnt1 to1
+  sent1=$(metric_sum horizontal_adapter_sent_requests light)
+  rsum1=$(metric_sum horizontal_adapter_resolve_time_sum light)
+  rcnt1=$(metric_sum horizontal_adapter_resolve_time_count light)
+  to1=$(timeouts)
+
+  local dsent rate dcnt davg subacks
+  dsent=$(awk "BEGIN{printf \"%.0f\", $sent1-$sent0}")
+  rate=$(awk "BEGIN{printf \"%.1f\", ($sent1-$sent0)/$SECS}")
+  dcnt=$(awk "BEGIN{printf \"%.0f\", $rcnt1-$rcnt0}")
+  davg=$(awk "BEGIN{d=$rcnt1-$rcnt0; if(d>0) printf \"%.0f\", 1000*($rsum1-$rsum0)/d; else print 0}")
+  subacks=$(grep sub_acks "/tmp/ab_$label.txt" | grep -oE '[0-9]+' | head -1)
+
+  echo "  RESULT[$label]: cluster count fanout (sent_requests, app=light) +$dsent  =>  ${rate} req/s"
+  echo "  RESULT[$label]: fanout resolve latency ~${davg} ms avg over $dcnt resolved"
+  echo "  RESULT[$label]: request timeouts during load: +$((to1-to0))"
+  echo "  RESULT[$label]: offered churn (k6 sub_acks): ${subacks}"
+  echo
+}
+
+run_gen OLD_pregate sockudo:churn-old
+run_gen NEW_gated   sockudo:churn-test
+echo "================================================================"
+echo "Same workload, app 'light' (no count consumer)."
+echo "OLD_pregate: count fanout fires per sub/unsub.  NEW_gated: gate skips it."
+SOCKUDO_IMAGE=sockudo:churn-test $COMPOSE down -v >/dev/null 2>&1

--- a/loadtest/churn/bulk_subs.js
+++ b/loadtest/churn/bulk_subs.js
@@ -1,0 +1,41 @@
+// Bulk subscribers: many WS connections from ONE machine, all subscribed to a
+// single hot channel, holding + reading. Each records its OWN view of
+// publish->receive latency (from the timestamp the publisher embeds). This is the
+// "saturated load-gen client" measurement that may be inflated by the host, not
+// the server.
+import ws from 'k6/ws';
+import { Trend, Counter } from 'k6/metrics';
+
+const NODES = (__ENV.NODES || 'ws://localhost:6011,ws://localhost:6012,ws://localhost:6013').split(',');
+const KEY = __ENV.APP_KEY || 'lightkey';
+const CHANNEL = __ENV.CHANNEL || 'hot-room';
+const EVENT = __ENV.EVENT || 'msg';
+const VUS = parseInt(__ENV.VUS || '2500');
+const DURATION = __ENV.DURATION || '70s';
+
+const bulkLat = new Trend('bulk_latency', true);
+const bulkRecv = new Counter('bulk_recv');
+
+export const options = {
+  scenarios: { bulk: { executor: 'constant-vus', vus: VUS, duration: DURATION, gracefulStop: '3s' } },
+};
+
+export default function () {
+  const node = NODES[(__VU - 1) % NODES.length];
+  const url = node + '/app/' + KEY + '?protocol=7&client=bulk&version=1.0.0';
+  ws.connect(url, {}, function (socket) {
+    socket.on('open', function () {
+      socket.send(JSON.stringify({ event: 'pusher:subscribe', data: { channel: CHANNEL } }));
+    });
+    socket.on('message', function (m) {
+      if (m.indexOf('"event":"' + EVENT + '"') === -1) return;
+      try {
+        const msg = JSON.parse(m);
+        if (msg.event !== EVENT || !msg.data) return;
+        const d = typeof msg.data === 'string' ? JSON.parse(msg.data) : msg.data;
+        if (d && d.t) { bulkLat.add(Date.now() - d.t); bulkRecv.add(1); }
+      } catch (e) { /* ignore */ }
+    });
+    socket.on('error', function () {});
+  });
+}

--- a/loadtest/churn/channels_ab.sh
+++ b/loadtest/churn/channels_ab.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# A/B the GET /channels cross-node fan-out: BEFORE (no cache) vs AFTER (short-TTL
+# cache). Polls /channels at a fixed rate and measures (a) the cross-node
+# ChannelsWithSocketsCount request rate and (b) /channels response latency.
+set -uo pipefail
+cd "$(dirname "$0")"
+COMPOSE="docker compose -f docker-compose.yml"
+PORTS="9611 9612 9613"
+POLL_MS="${POLL_MS:-100}"
+DURATION="${DURATION:-20s}"
+SECS="${DURATION%s}"
+INFO="${INFO:-subscription_count}"
+
+# sum sent_requests for app "light" only (excludes cluster heartbeats)
+sent_light () {
+  for p in $PORTS; do curl -s -m3 "http://localhost:$p/metrics"; done \
+    | grep 'horizontal_adapter_sent_requests' | grep 'app_id="light"' \
+    | awk '{s+=$NF} END{printf "%.0f\n", s+0}'
+}
+
+run_case () { # label image
+  local label="$1" image="$2"
+  echo "################ $label ($image) ################"
+  SOCKUDO_IMAGE="$image" $COMPOSE down -v >/dev/null 2>&1
+  SOCKUDO_IMAGE="$image" $COMPOSE up -d >/dev/null 2>&1
+  echo "  warming..."; sleep 10
+  local before after polls
+  before=$(sent_light)
+  k6 run --quiet -e HOST=localhost:6011 -e INFO="$INFO" -e POLL_MS="$POLL_MS" \
+        -e DURATION="$DURATION" channels_poll.js > "/tmp/chpoll_$label.txt" 2>&1
+  after=$(sent_light)
+  polls=$(grep -E "channels_ok" "/tmp/chpoll_$label.txt" | grep -oE '[0-9]+' | head -1)
+  echo "  /channels polls=${polls}  cross-node fanouts(sent_requests, light)=+$((after-before)) over ${SECS}s"
+  grep -E "channels_latency|channels_fail" "/tmp/chpoll_$label.txt" | sed 's/^/    /'
+  echo
+}
+
+run_case BEFORE_no_cache sockudo:churn-test
+sleep 4
+run_case AFTER_cache     sockudo:churn-cache
+SOCKUDO_IMAGE=sockudo:churn-test $COMPOSE down -v >/dev/null 2>&1
+echo "Expect: BEFORE fanouts ~= poll count (one cross-node aggregation per request);"
+echo "        AFTER fanouts ~= duration/TTL (cache collapses repeated polls), lower latency."

--- a/loadtest/churn/channels_poll.js
+++ b/loadtest/churn/channels_poll.js
@@ -1,0 +1,36 @@
+// Polls GET /apps/{id}/channels with signed Pusher auth, measuring response time.
+// Used to A/B the cross-node fan-out rate before vs after the /channels cache.
+import http from 'k6/http';
+import crypto from 'k6/crypto';
+import { sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+
+const HOST = __ENV.HOST || 'localhost:6011';
+const APP_ID = __ENV.APP_ID || 'light';
+const KEY = __ENV.APP_KEY || 'lightkey';
+const SECRET = __ENV.APP_SECRET || 'lightsecret';
+const INFO = __ENV.INFO || 'subscription_count';
+const POLL_MS = parseInt(__ENV.POLL_MS || '100');
+const DURATION = __ENV.DURATION || '20s';
+
+const chLat = new Trend('channels_latency', true);
+const chOk = new Counter('channels_ok');
+const chFail = new Counter('channels_fail');
+
+export const options = {
+  scenarios: { poll: { executor: 'constant-vus', vus: 1, duration: DURATION } },
+};
+
+export default function () {
+  const ts = Math.floor(Date.now() / 1000).toString();
+  // Pusher auth: params sorted alphabetically (auth_key, auth_timestamp, auth_version, info)
+  const qs = 'auth_key=' + KEY + '&auth_timestamp=' + ts + '&auth_version=1.0&info=' + INFO;
+  const toSign = 'GET\n/apps/' + APP_ID + '/channels\n' + qs;
+  const sig = crypto.hmac('sha256', SECRET, toSign, 'hex');
+  const url = 'http://' + HOST + '/apps/' + APP_ID + '/channels?' + qs + '&auth_signature=' + sig;
+  const res = http.get(url);
+  chLat.add(res.timings.duration);
+  if (res.status === 200) chOk.add(1);
+  else chFail.add(1);
+  sleep(POLL_MS / 1000);
+}

--- a/loadtest/churn/churn.js
+++ b/loadtest/churn/churn.js
@@ -1,0 +1,54 @@
+// k6 room-switch churn loader (Pusher protocol, public channels).
+// Each VU holds one WebSocket connection and repeatedly unsubscribes its current
+// room and subscribes a new random one — exactly the room-switch pattern that is
+// swaglive's bottleneck. No publishing: publish throughput was already fine; the
+// variable under test is subscribe/unsubscribe frequency.
+import ws from 'k6/ws';
+import { Counter } from 'k6/metrics';
+
+const NODES = (__ENV.NODES || 'ws://localhost:6011,ws://localhost:6012,ws://localhost:6013').split(',');
+const KEY = __ENV.APP_KEY || 'heavykey';
+const ROOMS = parseInt(__ENV.ROOMS || '400');
+const CHURN_MS = parseInt(__ENV.CHURN_MS || '1000');
+const VUS = parseInt(__ENV.VUS || '200');
+const DURATION = __ENV.DURATION || '60s';
+
+const subsSent = new Counter('subs_sent');
+const unsubsSent = new Counter('unsubs_sent');
+const subAcks = new Counter('sub_acks');
+
+export const options = {
+  scenarios: {
+    churn: { executor: 'constant-vus', vus: VUS, duration: DURATION, gracefulStop: '2s' },
+  },
+};
+
+function room() { return 'room-' + Math.floor(Math.random() * ROOMS); }
+
+export default function () {
+  const node = NODES[(__VU - 1) % NODES.length];
+  const url = node + '/app/' + KEY + '?protocol=7&client=k6&version=1.0.0';
+  let current = null;
+
+  ws.connect(url, {}, function (socket) {
+    socket.on('open', function () {
+      current = room();
+      socket.send(JSON.stringify({ event: 'pusher:subscribe', data: { channel: current } }));
+      subsSent.add(1);
+
+      socket.setInterval(function () {
+        if (current) {
+          socket.send(JSON.stringify({ event: 'pusher:unsubscribe', data: { channel: current } }));
+          unsubsSent.add(1);
+        }
+        current = room();
+        socket.send(JSON.stringify({ event: 'pusher:subscribe', data: { channel: current } }));
+        subsSent.add(1);
+      }, CHURN_MS);
+    });
+    socket.on('message', function (msg) {
+      if (msg.indexOf('subscription_succeeded') !== -1) subAcks.add(1);
+    });
+    socket.on('error', function () {});
+  });
+}

--- a/loadtest/churn/config.json
+++ b/loadtest/churn/config.json
@@ -20,7 +20,8 @@
       "heartbeat_interval_ms": 2000,
       "node_timeout_ms": 10000,
       "cleanup_interval_ms": 2000
-    }
+    },
+    "aggregate_counts": true
   },
   "cache": { "driver": "memory", "memory": { "ttl": 300, "cleanup_interval": 60, "max_capacity": 100000 } },
   "queue": { "driver": "memory" },

--- a/loadtest/churn/config.json
+++ b/loadtest/churn/config.json
@@ -1,0 +1,67 @@
+{
+  "debug": false,
+  "host": "0.0.0.0",
+  "port": 6001,
+  "shutdown_grace_period": 2,
+  "adapter": {
+    "driver": "nats",
+    "enable_socket_counting": true,
+    "nats": {
+      "servers": ["nats://nats:4222"],
+      "prefix": "sockudo_adapter:",
+      "request_timeout_ms": 5000,
+      "nodes_number": 3,
+      "connection_timeout_ms": 5000,
+      "discovery_max_wait_ms": 1000,
+      "discovery_idle_wait_ms": 150
+    },
+    "cluster_health": {
+      "enabled": true,
+      "heartbeat_interval_ms": 2000,
+      "node_timeout_ms": 10000,
+      "cleanup_interval_ms": 2000
+    }
+  },
+  "cache": { "driver": "memory", "memory": { "ttl": 300, "cleanup_interval": 60, "max_capacity": 100000 } },
+  "queue": { "driver": "memory" },
+  "rate_limiter": { "enabled": false, "driver": "memory" },
+  "metrics": { "enabled": true, "driver": "prometheus", "host": "0.0.0.0", "port": 9601, "prometheus": { "prefix": "sockudo_" } },
+  "delta_compression": { "enabled": false },
+  "tag_filtering": { "enabled": false },
+  "connection_recovery": { "enabled": false },
+  "idempotency": { "enabled": false },
+  "app_manager": {
+    "driver": "memory",
+    "array": {
+      "apps": [
+        {
+          "id": "heavy",
+          "key": "heavykey",
+          "secret": "heavysecret",
+          "enabled": true,
+          "webhooks": [
+            {
+              "url": "http://webhook-sink:5678",
+              "event_types": ["channel_occupied", "channel_vacated", "subscription_count"]
+            }
+          ],
+          "policy": {
+            "limits": { "max_connections": 1000000, "max_client_events_per_second": 1000000 },
+            "channels": { "allowed_origins": ["*"] }
+          }
+        },
+        {
+          "id": "light",
+          "key": "lightkey",
+          "secret": "lightsecret",
+          "enabled": true,
+          "webhooks": [],
+          "policy": {
+            "limits": { "max_connections": 1000000, "max_client_events_per_second": 1000000 },
+            "channels": { "allowed_origins": ["*"] }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/loadtest/churn/docker-compose.yml
+++ b/loadtest/churn/docker-compose.yml
@@ -1,0 +1,62 @@
+# Subscription-churn reproduction harness.
+# Mirrors swaglive's driver setup that matters for the bug: NATS adapter, multi-node.
+# Cache/queue are memory here (they are NOT in the count fanout path — the team
+# confirmed NATS/Redis were healthy; the bottleneck is cross-node request/reply).
+#
+#   app "heavy" -> channel_occupied/channel_vacated/subscription_count webhooks
+#                  configured => count IS consumed => cluster-wide count fanout fires
+#                  on every subscribe/unsubscribe (== behaviour before the gate).
+#   app "light" -> no count consumer => the Tier 1B gate skips the fanout entirely.
+services:
+  nats:
+    image: nats:alpine
+    command: ["-m", "8222"]
+    ports: ["4222:4222", "8222:8222"]
+    networks: [churn]
+
+  webhook-sink:
+    image: hashicorp/http-echo
+    command: ["-text=ok", "-listen=:5678"]
+    networks: [churn]
+
+  sockudo1:
+    image: ${SOCKUDO_IMAGE:-sockudo:churn-test}
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1g
+    volumes: ["./config.json:/app/config/config.json:ro"]
+    environment: { RUST_LOG: "warn,sockudo_adapter::horizontal_adapter_base=warn" }
+    ports: ["6011:6001", "9611:9601"]
+    depends_on: [nats, webhook-sink]
+    networks: [churn]
+
+  sockudo2:
+    image: ${SOCKUDO_IMAGE:-sockudo:churn-test}
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1g
+    volumes: ["./config.json:/app/config/config.json:ro"]
+    environment: { RUST_LOG: "warn,sockudo_adapter::horizontal_adapter_base=warn" }
+    ports: ["6012:6001", "9612:9601"]
+    depends_on: [nats, webhook-sink]
+    networks: [churn]
+
+  sockudo3:
+    image: ${SOCKUDO_IMAGE:-sockudo:churn-test}
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1g
+    volumes: ["./config.json:/app/config/config.json:ro"]
+    environment: { RUST_LOG: "warn,sockudo_adapter::horizontal_adapter_base=warn" }
+    ports: ["6013:6001", "9613:9601"]
+    depends_on: [nats, webhook-sink]
+    networks: [churn]
+
+networks:
+  churn: {}

--- a/loadtest/churn/docker-compose.yml
+++ b/loadtest/churn/docker-compose.yml
@@ -21,11 +21,6 @@ services:
 
   sockudo1:
     image: ${SOCKUDO_IMAGE:-sockudo:churn-test}
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: 1g
     volumes: ["./config.json:/app/config/config.json:ro"]
     environment: { RUST_LOG: "warn,sockudo_adapter::horizontal_adapter_base=warn" }
     ports: ["6011:6001", "9611:9601"]
@@ -34,11 +29,6 @@ services:
 
   sockudo2:
     image: ${SOCKUDO_IMAGE:-sockudo:churn-test}
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: 1g
     volumes: ["./config.json:/app/config/config.json:ro"]
     environment: { RUST_LOG: "warn,sockudo_adapter::horizontal_adapter_base=warn" }
     ports: ["6012:6001", "9612:9601"]
@@ -47,11 +37,6 @@ services:
 
   sockudo3:
     image: ${SOCKUDO_IMAGE:-sockudo:churn-test}
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: 1g
     volumes: ["./config.json:/app/config/config.json:ro"]
     environment: { RUST_LOG: "warn,sockudo_adapter::horizontal_adapter_base=warn" }
     ports: ["6013:6001", "9613:9601"]

--- a/loadtest/churn/measure.sh
+++ b/loadtest/churn/measure.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Sum a Prometheus counter across all sockudo nodes' /metrics endpoints.
+# Usage: measure.sh <metric_substring>
+metric="${1:-horizontal_adapter_sent_requests}"
+PORTS="${PORTS:-9611 9612 9613}"
+for p in $PORTS; do
+  curl -s -m 3 "http://localhost:$p/metrics"
+done | grep "$metric" | grep -v '^#' | awk '{s+=$NF} END {printf "%.0f\n", s+0}'

--- a/loadtest/churn/probe.js
+++ b/loadtest/churn/probe.js
@@ -25,6 +25,7 @@ const probeLat = new Trend('probe_latency', true);
 const probeRecv = new Counter('probe_recv');
 const pubOk = new Counter('pub_ok');
 const pubFail = new Counter('pub_fail');
+const reportedCount = new Trend('reported_count'); // subscription_count returned by the API
 
 export const options = {
   scenarios: {
@@ -46,7 +47,17 @@ export function publisher() {
   const sig = crypto.hmac('sha256', SECRET, toSign, 'hex');
   const url = 'http://' + PUB_HOST + '/apps/' + APP_ID + '/events?' + qs + '&auth_signature=' + sig;
   const res = http.post(url, body, { headers: { 'Content-Type': 'application/json' } });
-  if (res.status === 200) pubOk.add(1); else pubFail.add(1);
+  if (res.status === 200) {
+    pubOk.add(1);
+    if (INFO) {
+      try {
+        const c = JSON.parse(res.body).channels[CHANNEL].subscription_count;
+        if (typeof c === 'number') reportedCount.add(c);
+      } catch (e) { /* ignore */ }
+    }
+  } else {
+    pubFail.add(1);
+  }
   sleep(PUB_INTERVAL_MS / 1000);
 }
 

--- a/loadtest/churn/probe.js
+++ b/loadtest/churn/probe.js
@@ -1,0 +1,70 @@
+// Independent publisher + probe, run as its OWN k6 process (separately scheduled
+// from the bulk load). The publisher POSTs signed Pusher events to a hot channel
+// with an embedded send timestamp; the probe holds ONE subscriber connection on a
+// DIFFERENT node and records true publish->receive latency. Because the probe is
+// tiny and isolated, its latency reflects the SERVER's delivery time, not
+// load-gen-client saturation.
+import ws from 'k6/ws';
+import http from 'k6/http';
+import crypto from 'k6/crypto';
+import { sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+
+const PUB_HOST = __ENV.PUB_HOST || 'localhost:6011';     // publish target node (HTTP)
+const PROBE_WS = __ENV.PROBE_WS || 'ws://localhost:6012'; // probe subscribes on a different node
+const APP_ID = __ENV.APP_ID || 'light';
+const KEY = __ENV.APP_KEY || 'lightkey';
+const SECRET = __ENV.APP_SECRET || 'lightsecret';
+const CHANNEL = __ENV.CHANNEL || 'hot-room';
+const EVENT = __ENV.EVENT || 'msg';
+const PUB_INTERVAL_MS = parseInt(__ENV.PUB_INTERVAL_MS || '100');
+const DURATION = __ENV.DURATION || '40s';
+const INFO = __ENV.INFO || ''; // e.g. "subscription_count" -> forces per-publish cross-node count
+
+const probeLat = new Trend('probe_latency', true);
+const probeRecv = new Counter('probe_recv');
+const pubOk = new Counter('pub_ok');
+const pubFail = new Counter('pub_fail');
+
+export const options = {
+  scenarios: {
+    publisher: { executor: 'constant-vus', vus: 1, duration: DURATION, exec: 'publisher', gracefulStop: '2s' },
+    probe: { executor: 'constant-vus', vus: 1, duration: DURATION, exec: 'probe', gracefulStop: '2s' },
+  },
+};
+
+// Pusher REST auth: HMAC-SHA256 over METHOD\nPATH\nsorted-query (incl. body_md5).
+export function publisher() {
+  const data = JSON.stringify({ t: Date.now() });
+  const payload = { name: EVENT, channels: [CHANNEL], data: data };
+  if (INFO) payload.info = INFO;
+  const body = JSON.stringify(payload);
+  const bodyMd5 = crypto.md5(body, 'hex');
+  const ts = Math.floor(Date.now() / 1000).toString();
+  const qs = 'auth_key=' + KEY + '&auth_timestamp=' + ts + '&auth_version=1.0&body_md5=' + bodyMd5;
+  const toSign = 'POST\n/apps/' + APP_ID + '/events\n' + qs;
+  const sig = crypto.hmac('sha256', SECRET, toSign, 'hex');
+  const url = 'http://' + PUB_HOST + '/apps/' + APP_ID + '/events?' + qs + '&auth_signature=' + sig;
+  const res = http.post(url, body, { headers: { 'Content-Type': 'application/json' } });
+  if (res.status === 200) pubOk.add(1); else pubFail.add(1);
+  sleep(PUB_INTERVAL_MS / 1000);
+}
+
+export function probe() {
+  const url = PROBE_WS + '/app/' + KEY + '?protocol=7&client=probe&version=1.0.0';
+  ws.connect(url, {}, function (socket) {
+    socket.on('open', function () {
+      socket.send(JSON.stringify({ event: 'pusher:subscribe', data: { channel: CHANNEL } }));
+    });
+    socket.on('message', function (m) {
+      if (m.indexOf('"event":"' + EVENT + '"') === -1) return;
+      try {
+        const msg = JSON.parse(m);
+        if (msg.event !== EVENT || !msg.data) return;
+        const d = typeof msg.data === 'string' ? JSON.parse(msg.data) : msg.data;
+        if (d && d.t) { probeLat.add(Date.now() - d.t); probeRecv.add(1); }
+      } catch (e) { /* ignore */ }
+    });
+    socket.on('error', function () {});
+  });
+}

--- a/loadtest/churn/pubsub_ab.sh
+++ b/loadtest/churn/pubsub_ab.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Probe-vs-bulk experiment: is the high broadcast latency a load-gen-client
+# artifact, or a real server bottleneck? And does /up degrade under publish load?
+#
+#   bulk_subs.js : VUS subscribers on a hot channel (the "one machine" load)
+#   probe.js     : separate process, publishes timestamped events + 1 clean probe
+#   poller       : samples /up status + response time on every node during load
+set -uo pipefail
+cd "$(dirname "$0")"
+COMPOSE="docker compose -f docker-compose.yml"
+
+VUS="${VUS:-2500}"
+PUB_INTERVAL_MS="${PUB_INTERVAL_MS:-100}"
+PROBE_SECS="${PROBE_SECS:-40}"
+CHANNEL="${CHANNEL:-hot-room}"
+HTTP_PORTS="6011 6012 6013"
+
+echo ">>> ensuring gated cluster is up"
+SOCKUDO_IMAGE=sockudo:churn-test $COMPOSE up -d >/dev/null 2>&1
+echo ">>> warming"; sleep 10
+
+# /up responsiveness poller
+( end=$((SECONDS + PROBE_SECS + 18)); : > /tmp/uphealth.csv
+  while [ $SECONDS -lt $end ]; do
+    for p in $HTTP_PORTS; do
+      echo "$p,$(curl -s -m 5 -o /dev/null -w '%{http_code},%{time_total}' http://localhost:$p/up/light)" >> /tmp/uphealth.csv
+    done
+    sleep 1
+  done ) &
+POLLER=$!
+
+# pod CPU snapshot mid-load
+( sleep $((12 + PROBE_SECS/2)); docker stats --no-stream --format '{{.Name}} cpu={{.CPUPerc}} mem={{.MemPerc}}' $(docker ps --format '{{.Names}}' | grep churn-sockudo) > /tmp/podcpu.txt 2>&1 ) &
+
+# bulk subscribers (cover the probe window)
+BULK_DUR=$((PROBE_SECS + 25))
+k6 run --quiet -e APP_KEY=lightkey -e CHANNEL="$CHANNEL" -e VUS="$VUS" -e DURATION="${BULK_DUR}s" bulk_subs.js > /tmp/bulk.txt 2>&1 &
+BULK=$!
+
+echo ">>> letting $VUS bulk subscribers connect..."; sleep 12
+
+echo ">>> publishing + probing for ${PROBE_SECS}s under load"
+k6 run --quiet -e PUB_HOST=localhost:6011 -e PROBE_WS=ws://localhost:6012 \
+   -e CHANNEL="$CHANNEL" -e PUB_INTERVAL_MS="$PUB_INTERVAL_MS" -e INFO="${INFO:-}" \
+   -e DURATION="${PROBE_SECS}s" probe.js > /tmp/probe.txt 2>&1
+
+wait $BULK 2>/dev/null
+kill $POLLER 2>/dev/null; wait $POLLER 2>/dev/null
+
+echo
+echo "================== RESULTS =================="
+echo "--- PROBE (clean: 1 conn, separate process = true server latency) ---"
+grep -E "probe_latency|probe_recv|pub_ok|pub_fail" /tmp/probe.txt | sed 's/^/  /'
+echo "--- BULK ($VUS conns on this one host = saturated client view) ---"
+grep -E "bulk_latency|bulk_recv|ws_sessions|^\s*vus" /tmp/bulk.txt | sed 's/^/  /'
+echo "--- /up readiness under load ---"
+awk -F, '{n++; if($3>maxt)maxt=$3; if($2!=200)bad++} END{printf "  probes=%d  non-200=%d  max_/up_response=%.0fms\n", n, bad+0, maxt*1000}' /tmp/uphealth.csv
+echo "--- pod CPU mid-load ---"; sed 's/^/  /' /tmp/podcpu.txt
+echo "============================================="
+echo "READ: probe low + /up fast => client artifact (latency was the load box)."
+echo "      probe high OR /up slow/non-200 => real server bottleneck."

--- a/loadtest/churn/run.sh
+++ b/loadtest/churn/run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# A/B verification for the Tier 1B count-fanout gate.
+#   baseline (app "heavy", count webhooks ON)  -> fanout fires per sub/unsub
+#   fixed    (app "light", no count consumer)  -> gate skips the fanout
+# Same churn workload for both. We measure the cluster-wide request/reply rate
+# (sockudo_horizontal_adapter_sent_requests) and pod health during load.
+set -uo pipefail
+cd "$(dirname "$0")"
+
+export PORTS="9611 9612 9613"
+WS_PORTS="6011 6012 6013"
+DURATION="${DURATION:-60s}"
+SECS="${DURATION%s}"
+VUS="${VUS:-200}"
+CHURN_MS="${CHURN_MS:-1000}"
+ROOMS="${ROOMS:-400}"
+
+timeouts_total () { docker compose logs --no-color 2>/dev/null | grep -c "timed out after"; }
+
+poll_health () { # app_id seconds tag
+  local app_id="$1" secs="$2" tag="$3"
+  local up_ok=0 up_fail=0 live_ok=0 live_fail=0 end=$((SECONDS + secs))
+  while [ $SECONDS -lt $end ]; do
+    for p in $WS_PORTS; do
+      lc=$(curl -s -m 2 -o /dev/null -w "%{http_code}" "http://localhost:$p/live")
+      uc=$(curl -s -m 2 -o /dev/null -w "%{http_code}" "http://localhost:$p/up/$app_id")
+      [ "$lc" = "200" ] && live_ok=$((live_ok+1)) || live_fail=$((live_fail+1))
+      [ "$uc" = "200" ] && up_ok=$((up_ok+1)) || up_fail=$((up_fail+1))
+    done
+    sleep 2
+  done
+  echo "  [$tag] health during load: /live ok=$live_ok fail=$live_fail | /up ok=$up_ok fail=$up_fail"
+}
+
+run_case () { # label app_key app_id
+  local label="$1" key="$2" app_id="$3"
+  echo "================ CASE: $label  (app=$app_id, key=$key) ================"
+  local to_before=$(timeouts_total)
+  local sent_before=$(./measure.sh horizontal_adapter_sent_requests)
+
+  k6 run --quiet -e APP_KEY="$key" -e VUS="$VUS" -e CHURN_MS="$CHURN_MS" \
+        -e ROOMS="$ROOMS" -e DURATION="$DURATION" churn.js > "/tmp/k6_${label}.txt" 2>&1 &
+  local k6pid=$!
+  poll_health "$app_id" "$SECS" "$label"
+  wait $k6pid
+
+  local sent_after=$(./measure.sh horizontal_adapter_sent_requests)
+  local to_after=$(timeouts_total)
+  local sent_delta=$((sent_after - sent_before))
+  local to_delta=$((to_after - to_before))
+  local rate=$(awk "BEGIN{printf \"%.1f\", $sent_delta/$SECS}")
+  local offered=$(grep -E "subs_sent|unsubs_sent" "/tmp/k6_${label}.txt" | grep -oE '[0-9]+([.][0-9]+)?(/s)?' | head -4 | tr '\n' ' ')
+  echo "  RESULT[$label]: horizontal_adapter_sent_requests +$sent_delta over ${SECS}s => ${rate} req/s"
+  echo "  RESULT[$label]: request timeouts during case: +$to_delta"
+  echo "  offered churn (k6 subs/unsubs counters): see /tmp/k6_${label}.txt"
+  echo
+}
+
+echo ">>> warming cluster (cluster_health heartbeats need a few seconds)..."
+sleep 8
+echo ">>> node liveness/readiness pre-load:"
+for p in $WS_PORTS; do
+  echo "  node :$p  /live=$(curl -s -m2 -o /dev/null -w '%{http_code}' http://localhost:$p/live)  /up/heavy=$(curl -s -m2 -o /dev/null -w '%{http_code}' http://localhost:$p/up/heavy)"
+done
+echo
+
+run_case baseline_heavy heavykey heavy
+echo ">>> cooldown..."; sleep 6
+run_case fixed_light lightkey light
+
+echo "================ SUMMARY ================"
+echo "baseline = count webhooks ON  (fanout fires)  -> expect high req/s"
+echo "fixed    = no count consumer  (gate skips)    -> expect ~0 req/s"

--- a/loadtest/churn/tier1a_verify.sh
+++ b/loadtest/churn/tier1a_verify.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Tier 1A verification (aggregate_counts ON). Proves two things at once:
+#   correctness: info=subscription_count returns the correct CROSS-NODE total
+#   performance: those count reads do ~ZERO ChannelSocketsCount cross-node fan-out
+# Requires the sockudo:churn-tier1a image and config.json with aggregate_counts=true.
+set -uo pipefail
+cd "$(dirname "$0")"
+COMPOSE="docker compose -f docker-compose.yml"
+PORTS="9611 9612 9613"
+VUS="${VUS:-600}"
+PUB_INTERVAL_MS="${PUB_INTERVAL_MS:-20}"
+PROBE_SECS="${PROBE_SECS:-20}"
+CHANNEL="${CHANNEL:-hot-room}"
+
+sent_light () {
+  for p in $PORTS; do curl -s -m3 "http://localhost:$p/metrics"; done \
+    | grep 'horizontal_adapter_sent_requests' | grep 'app_id="light"' \
+    | awk '{s+=$NF} END{printf "%.0f\n", s+0}'
+}
+
+echo ">>> up Tier 1A image (aggregate_counts on)"
+SOCKUDO_IMAGE=sockudo:churn-tier1a $COMPOSE up -d >/dev/null 2>&1
+echo ">>> warming"; sleep 10
+
+echo ">>> subscribing $VUS connections to $CHANNEL across 3 nodes"
+k6 run --quiet -e APP_KEY=lightkey -e CHANNEL="$CHANNEL" -e VUS="$VUS" \
+      -e DURATION="$((PROBE_SECS + 28))s" bulk_subs.js > /tmp/t1a_bulk.txt 2>&1 &
+BULK=$!
+echo ">>> waiting for subscribe + gossip convergence (full snapshot ~5s)"; sleep 20
+
+before=$(sent_light)
+echo ">>> ${PROBE_SECS}s of info=subscription_count reads (each would fan out without Tier 1A)"
+k6 run --quiet -e PUB_HOST=localhost:6011 -e PROBE_WS=ws://localhost:6012 \
+      -e CHANNEL="$CHANNEL" -e INFO=subscription_count -e PUB_INTERVAL_MS="$PUB_INTERVAL_MS" \
+      -e DURATION="${PROBE_SECS}s" probe.js > /tmp/t1a_probe.txt 2>&1
+after=$(sent_light)
+wait $BULK 2>/dev/null
+
+echo "==================== TIER 1A RESULT ===================="
+echo "bulk subscribed (ws_sessions): $(grep ws_sessions /tmp/t1a_bulk.txt | grep -oE '[0-9]+' | head -1)"
+echo "CORRECTNESS — reported subscription_count (should ~= $VUS across nodes):"
+grep -E "reported_count" /tmp/t1a_probe.txt | sed 's/^/  /'
+echo "PERF — ChannelSocketsCount fan-out during count reads: +$((after - before)) (Tier 1A target: ~0)"
+echo "       info reads performed (pub_ok): $(grep pub_ok /tmp/t1a_probe.txt | grep -oE '[0-9]+' | head -1)"
+SOCKUDO_IMAGE=sockudo:churn-tier1a $COMPOSE down -v >/dev/null 2>&1
+echo "Interpretation: reported_count ~= $VUS AND fan-out ~0 => aggregate counts are correct cross-node and read locally."


### PR DESCRIPTION
Subscribe and unsubscribe now use local transition counts on the client hot path, while cluster-wide counts move to post-ack notifications and inspection paths. This keeps room-switch churn from blocking on horizontal request/reply fanout and documents the NATS/probe guidance that shaped the operational fix.

Constraint: Room-switch workloads can generate hundreds of subscribe/unsubscribe cycles per second across Sockudo nodes

Rejected: Keep synchronous cluster-wide count lookup in subscribe/unsubscribe | it preserves exact immediate counts but keeps horizontal request fanout in the hottest client path

Confidence: high

Scope-risk: moderate

Directive: Do not reintroduce cluster-wide count fanout before client subscribe/unsubscribe acknowledgements without benchmarking room-switch churn

Tested: cargo fmt --all

Tested: cargo test -p sockudo-adapter active_channels_gauge

Tested: cargo test -p sockudo-adapter single_node

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->