### PR TITLE
Cover AI transport rewind and conformance flows

### DIFF
--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -9,6 +9,7 @@ use sockudo_core::app::App;
 use sockudo_core::channel::{ChannelType, PresenceMemberInfo};
 use sockudo_core::error::Result;
 use sockudo_core::history::{HistoryDirection, HistoryItem, HistoryReadRequest, now_ms};
+use sockudo_core::versioned_messages::MessageSerial;
 #[cfg(feature = "delta")]
 use sockudo_delta::DeltaCompressionManager;
 
@@ -20,6 +21,7 @@ use sockudo_protocol::messages::{
     AnnotationSummaryEnvelope, MESSAGE_SUMMARY_EVENT_NAME, MessageData, MessageExtras,
     MessageSummaryData, PresenceData, PusherMessage,
 };
+use sockudo_protocol::versioned_messages::extract_runtime_message_serial;
 use sonic_rs::Value;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
@@ -517,10 +519,48 @@ impl ConnectionHandler {
                         "Invalid stored history payload: {e}"
                     ))
                 })?;
+            let message = self
+                .substitute_latest_versioned_rewind_message(app_config, &message)
+                .await?;
             self.send_message_to_socket(&app_config.id, socket_id, message)
                 .await?;
         }
         Ok(())
+    }
+
+    async fn substitute_latest_versioned_rewind_message(
+        &self,
+        app_config: &App,
+        message: &PusherMessage,
+    ) -> Result<PusherMessage> {
+        if !self.server_options().versioned_messages.enabled {
+            return Ok(message.clone());
+        }
+
+        let Some(channel) = message.channel.as_deref() else {
+            return Ok(message.clone());
+        };
+        let Some(raw_message_serial) = extract_runtime_message_serial(message) else {
+            return Ok(message.clone());
+        };
+
+        let message_serial = MessageSerial::new(raw_message_serial.to_string())?;
+        let Some(latest) = self
+            .version_store()
+            .get_latest(&app_config.id, channel, &message_serial)
+            .await?
+        else {
+            return Ok(message.clone());
+        };
+
+        let stream_id = self
+            .version_store()
+            .stream_state(&app_config.id, channel)
+            .await?
+            .stream_id
+            .or_else(|| message.stream_id.clone());
+
+        Ok(self.build_runtime_message_from_record(&latest, stream_id))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/sockudo-adapter/tests/adapter/handler/runtime_rewind_recovery_e2e_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/runtime_rewind_recovery_e2e_test.rs
@@ -15,8 +15,14 @@ use sockudo_core::history::{
     MemoryHistoryStore, MemoryHistoryStoreConfig,
 };
 use sockudo_core::options::ServerOptions;
+use sockudo_core::version_store::{MemoryVersionStore, StoredVersionRecord, VersionStore};
+use sockudo_core::versioned_messages::{
+    FieldPatch, MessageAction as CoreMessageAction, MessageAppend, MessageFieldDelta,
+    MessageSerial, VersionMetadata, VersionSerial,
+};
 use sockudo_core::websocket::{SocketId, WebSocketBufferConfig};
-use sockudo_protocol::messages::{MessageData, PusherMessage};
+use sockudo_protocol::messages::{ExtrasValue, MessageData, MessageExtras, PusherMessage};
+use sockudo_protocol::versioned_messages::extract_runtime_message_serial;
 use sockudo_protocol::{ProtocolVersion, WireFormat};
 use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
 use sockudo_ws::client::WebSocketClient;
@@ -152,6 +158,7 @@ struct TestHarness {
     app_manager: Arc<MemoryAppManager>,
     adapter: Arc<LocalAdapter>,
     history_store: Arc<GateHistoryStore>,
+    version_store: Arc<MemoryVersionStore>,
 }
 
 async fn build_harness(options: ServerOptions) -> TestHarness {
@@ -168,6 +175,7 @@ async fn build_harness(options: ServerOptions) -> TestHarness {
     let adapter = Arc::new(LocalAdapter::new());
     let history_inner = Arc::new(MemoryHistoryStore::new(MemoryHistoryStoreConfig::default()));
     let history_store = Arc::new(GateHistoryStore::new(history_inner));
+    let version_store = Arc::new(MemoryVersionStore::new());
 
     let handler = ConnectionHandler::builder(
         app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
@@ -177,6 +185,7 @@ async fn build_harness(options: ServerOptions) -> TestHarness {
     )
     .local_adapter(adapter.clone())
     .history_store(history_store.clone() as Arc<dyn HistoryStore + Send + Sync>)
+    .version_store(version_store.clone() as Arc<dyn VersionStore + Send + Sync>)
     .metrics(Arc::new(MockMetricsInterface::new()))
     .build();
 
@@ -186,6 +195,7 @@ async fn build_harness(options: ServerOptions) -> TestHarness {
         app_manager,
         adapter,
         history_store,
+        version_store,
     }
 }
 
@@ -338,6 +348,230 @@ fn live_message(channel: &str, event: &str, message_id: &str) -> PusherMessage {
     }
 }
 
+fn ai_headers(entries: &[(&str, &str)]) -> MessageExtras {
+    MessageExtras {
+        headers: Some(
+            entries
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        (*key).to_string(),
+                        ExtrasValue::String((*value).to_string()),
+                    )
+                })
+                .collect(),
+        ),
+        ..Default::default()
+    }
+}
+
+fn ai_text_message(
+    channel: &str,
+    event: &str,
+    data: &str,
+    message_id: &str,
+    headers: &[(&str, &str)],
+) -> PusherMessage {
+    let mut message = live_message(channel, event, message_id);
+    message.data = Some(MessageData::String(data.to_string()));
+    message.extras = Some(ai_headers(headers));
+    message
+}
+
+fn message_string_data(message: &PusherMessage) -> &str {
+    match message.data.as_ref() {
+        Some(MessageData::String(data)) => data,
+        other => panic!("expected string message data, got {other:?}"),
+    }
+}
+
+fn header_string<'a>(message: &'a PusherMessage, key: &str) -> Option<&'a str> {
+    match message
+        .extras
+        .as_ref()
+        .and_then(|extras| extras.headers.as_ref())
+        .and_then(|headers| headers.get(key))
+    {
+        Some(ExtrasValue::String(value)) => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+struct AiMutation {
+    action: CoreMessageAction,
+    client_id: String,
+    append: Option<MessageAppend>,
+    delta: MessageFieldDelta,
+    metadata: sonic_rs::Value,
+}
+
+async fn subscribe_v2(
+    harness: &TestHarness,
+    socket_id: &SocketId,
+    reader: &mut ClientReader,
+    channel: &str,
+    rewind: Option<SubscriptionRewind>,
+) {
+    harness
+        .handler
+        .handle_subscribe_request(
+            socket_id,
+            &harness.app,
+            SubscriptionRequest {
+                channel: channel.to_string(),
+                auth: None,
+                channel_data: None,
+                #[cfg(feature = "tag-filtering")]
+                tags_filter: None,
+                #[cfg(feature = "delta")]
+                delta: None,
+                rewind,
+                event_name_filter: None,
+                annotation_subscribe: false,
+            },
+        )
+        .await
+        .unwrap();
+    let subscribed = recv_message(reader).await;
+    assert_eq!(
+        subscribed.event.as_deref(),
+        Some("sockudo_internal:subscription_succeeded")
+    );
+}
+
+async fn append_ai_message(
+    harness: &TestHarness,
+    channel: &str,
+    raw_message_serial: &str,
+    fragment: &str,
+    client_id: &str,
+    metadata: sonic_rs::Value,
+) -> PusherMessage {
+    mutate_ai_message(
+        harness,
+        channel,
+        raw_message_serial,
+        AiMutation {
+            action: CoreMessageAction::Append,
+            client_id: client_id.to_string(),
+            append: Some(MessageAppend {
+                data_fragment: fragment.to_string(),
+            }),
+            delta: MessageFieldDelta::default(),
+            metadata,
+        },
+    )
+    .await
+}
+
+async fn update_ai_message_status(
+    harness: &TestHarness,
+    channel: &str,
+    raw_message_serial: &str,
+    status: &str,
+    client_id: &str,
+    metadata: sonic_rs::Value,
+) -> PusherMessage {
+    let message_serial = MessageSerial::new(raw_message_serial.to_string()).unwrap();
+    let current = harness
+        .version_store
+        .get_latest(&harness.app.id, channel, &message_serial)
+        .await
+        .unwrap()
+        .expect("expected versioned AI message");
+    let mut extras = current.message.extras.clone().unwrap_or_default();
+    extras.headers.get_or_insert_with(Default::default).insert(
+        "x-sockudo-status".to_string(),
+        ExtrasValue::String(status.to_string()),
+    );
+
+    mutate_ai_message(
+        harness,
+        channel,
+        raw_message_serial,
+        AiMutation {
+            action: CoreMessageAction::Update,
+            client_id: client_id.to_string(),
+            append: None,
+            delta: MessageFieldDelta {
+                extras: FieldPatch::Replace(extras),
+                ..Default::default()
+            },
+            metadata,
+        },
+    )
+    .await
+}
+
+async fn mutate_ai_message(
+    harness: &TestHarness,
+    channel: &str,
+    raw_message_serial: &str,
+    mutation: AiMutation,
+) -> PusherMessage {
+    let message_serial = MessageSerial::new(raw_message_serial.to_string()).unwrap();
+    let current = harness
+        .version_store
+        .get_latest(&harness.app.id, channel, &message_serial)
+        .await
+        .unwrap()
+        .expect("expected versioned AI message");
+    let reservation = harness
+        .version_store
+        .reserve_delivery_position(&harness.app.id, channel)
+        .await
+        .unwrap();
+    let version = VersionMetadata {
+        serial: VersionSerial::new(harness.handler.next_version_serial()).unwrap(),
+        client_id: Some(mutation.client_id),
+        timestamp_ms: sockudo_core::history::now_ms(),
+        description: Some("ai-transport parity test mutation".to_string()),
+        metadata: Some(mutation.metadata),
+    };
+
+    let message = match mutation.action {
+        CoreMessageAction::Append => current
+            .message
+            .apply_append(
+                version,
+                reservation.delivery_serial,
+                mutation.append.expect("append action requires data"),
+            )
+            .unwrap(),
+        CoreMessageAction::Update => current
+            .message
+            .apply_mutation(
+                mutation.action,
+                version,
+                reservation.delivery_serial,
+                mutation.delta,
+            )
+            .unwrap(),
+        other => panic!("unsupported AI message mutation in test: {other:?}"),
+    };
+
+    let record = StoredVersionRecord {
+        app_id: current.app_id,
+        channel: current.channel,
+        original_client_id: current.original_client_id,
+        message,
+    };
+    harness
+        .version_store
+        .append_version(record.clone())
+        .await
+        .unwrap();
+    let runtime = harness
+        .handler
+        .build_runtime_message_from_record(&record, Some(reservation.stream_id));
+    harness
+        .handler
+        .broadcast_to_channel_force_full(&harness.app, channel, runtime.clone(), None, None)
+        .await
+        .unwrap();
+    runtime
+}
+
 async fn recv_message(reader: &mut ClientReader) -> PusherMessage {
     let next = timeout(Duration::from_secs(2), reader.next())
         .await
@@ -376,6 +610,426 @@ async fn expect_no_message(reader: &mut ClientReader, wait_for: Duration) {
         }
         Ok(Some(Err(err))) => panic!("unexpected websocket read error: {err:?}"),
     }
+}
+
+#[tokio::test]
+async fn ai_transport_streamed_response_fans_out_and_rewinds_as_latest_message_e2e() {
+    let mut options = ServerOptions::default();
+    options.history.enabled = true;
+    options.history.max_page_size = 100;
+    options.versioned_messages.enabled = true;
+    let harness = build_harness(options).await;
+    let channel = "ai-session-stream";
+
+    let (laptop_socket, mut laptop_reader) = connect_v2_socket(&harness).await;
+    subscribe_v2(&harness, &laptop_socket, &mut laptop_reader, channel, None).await;
+    let (phone_socket, mut phone_reader) = connect_v2_socket(&harness).await;
+    subscribe_v2(&harness, &phone_socket, &mut phone_reader, channel, None).await;
+
+    harness
+        .handler
+        .broadcast_to_channel(
+            &harness.app,
+            channel,
+            ai_text_message(
+                channel,
+                "ai.response",
+                "Hel",
+                "ai-response-1",
+                &[
+                    ("x-sockudo-turn-id", "turn-stream"),
+                    ("x-sockudo-client-id", "agent-1"),
+                    ("x-sockudo-role", "assistant"),
+                    ("x-sockudo-status", "streaming"),
+                ],
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let laptop_create = recv_message(&mut laptop_reader).await;
+    let phone_create = recv_message(&mut phone_reader).await;
+    assert_eq!(message_string_data(&laptop_create), "Hel");
+    assert_eq!(message_string_data(&phone_create), "Hel");
+    assert_eq!(
+        header_string(&laptop_create, "x-sockudo-status"),
+        Some("streaming")
+    );
+    let message_serial = extract_runtime_message_serial(&laptop_create)
+        .expect("expected versioned create metadata")
+        .to_string();
+    assert_eq!(
+        extract_runtime_message_serial(&phone_create),
+        Some(message_serial.as_str())
+    );
+
+    append_ai_message(
+        &harness,
+        channel,
+        &message_serial,
+        "lo",
+        "agent-1",
+        sonic_rs::json!({"x-sockudo-token-index": 2}),
+    )
+    .await;
+    let laptop_append = recv_message(&mut laptop_reader).await;
+    let phone_append = recv_message(&mut phone_reader).await;
+    assert_eq!(
+        laptop_append.event.as_deref(),
+        Some("sockudo:message.append")
+    );
+    assert_eq!(message_string_data(&laptop_append), "Hello");
+    assert_eq!(message_string_data(&phone_append), "Hello");
+
+    update_ai_message_status(
+        &harness,
+        channel,
+        &message_serial,
+        "finished",
+        "agent-1",
+        sonic_rs::json!({"x-sockudo-finish-reason": "complete"}),
+    )
+    .await;
+    let laptop_done = recv_message(&mut laptop_reader).await;
+    let phone_done = recv_message(&mut phone_reader).await;
+    assert_eq!(laptop_done.event.as_deref(), Some("sockudo:message.update"));
+    assert_eq!(message_string_data(&laptop_done), "Hello");
+    assert_eq!(
+        header_string(&laptop_done, "x-sockudo-status"),
+        Some("finished")
+    );
+    assert_eq!(message_string_data(&phone_done), "Hello");
+    assert_eq!(
+        header_string(&phone_done, "x-sockudo-status"),
+        Some("finished")
+    );
+
+    let (late_socket, mut late_reader) = connect_v2_socket(&harness).await;
+    subscribe_v2(
+        &harness,
+        &late_socket,
+        &mut late_reader,
+        channel,
+        Some(SubscriptionRewind::Count(10)),
+    )
+    .await;
+    let late_messages = recv_until_event(&mut late_reader, "sockudo:rewind_complete").await;
+    let latest = late_messages
+        .iter()
+        .find(|message| extract_runtime_message_serial(message) == Some(message_serial.as_str()))
+        .expect("late joiner should receive accumulated AI response");
+    assert_eq!(latest.event.as_deref(), Some("sockudo:message.update"));
+    assert_eq!(message_string_data(latest), "Hello");
+    assert_eq!(header_string(latest, "x-sockudo-status"), Some("finished"));
+    assert!(
+        !late_messages
+            .iter()
+            .any(|message| extract_runtime_message_serial(message)
+                == Some(message_serial.as_str())
+                && message_string_data(message) == "Hel")
+    );
+}
+
+#[tokio::test]
+async fn ai_transport_recovery_replays_stream_mutations_after_disconnect_e2e() {
+    let mut options = ServerOptions::default();
+    options.history.enabled = true;
+    options.history.max_page_size = 100;
+    options.connection_recovery.enabled = true;
+    options.versioned_messages.enabled = true;
+    let harness = build_harness(options).await;
+    let channel = "ai-session-recovery";
+
+    let (source_socket, mut source_reader) = connect_v2_socket(&harness).await;
+    subscribe_v2(&harness, &source_socket, &mut source_reader, channel, None).await;
+
+    harness
+        .handler
+        .broadcast_to_channel(
+            &harness.app,
+            channel,
+            ai_text_message(
+                channel,
+                "ai.response",
+                "Token",
+                "ai-response-recovery",
+                &[
+                    ("x-sockudo-turn-id", "turn-recovery"),
+                    ("x-sockudo-client-id", "agent-1"),
+                    ("x-sockudo-status", "streaming"),
+                ],
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+    let first = recv_message(&mut source_reader).await;
+    let message_serial = extract_runtime_message_serial(&first)
+        .expect("expected versioned create metadata")
+        .to_string();
+
+    append_ai_message(
+        &harness,
+        channel,
+        &message_serial,
+        " around",
+        "agent-1",
+        sonic_rs::json!({"x-sockudo-token-index": 1}),
+    )
+    .await;
+    update_ai_message_status(
+        &harness,
+        channel,
+        &message_serial,
+        "finished",
+        "agent-1",
+        sonic_rs::json!({"x-sockudo-finish-reason": "complete"}),
+    )
+    .await;
+
+    let (resume_socket, mut resume_reader) = connect_v2_socket(&harness).await;
+    harness
+        .handler
+        .handle_resume(
+            &resume_socket,
+            &harness.app,
+            &PusherMessage {
+                event: Some("sockudo:resume".to_string()),
+                channel: None,
+                data: Some(MessageData::Json(sonic_rs::json!({
+                    "channel_positions": {
+                        channel: {
+                            "stream_id": first.stream_id,
+                            "serial": first.serial,
+                            "last_message_id": first.message_id,
+                        }
+                    }
+                }))),
+                name: None,
+                user_id: None,
+                tags: None,
+                sequence: None,
+                conflation_key: None,
+                message_id: None,
+                stream_id: None,
+                serial: None,
+                idempotency_key: None,
+                extras: None,
+                delta_sequence: None,
+                delta_conflation_key: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let replayed = recv_until_event(&mut resume_reader, "sockudo:resume_success").await;
+    let replayed_ai_messages = replayed
+        .iter()
+        .filter(|message| extract_runtime_message_serial(message) == Some(message_serial.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(replayed_ai_messages.len(), 2);
+    assert_eq!(
+        replayed_ai_messages[0].event.as_deref(),
+        Some("sockudo:message.append")
+    );
+    assert_eq!(message_string_data(replayed_ai_messages[0]), "Token around");
+    assert_eq!(
+        replayed_ai_messages[1].event.as_deref(),
+        Some("sockudo:message.update")
+    );
+    assert_eq!(message_string_data(replayed_ai_messages[1]), "Token around");
+    assert_eq!(
+        header_string(replayed_ai_messages[1], "x-sockudo-status"),
+        Some("finished")
+    );
+}
+
+#[tokio::test]
+async fn ai_transport_concurrent_turns_cancel_and_codec_metadata_round_trip_e2e() {
+    let mut options = ServerOptions::default();
+    options.history.enabled = true;
+    options.history.max_page_size = 100;
+    options.versioned_messages.enabled = true;
+    let harness = build_harness(options).await;
+    let channel = "ai-session-concurrent";
+
+    let (observer_socket, mut observer_reader) = connect_v2_socket(&harness).await;
+    subscribe_v2(
+        &harness,
+        &observer_socket,
+        &mut observer_reader,
+        channel,
+        None,
+    )
+    .await;
+
+    for (turn_id, message_id, text, parent, fork_of) in [
+        ("turn-summary", "ai-summary", "Sum", "root", ""),
+        ("turn-risks", "ai-risks", "Ris", "root", "ai-summary"),
+    ] {
+        let mut headers = vec![
+            ("x-sockudo-turn-id", turn_id),
+            ("x-sockudo-client-id", "agent-1"),
+            ("x-sockudo-status", "streaming"),
+            ("x-sockudo-parent", parent),
+            ("x-sockudo-part", "text"),
+            ("x-sockudo-tool-call-id", "lookup-1"),
+            ("x-sockudo-approval-state", "pending"),
+        ];
+        if !fork_of.is_empty() {
+            headers.push(("x-sockudo-fork-of", fork_of));
+        }
+        harness
+            .handler
+            .broadcast_to_channel(
+                &harness.app,
+                channel,
+                ai_text_message(channel, "ai.response", text, message_id, &headers),
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    let summary_create = recv_message(&mut observer_reader).await;
+    let risks_create = recv_message(&mut observer_reader).await;
+    let summary_serial = extract_runtime_message_serial(&summary_create)
+        .expect("expected summary message serial")
+        .to_string();
+    let risks_serial = extract_runtime_message_serial(&risks_create)
+        .expect("expected risks message serial")
+        .to_string();
+    assert_ne!(summary_serial, risks_serial);
+    assert_eq!(
+        header_string(&risks_create, "x-sockudo-fork-of"),
+        Some("ai-summary")
+    );
+    assert_eq!(
+        header_string(&summary_create, "x-sockudo-tool-call-id"),
+        Some("lookup-1")
+    );
+
+    append_ai_message(
+        &harness,
+        channel,
+        &summary_serial,
+        "mary",
+        "agent-1",
+        sonic_rs::json!({"x-sockudo-part": "text"}),
+    )
+    .await;
+    append_ai_message(
+        &harness,
+        channel,
+        &risks_serial,
+        "ks",
+        "agent-1",
+        sonic_rs::json!({"x-sockudo-part": "reasoning"}),
+    )
+    .await;
+    let summary_append = recv_message(&mut observer_reader).await;
+    let risks_append = recv_message(&mut observer_reader).await;
+    assert_eq!(message_string_data(&summary_append), "Summary");
+    assert_eq!(message_string_data(&risks_append), "Risks");
+
+    harness
+        .handler
+        .broadcast_to_channel(
+            &harness.app,
+            channel,
+            ai_text_message(
+                channel,
+                "ai.cancel",
+                r#"{"filter":{"turnId":"turn-summary"}}"#,
+                "ai-cancel-summary",
+                &[
+                    ("x-sockudo-signal", "cancel"),
+                    ("x-sockudo-turn-id", "turn-summary"),
+                    ("x-sockudo-client-id", "user-phone"),
+                ],
+            ),
+            None,
+        )
+        .await
+        .unwrap();
+    let cancel = recv_message(&mut observer_reader).await;
+    assert_eq!(cancel.event.as_deref(), Some("ai.cancel"));
+    assert_eq!(header_string(&cancel, "x-sockudo-signal"), Some("cancel"));
+    assert_eq!(
+        header_string(&cancel, "x-sockudo-turn-id"),
+        Some("turn-summary")
+    );
+
+    update_ai_message_status(
+        &harness,
+        channel,
+        &summary_serial,
+        "aborted",
+        "agent-1",
+        sonic_rs::json!({"x-sockudo-finish-reason": "cancelled"}),
+    )
+    .await;
+    append_ai_message(
+        &harness,
+        channel,
+        &risks_serial,
+        " done",
+        "agent-1",
+        sonic_rs::json!({"x-sockudo-part": "text"}),
+    )
+    .await;
+    update_ai_message_status(
+        &harness,
+        channel,
+        &risks_serial,
+        "finished",
+        "agent-1",
+        sonic_rs::json!({"x-sockudo-finish-reason": "complete"}),
+    )
+    .await;
+
+    let summary_aborted = recv_message(&mut observer_reader).await;
+    let risks_done = recv_message(&mut observer_reader).await;
+    let risks_finished = recv_message(&mut observer_reader).await;
+    assert_eq!(
+        header_string(&summary_aborted, "x-sockudo-status"),
+        Some("aborted")
+    );
+    assert_eq!(message_string_data(&summary_aborted), "Summary");
+    assert_eq!(message_string_data(&risks_done), "Risks done");
+    assert_eq!(message_string_data(&risks_finished), "Risks done");
+    assert_eq!(
+        header_string(&risks_finished, "x-sockudo-status"),
+        Some("finished")
+    );
+
+    let (late_socket, mut late_reader) = connect_v2_socket(&harness).await;
+    subscribe_v2(
+        &harness,
+        &late_socket,
+        &mut late_reader,
+        channel,
+        Some(SubscriptionRewind::Count(10)),
+    )
+    .await;
+    let history = recv_until_event(&mut late_reader, "sockudo:rewind_complete").await;
+    let summary = history
+        .iter()
+        .find(|message| extract_runtime_message_serial(message) == Some(summary_serial.as_str()))
+        .expect("expected cancelled summary turn in history");
+    let risks = history
+        .iter()
+        .find(|message| extract_runtime_message_serial(message) == Some(risks_serial.as_str()))
+        .expect("expected completed risks turn in history");
+    assert_eq!(header_string(summary, "x-sockudo-status"), Some("aborted"));
+    assert_eq!(message_string_data(summary), "Summary");
+    assert_eq!(header_string(risks, "x-sockudo-status"), Some("finished"));
+    assert_eq!(message_string_data(risks), "Risks done");
+    assert_eq!(
+        header_string(risks, "x-sockudo-fork-of"),
+        Some("ai-summary")
+    );
 }
 
 #[tokio::test]

--- a/docs/content/docs/server/history-recovery.mdx
+++ b/docs/content/docs/server/history-recovery.mdx
@@ -89,6 +89,7 @@ Protocol V2 mutable messages use action events:
 - `sockudo:message.append`
 
 Clients reduce those events into local state. Server SDKs can fetch the latest visible state or list preserved versions.
+When a V2 subscription uses rewind, historical rows that point at mutable messages are delivered as the latest visible version, so late joiners see accumulated appended content rather than only the original create payload.
 
 ```ts
 const latest = await channel.getMessage("42");

--- a/test/ai-conformance/fixtures/golden/abortPartial.json
+++ b/test/ai-conformance/fixtures/golden/abortPartial.json
@@ -1,0 +1,19 @@
+[
+  {
+    "event": "ai-output",
+    "channel": "private-ai-abort-golden",
+    "data": ""
+  },
+  {
+    "event": "sockudo:message.append",
+    "channel": "private-ai-abort-golden",
+    "action": "append",
+    "data": "partial"
+  },
+  {
+    "event": "sockudo:message.update",
+    "channel": "private-ai-abort-golden",
+    "action": "update",
+    "data": "partial"
+  }
+]

--- a/test/ai-conformance/fixtures/golden/cancelTurn.json
+++ b/test/ai-conformance/fixtures/golden/cancelTurn.json
@@ -1,0 +1,10 @@
+[
+  {
+    "event": "ai-turn-start",
+    "channel": "private-ai-cancel-golden"
+  },
+  {
+    "event": "ai-turn-end",
+    "channel": "private-ai-cancel-golden"
+  }
+]

--- a/test/ai-conformance/fixtures/golden/concurrentTurns.json
+++ b/test/ai-conformance/fixtures/golden/concurrentTurns.json
@@ -1,0 +1,18 @@
+[
+  {
+    "event": "ai-turn-start",
+    "channel": "private-ai-concurrent-golden"
+  },
+  {
+    "event": "ai-turn-end",
+    "channel": "private-ai-concurrent-golden"
+  },
+  {
+    "event": "ai-turn-start",
+    "channel": "private-ai-concurrent-golden"
+  },
+  {
+    "event": "ai-turn-end",
+    "channel": "private-ai-concurrent-golden"
+  }
+]

--- a/test/ai-conformance/fixtures/golden/edit.json
+++ b/test/ai-conformance/fixtures/golden/edit.json
@@ -1,0 +1,7 @@
+[
+  {
+    "event": "ai-output",
+    "channel": "private-ai-edit-golden",
+    "data": ""
+  }
+]

--- a/test/ai-conformance/fixtures/golden/errorTurn.json
+++ b/test/ai-conformance/fixtures/golden/errorTurn.json
@@ -1,0 +1,10 @@
+[
+  {
+    "event": "ai-turn-start",
+    "channel": "private-ai-error-golden"
+  },
+  {
+    "event": "ai-turn-end",
+    "channel": "private-ai-error-golden"
+  }
+]

--- a/test/ai-conformance/fixtures/golden/lateJoinHistory.json
+++ b/test/ai-conformance/fixtures/golden/lateJoinHistory.json
@@ -1,0 +1,10 @@
+[
+  {
+    "event": "history:get_latest",
+    "channel": "private-ai-late-golden",
+    "data": {
+      "data": "late-state",
+      "message_serial": "msg-late"
+    }
+  }
+]

--- a/test/ai-conformance/fixtures/golden/normalTurn.json
+++ b/test/ai-conformance/fixtures/golden/normalTurn.json
@@ -1,0 +1,27 @@
+[
+  {
+    "event": "ai-turn-start",
+    "channel": "private-ai-normal-golden"
+  },
+  {
+    "event": "ai-output",
+    "channel": "private-ai-normal-golden",
+    "data": ""
+  },
+  {
+    "event": "sockudo:message.append",
+    "channel": "private-ai-normal-golden",
+    "action": "append",
+    "data": "hello"
+  },
+  {
+    "event": "sockudo:message.update",
+    "channel": "private-ai-normal-golden",
+    "action": "update",
+    "data": "hello world"
+  },
+  {
+    "event": "ai-turn-end",
+    "channel": "private-ai-normal-golden"
+  }
+]

--- a/test/ai-conformance/fixtures/golden/recoverySmoke.json
+++ b/test/ai-conformance/fixtures/golden/recoverySmoke.json
@@ -1,0 +1,10 @@
+[
+  {
+    "event": "history:get_latest",
+    "channel": "private-ai-recovery-golden",
+    "data": {
+      "data": "recoverable",
+      "message_serial": "msg-recovery"
+    }
+  }
+]

--- a/test/ai-conformance/fixtures/golden/regenerate.json
+++ b/test/ai-conformance/fixtures/golden/regenerate.json
@@ -1,0 +1,10 @@
+[
+  {
+    "event": "history:get_latest",
+    "channel": "private-ai-regenerate-golden",
+    "data": {
+      "data": "new answer",
+      "message_serial": "msg-regenerate"
+    }
+  }
+]

--- a/test/ai-conformance/fixtures/golden/suspendedContinuation.json
+++ b/test/ai-conformance/fixtures/golden/suspendedContinuation.json
@@ -1,0 +1,14 @@
+[
+  {
+    "event": "ai-turn-start",
+    "channel": "private-ai-suspended-golden"
+  },
+  {
+    "event": "ai-turn-start",
+    "channel": "private-ai-suspended-golden"
+  },
+  {
+    "event": "ai-turn-end",
+    "channel": "private-ai-suspended-golden"
+  }
+]

--- a/test/ai-conformance/src/run.mjs
+++ b/test/ai-conformance/src/run.mjs
@@ -1,0 +1,483 @@
+#!/usr/bin/env node
+import { createHash, createHmac } from "node:crypto";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const requiredFixtures = [
+  "abortPartial",
+  "cancelTurn",
+  "concurrentTurns",
+  "edit",
+  "errorTurn",
+  "lateJoinHistory",
+  "normalTurn",
+  "recoverySmoke",
+  "regenerate",
+  "suspendedContinuation",
+];
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(thisDir, "../../..");
+const fixtureDir = join(rootDir, "test/ai-conformance/fixtures/golden");
+
+if (process.env.AIT_CONFORMANCE_OFFLINE === "1") {
+  await validateFixtures();
+  console.log("offline fixture validation passed");
+  process.exit(0);
+}
+
+const config = {
+  baseUrl:
+    process.env.SOCKUDO_BASE_URL ??
+    process.env.SOCKUDO_URL ??
+    "http://127.0.0.1:6001",
+  appId: process.env.SOCKUDO_APP_ID ?? "app-id",
+  appKey: process.env.SOCKUDO_APP_KEY ?? "app-key",
+  appSecret: process.env.SOCKUDO_APP_SECRET ?? "app-secret",
+};
+
+await validateFixtures();
+await assertHealthy();
+
+const runId = `${Date.now()}-${process.pid}`;
+const scenarios = [
+  testTokenStreamingAndLatestView,
+  testCancellationAndLifecycle,
+  testConcurrentTurns,
+  testBranchMetadata,
+  testHistoryFallback,
+];
+
+for (const scenario of scenarios) {
+  await scenario(runId);
+}
+
+console.log(`AI conformance passed (${scenarios.length} live scenarios)`);
+
+async function validateFixtures() {
+  const files = (await readdir(fixtureDir))
+    .filter((file) => file.endsWith(".json"))
+    .sort();
+  const names = files.map((file) => file.replace(/\.json$/u, ""));
+  assertDeepEqual(names, requiredFixtures, "golden fixture set changed");
+  for (const file of files) {
+    const frames = JSON.parse(await readFile(join(fixtureDir, file), "utf8"));
+    assert(Array.isArray(frames), `${file} must be a JSON frame array`);
+    assert(frames.length > 0, `${file} must not be empty`);
+    for (const [index, frame] of frames.entries()) {
+      assert(typeof frame.event === "string", `${file}[${index}].event`);
+      assert(
+        frame.channel === undefined || typeof frame.channel === "string",
+        `${file}[${index}].channel`,
+      );
+    }
+  }
+}
+
+async function assertHealthy() {
+  const response = await fetch(`${config.baseUrl}/up/${config.appId}`);
+  assert(response.ok, `Sockudo health check failed: ${response.status}`);
+}
+
+async function testTokenStreamingAndLatestView(runId) {
+  const channel = channelName(runId, "stream");
+  await publish(channel, {
+    name: "ai-output",
+    data: "",
+    extras: aiHeaders({
+      turnId: "turn-stream",
+      role: "assistant",
+      status: "streaming",
+      stream: true,
+      streamId: "text:turn-stream:text",
+      codecType: "text-start",
+      codecId: "text",
+    }),
+  });
+
+  const created = await eventually(() => latestHistoryMessage(channel));
+  const messageSerial = created.message.message_serial;
+  assertString(messageSerial, "stream create message_serial");
+
+  await post(
+    `/apps/${config.appId}/channels/${channel}/messages/${messageSerial}/append`,
+    { data: "hello" },
+  );
+  await post(
+    `/apps/${config.appId}/channels/${channel}/messages/${messageSerial}/update`,
+    {
+      data: "hello world",
+      extras: aiHeaders({
+        turnId: "turn-stream",
+        role: "assistant",
+        status: "complete",
+        stream: true,
+        streamId: "text:turn-stream:text",
+        codecType: "text-end",
+        codecId: "text",
+      }),
+    },
+  );
+
+  const latest = await get(
+    `/apps/${config.appId}/channels/${channel}/messages/${messageSerial}`,
+  );
+  assertEqual(latest.item.action, "update", "latest action is update");
+  assertEqual(latest.item.data, "hello world", "latest data is accumulated");
+  assertEqual(
+    latest.item.extras.headers["x-sockudo-status"],
+    "complete",
+    "latest status is complete",
+  );
+
+  const history = await getHistory(channel);
+  const substituted = history.items.find(
+    (item) => item.message?.message_serial === messageSerial,
+  );
+  assert(substituted, "history contains versioned stream message");
+  assertEqual(
+    substituted.message.data,
+    "hello world",
+    "history exposes latest version for late join",
+  );
+}
+
+async function testCancellationAndLifecycle(runId) {
+  const channel = channelName(runId, "cancel");
+  await publish(channel, {
+    name: "ai-turn-start",
+    data: "",
+    extras: aiHeaders({
+      turnId: "turn-cancel",
+      invocationId: "inv-cancel",
+      clientId: "client-a",
+    }),
+  });
+  await publish(channel, {
+    name: "ai-cancel",
+    data: "",
+    extras: aiHeaders({ turnId: "turn-cancel", clientId: "client-b" }),
+  });
+  await publish(channel, {
+    name: "ai-turn-end",
+    data: "",
+    extras: aiHeaders({ turnId: "turn-cancel", turnReason: "cancelled" }),
+  });
+
+  const history = await eventually(() => historyWithAtLeast(channel, 3));
+  assert(
+    history.items.some((item) => item.message?.name === "ai-cancel"),
+    "cancel signal is durable",
+  );
+  assert(
+    history.items.some(
+      (item) =>
+        item.message?.name === "ai-turn-end" &&
+        item.message?.extras?.headers?.["x-sockudo-turn-reason"] ===
+          "cancelled",
+    ),
+    "cancelled turn end is durable",
+  );
+}
+
+async function testConcurrentTurns(runId) {
+  const channel = channelName(runId, "concurrent");
+  const first = await createStreamingMessage(channel, "turn-a", "A");
+  const second = await createStreamingMessage(channel, "turn-b", "B");
+
+  await post(
+    `/apps/${config.appId}/channels/${channel}/messages/${first}/append`,
+    { data: "1" },
+  );
+  await post(
+    `/apps/${config.appId}/channels/${channel}/messages/${second}/append`,
+    { data: "2" },
+  );
+  await post(
+    `/apps/${config.appId}/channels/${channel}/messages/${first}/update`,
+    {
+      data: "A1",
+      extras: aiHeaders({
+        turnId: "turn-a",
+        role: "assistant",
+        status: "complete",
+        stream: true,
+        streamId: "text:turn-a:text",
+        codecType: "text-end",
+        codecId: "text",
+      }),
+    },
+  );
+  await post(
+    `/apps/${config.appId}/channels/${channel}/messages/${second}/update`,
+    {
+      data: "B2",
+      extras: aiHeaders({
+        turnId: "turn-b",
+        role: "assistant",
+        status: "cancelled",
+        stream: true,
+        streamId: "text:turn-b:text",
+        codecType: "text-end",
+        codecId: "text",
+      }),
+    },
+  );
+
+  const latestFirst = await get(
+    `/apps/${config.appId}/channels/${channel}/messages/${first}`,
+  );
+  const latestSecond = await get(
+    `/apps/${config.appId}/channels/${channel}/messages/${second}`,
+  );
+  assertEqual(latestFirst.item.data, "A1", "first turn accumulated");
+  assertEqual(latestSecond.item.data, "B2", "second turn accumulated");
+  assertEqual(
+    latestSecond.item.extras.headers["x-sockudo-status"],
+    "cancelled",
+    "second turn can terminate independently",
+  );
+}
+
+async function testBranchMetadata(runId) {
+  const channel = channelName(runId, "branch");
+  await publish(channel, {
+    name: "ai-output",
+    data: "branch answer",
+    extras: aiHeaders({
+      turnId: "turn-branch",
+      parent: "msg-parent",
+      forkOf: "msg-original",
+      role: "assistant",
+      status: "complete",
+      stream: true,
+      streamId: "text:turn-branch:text",
+      codecType: "text-delta",
+      codecId: "text",
+    }),
+  });
+
+  const latest = await eventually(() => latestHistoryMessage(channel));
+  assertEqual(
+    latest.message.extras.headers["x-sockudo-parent"],
+    "msg-parent",
+    "parent metadata round-trips",
+  );
+  assertEqual(
+    latest.message.extras.headers["x-sockudo-fork-of"],
+    "msg-original",
+    "fork metadata round-trips",
+  );
+}
+
+async function testHistoryFallback(runId) {
+  const channel = channelName(runId, "history");
+  const messageSerial = await createStreamingMessage(
+    channel,
+    "turn-history",
+    "recover",
+  );
+  await post(
+    `/apps/${config.appId}/channels/${channel}/messages/${messageSerial}/update`,
+    {
+      data: "recoverable",
+      extras: aiHeaders({
+        turnId: "turn-history",
+        role: "assistant",
+        status: "complete",
+        stream: true,
+        streamId: "text:turn-history:text",
+        codecType: "text-end",
+        codecId: "text",
+      }),
+    },
+  );
+
+  const history = await getHistory(channel, { direction: "newest_first" });
+  assert(
+    history.items.some(
+      (item) =>
+        item.message?.message_serial === messageSerial &&
+        item.message?.data === "recoverable",
+    ),
+    "history fallback returns accumulated latest state",
+  );
+}
+
+async function createStreamingMessage(channel, turnId, initialData) {
+  await publish(channel, {
+    name: "ai-output",
+    data: initialData,
+    extras: aiHeaders({
+      turnId,
+      role: "assistant",
+      status: "streaming",
+      stream: true,
+      streamId: `text:${turnId}:text`,
+      codecType: "text-start",
+      codecId: "text",
+    }),
+  });
+  const latest = await eventually(() => latestHistoryMessage(channel));
+  const messageSerial = latest.message.message_serial;
+  assertString(messageSerial, `${turnId} message_serial`);
+  return messageSerial;
+}
+
+async function publish(channel, message) {
+  return post(`/apps/${config.appId}/events`, {
+    channel,
+    name: message.name,
+    data: message.data,
+    extras: message.extras,
+  });
+}
+
+function aiHeaders(options) {
+  const headers = {};
+  set(headers, "x-sockudo-turn-id", options.turnId);
+  set(headers, "x-sockudo-client-id", options.clientId);
+  set(headers, "x-sockudo-turn-reason", options.turnReason);
+  set(headers, "x-sockudo-invocation-id", options.invocationId);
+  set(headers, "x-sockudo-parent", options.parent);
+  set(headers, "x-sockudo-fork-of", options.forkOf);
+  set(headers, "x-sockudo-role", options.role);
+  set(headers, "x-sockudo-status", options.status);
+  set(headers, "x-sockudo-stream", options.stream);
+  set(headers, "x-sockudo-stream-id", options.streamId);
+  set(headers, "x-sockudo-codec-type", options.codecType);
+  set(headers, "x-sockudo-codec-id", options.codecId);
+  return { headers };
+}
+
+function set(target, key, value) {
+  if (value !== undefined) {
+    target[key] = value;
+  }
+}
+
+async function latestHistoryMessage(channel) {
+  const history = await getHistory(channel, { direction: "newest_first" });
+  const item = history.items.find((entry) => entry.message?.message_serial);
+  assert(item, `no history message found for ${channel}`);
+  return item;
+}
+
+async function historyWithAtLeast(channel, count) {
+  const history = await getHistory(channel, {
+    direction: "oldest_first",
+    limit: Math.max(count, 10),
+  });
+  assert(
+    history.items.length >= count,
+    `${channel} expected at least ${count} history rows`,
+  );
+  return history;
+}
+
+async function getHistory(channel, options = {}) {
+  const params = {
+    limit: String(options.limit ?? 50),
+    direction: options.direction ?? "oldest_first",
+  };
+  return get(`/apps/${config.appId}/channels/${channel}/history`, params);
+}
+
+async function get(path, params = {}) {
+  return request("GET", path, undefined, params);
+}
+
+async function post(path, body) {
+  return request("POST", path, body);
+}
+
+async function request(method, path, body, params = {}) {
+  const bodyText = body === undefined ? "" : JSON.stringify(body);
+  const query = signedQuery(method, path, bodyText, params);
+  const response = await fetch(`${config.baseUrl}${path}?${query}`, {
+    method,
+    headers:
+      body === undefined
+        ? undefined
+        : {
+            "content-type": "application/json",
+          },
+    body: body === undefined ? undefined : bodyText,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${method} ${path} failed ${response.status}: ${text}`);
+  }
+  return text.trim() === "" ? undefined : JSON.parse(text);
+}
+
+function signedQuery(method, path, bodyText, params) {
+  const entries = {
+    ...params,
+    auth_key: config.appKey,
+    auth_timestamp: String(Math.floor(Date.now() / 1000)),
+    auth_version: "1.0",
+  };
+  if (method === "POST" && bodyText.length > 0) {
+    entries.body_md5 = createHash("md5").update(bodyText).digest("hex");
+  }
+  const sorted = Object.entries(entries)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+  const stringToSign = `${method}\n${path}\n${sorted}`;
+  const signature = createHmac("sha256", config.appSecret)
+    .update(stringToSign)
+    .digest("hex");
+  return `${new URLSearchParams(entries).toString()}&auth_signature=${signature}`;
+}
+
+function channelName(runId, scenario) {
+  return `private-ai-conformance-${runId}-${scenario}`;
+}
+
+async function eventually(fn) {
+  let lastError;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      await sleep(50);
+    }
+  }
+  throw lastError;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function assert(value, message) {
+  if (!value) {
+    throw new Error(message);
+  }
+}
+
+function assertString(value, message) {
+  assert(typeof value === "string" && value.length > 0, message);
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(
+      `${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function assertDeepEqual(actual, expected, message) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${message}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- rewinds V2 mutable messages as latest visible state for late AI transport subscribers
- adds adapter E2E coverage for streaming fanout, rewind, recovery, concurrency, cancel, branch/tool/approval metadata
- adds Node ai-conformance harness with golden fixtures and a history/recovery docs note

## Verification
- cargo fmt --all -- --check
- cargo test -p sockudo-adapter --test integration runtime_rewind_recovery_e2e_test -- --nocapture
- cargo test -p sockudo-adapter
- cargo clippy -p sockudo-adapter --all-targets -- -D warnings
- cargo test -p sockudo-adapter --test integration ai_transport -- --nocapture
- cargo test --workspace
- cargo build -p sockudo --features full
- AIT_CONFORMANCE_OFFLINE=1 node test/ai-conformance/src/run.mjs
- live node test/ai-conformance/src/run.mjs against local Sockudo on 127.0.0.1:6001