### PR TITLE
Eliminate hot-path lock contention on broadcast, presence, and recovery paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ reqwest = { version = "^0.12", default-features = false, features = [
 ] }
 rustls = { version = "0.23.35", default-features = false, features = ["ring", "std", "tls12"] }
 scylla = { version = "1.3.1", features = ["rustls-023"] }
-serde = { version = "^1", features = ["derive"] }
+serde = { version = "^1", features = ["derive", "rc"] }
 serde-aux = "4"
 serde_json = "1"
 serde_json_path = "0.7.2"

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -840,9 +840,16 @@ impl ConnectionHandler {
             let mut conn_locked = conn_arc.inner.lock().await;
             conn_locked.unsubscribe_from_channel(channel_name);
 
-            // Remove presence info if it's a presence channel
             if channel_name.starts_with("presence-") {
                 conn_locked.remove_presence_info(channel_name);
+                drop(conn_locked);
+
+                if let Some(ref local_adapter) = self.local_adapter
+                    && let Some(namespace) = local_adapter.namespaces.get(&app_config.id)
+                    && let Some(mut per_socket) = namespace.presence_data.get_mut(socket_id)
+                {
+                    per_socket.remove(channel_name);
+                }
             }
         }
         Ok(())

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -814,6 +814,59 @@ impl ConnectionHandler {
         }
     }
 
+    // Presence data is mirrored in Namespace.presence_data for lock-free reads.
+    // These helpers are the only writers of the mirror — every
+    // add_presence_info/remove_presence_info on connection state must be paired
+    // with the matching call here or reads and connection state drift apart.
+    pub(crate) fn set_namespace_presence(
+        &self,
+        app_id: &str,
+        socket_id: &SocketId,
+        channel: &str,
+        info: sockudo_core::channel::PresenceMemberInfo,
+    ) {
+        let Some(ref local_adapter) = self.local_adapter else {
+            warn!(
+                "local_adapter unavailable, namespace presence mirror not updated for socket {socket_id} in channel {channel}"
+            );
+            return;
+        };
+        let Some(namespace) = local_adapter.namespaces.get(app_id) else {
+            warn!("namespace {app_id} missing, presence mirror not updated for socket {socket_id}");
+            return;
+        };
+        namespace
+            .presence_data
+            .entry(*socket_id)
+            .or_default()
+            .insert(channel.to_string(), info);
+    }
+
+    pub(crate) fn clear_namespace_presence(
+        &self,
+        app_id: &str,
+        socket_id: &SocketId,
+        channel: &str,
+    ) {
+        let Some(ref local_adapter) = self.local_adapter else {
+            warn!(
+                "local_adapter unavailable, namespace presence mirror not cleared for socket {socket_id} in channel {channel}"
+            );
+            return;
+        };
+        let Some(namespace) = local_adapter.namespaces.get(app_id) else {
+            return;
+        };
+        if let dashmap::mapref::entry::Entry::Occupied(mut per_socket) =
+            namespace.presence_data.entry(*socket_id)
+        {
+            per_socket.get_mut().remove(channel);
+            if per_socket.get().is_empty() {
+                per_socket.remove();
+            }
+        }
+    }
+
     async fn update_connection_unsubscribe_state(
         &self,
         socket_id: &SocketId,
@@ -844,12 +897,7 @@ impl ConnectionHandler {
                 conn_locked.remove_presence_info(channel_name);
                 drop(conn_locked);
 
-                if let Some(ref local_adapter) = self.local_adapter
-                    && let Some(namespace) = local_adapter.namespaces.get(&app_config.id)
-                    && let Some(mut per_socket) = namespace.presence_data.get_mut(socket_id)
-                {
-                    per_socket.remove(channel_name);
-                }
+                self.clear_namespace_presence(&app_config.id, socket_id, channel_name);
             }
         }
         Ok(())

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -610,7 +610,6 @@ impl ConnectionHandler {
 
             let mut conn_locked = conn_arc.inner.lock().await;
 
-            // Handle presence data
             if let Some(ref member) = subscription_result.member {
                 conn_locked.state.user_id = Some(member.user_id.clone());
 
@@ -619,15 +618,21 @@ impl ConnectionHandler {
                     user_info: Some(member.user_info.clone()),
                 };
 
-                conn_locked.add_presence_info(request.channel.clone(), presence_info);
-
-                // Release the connection lock before calling add_user
+                conn_locked.add_presence_info(request.channel.clone(), presence_info.clone());
                 drop(conn_locked);
 
-                // Add user to the user-socket mapping so get_user_sockets() can find it
+                if let Some(ref local_adapter) = self.local_adapter
+                    && let Some(namespace) = local_adapter.namespaces.get(&app_config.id)
+                {
+                    namespace
+                        .presence_data
+                        .entry(*socket_id)
+                        .or_default()
+                        .insert(request.channel.clone(), presence_info);
+                }
+
                 self.connection_manager.add_user(conn_arc.clone()).await?;
             } else {
-                // Release locks when not needed
                 drop(conn_locked);
             }
         }

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -619,18 +619,17 @@ impl ConnectionHandler {
                 };
 
                 conn_locked.add_presence_info(request.channel.clone(), presence_info.clone());
+                // Release the connection lock before the mirror write and add_user
                 drop(conn_locked);
 
-                if let Some(ref local_adapter) = self.local_adapter
-                    && let Some(namespace) = local_adapter.namespaces.get(&app_config.id)
-                {
-                    namespace
-                        .presence_data
-                        .entry(*socket_id)
-                        .or_default()
-                        .insert(request.channel.clone(), presence_info);
-                }
+                self.set_namespace_presence(
+                    &app_config.id,
+                    socket_id,
+                    &request.channel,
+                    presence_info,
+                );
 
+                // Add user to the user-socket mapping so get_user_sockets() can find it
                 self.connection_manager.add_user(conn_arc.clone()).await?;
             } else {
                 drop(conn_locked);

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -829,7 +829,7 @@ impl ConnectionHandler {
                 delta_sequence: None,
                 delta_conflation_key: None,
             };
-            connection.send_message(&message).await?;
+            connection.send_message(&message)?;
             if let Some(metrics) = self.metrics() {
                 metrics.mark_annotation_summary_delivery(channel);
             }

--- a/crates/sockudo-adapter/src/horizontal_adapter.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter.rs
@@ -160,7 +160,9 @@ pub struct AggregationStats {
 /// Presence entry for cluster-wide presence tracking
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PresenceEntry {
-    pub user_info: Option<sonic_rs::Value>,
+    // Arc keeps registry-lock hold times short: readers clone the pointer under
+    // the lock and deep-clone the value after releasing it (serializes as plain Value)
+    pub user_info: Option<Arc<sonic_rs::Value>>,
     pub node_id: String,      // Which node owns this connection
     pub app_id: String,       // Which app this member belongs to
     pub user_id: String,      // Which user this socket belongs to
@@ -1107,13 +1109,16 @@ impl HorizontalAdapter {
         &self,
         dead_node_id: &str,
     ) -> Result<Vec<(String, String, String, Option<sonic_rs::Value>)>> {
-        let mut registry = self.cluster_presence_registry.write().await;
+        let removed_node_data = {
+            let mut registry = self.cluster_presence_registry.write().await;
+            registry.remove(dead_node_id)
+        };
 
         // O(1) lookup and removal of entire node's data
-        if let Some(dead_node_data) = registry.remove(dead_node_id) {
+        if let Some(dead_node_data) = removed_node_data {
             // Group sockets by (app_id, channel, user_id) to avoid duplicate cleanup calls for same user
             let mut unique_members =
-                ahash::AHashMap::<(String, String, String), Option<sonic_rs::Value>>::new();
+                ahash::AHashMap::<(String, String, String), Option<Arc<sonic_rs::Value>>>::new();
 
             for (channel, sockets) in dead_node_data {
                 for (_socket_id, entry) in sockets {
@@ -1123,11 +1128,14 @@ impl HorizontalAdapter {
                 }
             }
 
-            // Convert to list format
+            // Convert to list format — entries were just removed from the registry,
+            // so the Arc is normally sole-owned and unwraps without a deep clone
             let cleanup_tasks: Vec<(String, String, String, Option<sonic_rs::Value>)> =
                 unique_members
                     .into_iter()
                     .map(|((app_id, channel, user_id), user_info)| {
+                        let user_info = user_info
+                            .map(|info| Arc::try_unwrap(info).unwrap_or_else(|arc| (*arc).clone()));
                         (app_id, channel, user_id, user_info)
                     })
                     .collect();
@@ -1155,6 +1163,7 @@ impl HorizontalAdapter {
         app_id: &str,
         user_info: Option<sonic_rs::Value>,
     ) {
+        let user_info = user_info.map(Arc::new);
         let mut registry = self.cluster_presence_registry.write().await;
         registry
             .entry(node_id.to_string())

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -1282,8 +1282,9 @@ where
             .get_channel_members(app_id, channel)
             .await?;
 
-        {
+        let collected: Vec<(String, Option<sonic_rs::Value>)> = {
             let registry = self.horizontal.cluster_presence_registry.read().await;
+            let mut collected = Vec::new();
             for (node_id, node_data) in registry.iter() {
                 if node_id == &self.node_id {
                     continue;
@@ -1293,15 +1294,17 @@ where
                         if entry.app_id != app_id {
                             continue;
                         }
-                        members.entry(entry.user_id.clone()).or_insert_with(|| {
-                            PresenceMemberInfo {
-                                user_id: entry.user_id.clone(),
-                                user_info: entry.user_info.clone(),
-                            }
-                        });
+                        collected.push((entry.user_id.clone(), entry.user_info.clone()));
                     }
                 }
             }
+            collected
+        };
+
+        for (user_id, user_info) in collected {
+            members
+                .entry(user_id.clone())
+                .or_insert_with(|| PresenceMemberInfo { user_id, user_info });
         }
 
         Ok(members)

--- a/crates/sockudo-adapter/src/horizontal_adapter_base.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base.rs
@@ -1282,7 +1282,9 @@ where
             .get_channel_members(app_id, channel)
             .await?;
 
-        let collected: Vec<(String, Option<sonic_rs::Value>)> = {
+        // Only Arc pointer clones happen under the read guard; the deep
+        // sonic_rs::Value clone is deferred until after the lock is released
+        let collected: Vec<(String, Option<Arc<sonic_rs::Value>>)> = {
             let registry = self.horizontal.cluster_presence_registry.read().await;
             let mut collected = Vec::new();
             for (node_id, node_data) in registry.iter() {
@@ -1302,9 +1304,10 @@ where
         };
 
         for (user_id, user_info) in collected {
-            members
-                .entry(user_id.clone())
-                .or_insert_with(|| PresenceMemberInfo { user_id, user_info });
+            members.entry(user_id.clone()).or_insert_with(|| {
+                let user_info = user_info.map(|info| (*info).clone());
+                PresenceMemberInfo { user_id, user_info }
+            });
         }
 
         Ok(members)

--- a/crates/sockudo-adapter/src/local_adapter.rs
+++ b/crates/sockudo-adapter/src/local_adapter.rs
@@ -247,7 +247,7 @@ impl LocalAdapter {
                     let chunk_results: Vec<Result<()>> = stream::iter(chunk_vec)
                         .map(|socket_ref| {
                             let msg = message.clone();
-                            async move { socket_ref.send_message(&msg).await }
+                            async move { socket_ref.send_message(&msg) }
                         })
                         .buffer_unordered(chunk_size)
                         .collect()
@@ -787,7 +787,7 @@ impl LocalAdapter {
         };
 
         match compression_result {
-            CompressionResult::Uncompressed => socket_ref.send_message(&base_message).await,
+            CompressionResult::Uncompressed => socket_ref.send_message(&base_message),
             CompressionResult::FullMessage {
                 sequence,
                 conflation_key,
@@ -827,7 +827,7 @@ impl LocalAdapter {
                 let mut full_message = base_message;
                 full_message.delta_sequence = Some(sequence.into());
                 full_message.delta_conflation_key = conflation_key;
-                socket_ref.send_message(&full_message).await
+                socket_ref.send_message(&full_message)
             }
             CompressionResult::Delta {
                 delta,
@@ -909,7 +909,7 @@ impl LocalAdapter {
                 {
                     warn!("Failed to store delta base message state: {e}");
                 }
-                socket_ref.send_message(&pusher_msg).await
+                socket_ref.send_message(&pusher_msg)
             }
         }
     }
@@ -1070,7 +1070,7 @@ impl LocalAdapter {
                     channel_settings,
                 )
                 .await;
-            socket_ref.send_message(&pusher_msg).await
+            socket_ref.send_message(&pusher_msg)
         } else {
             // No delta available (first message or delta not beneficial), send full message
             debug!(
@@ -1146,7 +1146,7 @@ impl LocalAdapter {
             if !conflation_key.is_empty() {
                 full_message.delta_conflation_key = Some(conflation_key);
             }
-            socket_ref.send_message(&full_message).await
+            socket_ref.send_message(&full_message)
         }
     }
 
@@ -1486,10 +1486,10 @@ impl ConnectionManager for LocalAdapter {
                     rewritten.message_id = Some(generate_message_id());
                 }
                 rewritten.rewrite_prefix(sockudo_protocol::ProtocolVersion::V2);
-                connection.send_message(&rewritten).await
+                connection.send_message(&rewritten)
             }
             sockudo_protocol::ProtocolVersion::V1 => match Self::v1_compatible_message(&message) {
-                Some(v1_msg) => connection.send_message(&v1_msg).await,
+                Some(v1_msg) => connection.send_message(&v1_msg),
                 None => Ok(()),
             },
         }

--- a/crates/sockudo-adapter/src/local_adapter.rs
+++ b/crates/sockudo-adapter/src/local_adapter.rs
@@ -1717,7 +1717,7 @@ impl ConnectionManager for LocalAdapter {
         channel: &str,
     ) -> Result<HashMap<String, PresenceMemberInfo>> {
         match self.existing_namespace(app_id) {
-            Some(namespace) => namespace.get_channel_members(channel).await,
+            Some(namespace) => namespace.get_channel_members(channel),
             None => Ok(HashMap::new()),
         }
     }
@@ -1867,7 +1867,7 @@ impl ConnectionManager for LocalAdapter {
         socket_id: &SocketId,
     ) -> Option<PresenceMemberInfo> {
         let namespace = self.get_or_create_namespace(app_id).await;
-        namespace.get_presence_member(channel, socket_id).await
+        namespace.get_presence_member(channel, socket_id)
     }
 
     async fn terminate_user_connections(&self, app_id: &str, user_id: &str) -> Result<()> {
@@ -1923,9 +1923,7 @@ impl ConnectionManager for LocalAdapter {
     ) -> Result<usize> {
         match self.existing_namespace(app_id) {
             Some(namespace) => {
-                namespace
-                    .count_user_connections_in_channel(user_id, channel, excluding_socket)
-                    .await
+                namespace.count_user_connections_in_channel(user_id, channel, excluding_socket)
             }
             None => Ok(0),
         }

--- a/crates/sockudo-adapter/src/presence.rs
+++ b/crates/sockudo-adapter/src/presence.rs
@@ -76,29 +76,84 @@ impl PresenceManager {
         let lock_key = presence_lock_key(&app_config.id, channel, user_id);
         let presence_lock = self.get_presence_lock(&lock_key);
 
-        // TOCTOU check under the per-user lock.
-        // The lock is held ONLY for the connection-count check so the decision is atomic.
-        // The lock guard is dropped at the end of this block — BEFORE webhook, broadcast,
-        // and history I/O — keeping the critical section as short as possible.
+        // TOCTOU check AND member_added broadcasts under the per-user lock.
+        // The lock serializes the count check so two concurrent first-joins can't
+        // both see count=0 and emit duplicate member_added events.
+        // The broadcast must stay inside the lock: a concurrent last-leave/first-join
+        // race on the same user emits both member_removed and member_added, and the
+        // wire order must match the decision order or clients end up with an inverted
+        // member list. The lock is keyed per (app, channel, user), so this only
+        // serializes the same user's join/leave on the same channel.
+        // Webhook enqueue and history recording happen AFTER the lock is released.
         let should_send_event = {
             let _lock_guard = presence_lock.lock().await;
-            !Self::user_has_other_connections_in_presence_channel(
+            let first_join = !Self::user_has_other_connections_in_presence_channel(
                 Arc::clone(&connection_manager),
                 &app_config.id,
                 channel,
                 user_id,
                 excluding_socket,
             )
-            .await?
+            .await?;
+
+            if first_join {
+                debug!(
+                    "User {} is joining channel {} for the first time, sending member_added events",
+                    user_id, channel
+                );
+
+                // Broadcast member_added event to existing clients in the channel
+                let member_added_msg = sockudo_protocol::messages::PusherMessage::member_added(
+                    channel.to_string(),
+                    user_id.to_string(),
+                    user_info.cloned(),
+                );
+                Self::broadcast_to_channel(
+                    Arc::clone(&connection_manager),
+                    &app_config.id,
+                    channel,
+                    member_added_msg,
+                    excluding_socket,
+                )
+                .await?;
+
+                let _ = Self::broadcast_to_channel(
+                    Arc::clone(&connection_manager),
+                    &app_config.id,
+                    &format!("[meta]{channel}"),
+                    sockudo_protocol::messages::PusherMessage {
+                        event: Some("sockudo_internal:member_added".to_string()),
+                        channel: Some(format!("[meta]{channel}")),
+                        data: Some(sockudo_protocol::messages::MessageData::Json(
+                            sonic_rs::json!({
+                                "channel": channel,
+                                "user_id": user_id,
+                            }),
+                        )),
+                        name: None,
+                        user_id: None,
+                        tags: None,
+                        sequence: None,
+                        conflation_key: None,
+                        message_id: None,
+                        stream_id: None,
+                        serial: None,
+                        idempotency_key: None,
+                        extras: None,
+                        delta_sequence: None,
+                        delta_conflation_key: None,
+                    },
+                    None,
+                )
+                .await;
+            }
+
+            first_join
         }; // _lock_guard dropped here
 
         if should_send_event {
-            debug!(
-                "User {} is joining channel {} for the first time, sending member_added events",
-                user_id, channel
-            );
-
-            // Send member_added webhook
+            // Send member_added webhook (queue enqueue, outside the lock —
+            // webhook delivery order is timestamp-based, not enqueue-order-based)
             if let Some(webhook_integration) = webhook_integration
                 && let Err(e) = webhook_integration
                     .send_member_added(app_config, channel, user_id)
@@ -109,51 +164,6 @@ impl PresenceManager {
                     user_id, channel, e
                 );
             }
-
-            // Broadcast member_added event to existing clients in the channel
-            let member_added_msg = sockudo_protocol::messages::PusherMessage::member_added(
-                channel.to_string(),
-                user_id.to_string(),
-                user_info.cloned(),
-            );
-            Self::broadcast_to_channel(
-                Arc::clone(&connection_manager),
-                &app_config.id,
-                channel,
-                member_added_msg,
-                excluding_socket,
-            )
-            .await?;
-
-            let _ = Self::broadcast_to_channel(
-                Arc::clone(&connection_manager),
-                &app_config.id,
-                &format!("[meta]{channel}"),
-                sockudo_protocol::messages::PusherMessage {
-                    event: Some("sockudo_internal:member_added".to_string()),
-                    channel: Some(format!("[meta]{channel}")),
-                    data: Some(sockudo_protocol::messages::MessageData::Json(
-                        sonic_rs::json!({
-                            "channel": channel,
-                            "user_id": user_id,
-                        }),
-                    )),
-                    name: None,
-                    user_id: None,
-                    tags: None,
-                    sequence: None,
-                    conflation_key: None,
-                    message_id: None,
-                    stream_id: None,
-                    serial: None,
-                    idempotency_key: None,
-                    extras: None,
-                    delta_sequence: None,
-                    delta_conflation_key: None,
-                },
-                None,
-            )
-            .await;
 
             debug!(
                 "Successfully processed member_added for user {} in channel {}",
@@ -257,28 +267,79 @@ impl PresenceManager {
         let lock_key = presence_lock_key(&app_config.id, channel, user_id);
         let presence_lock = self.get_presence_lock(&lock_key);
 
-        // TOCTOU check under the per-user lock.
-        // The lock is held ONLY for the connection-count check so the decision is atomic.
-        // The lock guard is dropped at the end of this block — BEFORE webhook, broadcast,
-        // and history I/O — keeping the critical section as short as possible.
+        // TOCTOU check AND member_removed broadcasts under the per-user lock.
+        // The lock serializes the count check so a disconnect racing a same-user
+        // connect can't emit member_removed for a user that is still present.
+        // The broadcast must stay inside the lock: a concurrent last-leave/first-join
+        // race on the same user emits both member_removed and member_added, and the
+        // wire order must match the decision order or clients end up with an inverted
+        // member list. The lock is keyed per (app, channel, user), so this only
+        // serializes the same user's join/leave on the same channel.
+        // Webhook enqueue and history recording happen AFTER the lock is released.
         let should_send_event = {
             let _lock_guard = presence_lock.lock().await;
-            !Self::user_has_other_connections_in_presence_channel(
+            let last_leave = !Self::user_has_other_connections_in_presence_channel(
                 Arc::clone(connection_manager),
                 &app_config.id,
                 channel,
                 user_id,
                 excluding_socket,
             )
-            .await?
+            .await?;
+
+            if last_leave {
+                debug!(
+                    "User {} has no other connections in channel {}, sending member_removed events",
+                    user_id, channel
+                );
+
+                // Broadcast member_removed event to remaining clients in the channel
+                let member_removed_msg =
+                    PusherMessage::member_removed(channel.to_string(), user_id.to_string());
+                Self::broadcast_to_channel(
+                    Arc::clone(connection_manager),
+                    &app_config.id,
+                    channel,
+                    member_removed_msg,
+                    excluding_socket,
+                )
+                .await?;
+
+                let _ = Self::broadcast_to_channel(
+                    Arc::clone(connection_manager),
+                    &app_config.id,
+                    &format!("[meta]{channel}"),
+                    PusherMessage {
+                        event: Some("sockudo_internal:member_removed".to_string()),
+                        channel: Some(format!("[meta]{channel}")),
+                        data: Some(sockudo_protocol::messages::MessageData::Json(
+                            sonic_rs::json!({
+                                "channel": channel,
+                                "user_id": user_id,
+                            }),
+                        )),
+                        name: None,
+                        user_id: None,
+                        tags: None,
+                        sequence: None,
+                        conflation_key: None,
+                        message_id: None,
+                        stream_id: None,
+                        serial: None,
+                        idempotency_key: None,
+                        extras: None,
+                        delta_sequence: None,
+                        delta_conflation_key: None,
+                    },
+                    None,
+                )
+                .await;
+            }
+
+            last_leave
         }; // _lock_guard dropped here
 
         if should_send_event {
-            debug!(
-                "User {} has no other connections in channel {}, sending member_removed events",
-                user_id, channel
-            );
-
             // Send member_removed webhook with 3-second delay
             // Per Pusher spec: delay prevents spurious webhooks from momentary disconnects.
             // If the user reconnects within the delay, no webhook is sent.
@@ -308,48 +369,6 @@ impl PresenceManager {
                     }
                 });
             }
-
-            // Broadcast member_removed event to remaining clients in the channel
-            let member_removed_msg =
-                PusherMessage::member_removed(channel.to_string(), user_id.to_string());
-            Self::broadcast_to_channel(
-                Arc::clone(connection_manager),
-                &app_config.id,
-                channel,
-                member_removed_msg,
-                excluding_socket,
-            )
-            .await?;
-
-            let _ = Self::broadcast_to_channel(
-                Arc::clone(connection_manager),
-                &app_config.id,
-                &format!("[meta]{channel}"),
-                PusherMessage {
-                    event: Some("sockudo_internal:member_removed".to_string()),
-                    channel: Some(format!("[meta]{channel}")),
-                    data: Some(sockudo_protocol::messages::MessageData::Json(
-                        sonic_rs::json!({
-                            "channel": channel,
-                            "user_id": user_id,
-                        }),
-                    )),
-                    name: None,
-                    user_id: None,
-                    tags: None,
-                    sequence: None,
-                    conflation_key: None,
-                    message_id: None,
-                    stream_id: None,
-                    serial: None,
-                    idempotency_key: None,
-                    extras: None,
-                    delta_sequence: None,
-                    delta_conflation_key: None,
-                },
-                None,
-            )
-            .await;
 
             debug!(
                 "Successfully processed member_removed for user {} in channel {}",

--- a/crates/sockudo-adapter/src/presence.rs
+++ b/crates/sockudo-adapter/src/presence.rs
@@ -74,31 +74,25 @@ impl PresenceManager {
         );
 
         let lock_key = presence_lock_key(&app_config.id, channel, user_id);
-
-        // FIX: Acquire per-user lock to prevent TOCTOU race between checking connection count
-        // and sending member_added events. Without this lock:
-        // - Thread A: checks count=0, about to send member_added
-        // - Thread B: checks count=0, sends member_added (duplicate!)
-        // - Thread A: sends member_added (duplicate!)
-        //
-        // With lock:
-        // - Thread A: acquires lock, checks count=0, sends member_added, releases lock
-        // - Thread B: acquires lock, checks count=1, skips member_added, releases lock
         let presence_lock = self.get_presence_lock(&lock_key);
-        let _lock_guard = presence_lock.lock().await;
 
-        // Check if user already had connections in this presence channel (excluding current socket)
-        // This check is now protected by the lock
-        let had_other_connections = Self::user_has_other_connections_in_presence_channel(
-            Arc::clone(&connection_manager),
-            &app_config.id,
-            channel,
-            user_id,
-            excluding_socket,
-        )
-        .await?;
+        // TOCTOU check under the per-user lock.
+        // The lock is held ONLY for the connection-count check so the decision is atomic.
+        // The lock guard is dropped at the end of this block — BEFORE webhook, broadcast,
+        // and history I/O — keeping the critical section as short as possible.
+        let should_send_event = {
+            let _lock_guard = presence_lock.lock().await;
+            !Self::user_has_other_connections_in_presence_channel(
+                Arc::clone(&connection_manager),
+                &app_config.id,
+                channel,
+                user_id,
+                excluding_socket,
+            )
+            .await?
+        }; // _lock_guard dropped here
 
-        if !had_other_connections {
+        if should_send_event {
             debug!(
                 "User {} is joining channel {} for the first time, sending member_added events",
                 user_id, channel
@@ -202,14 +196,10 @@ impl PresenceManager {
             }
         } else {
             debug!(
-                "User {} already has {} connections in channel {}, skipping member_added events",
-                user_id,
-                if had_other_connections { "other" } else { "no" },
-                channel
+                "User {} already has other connections in channel {}, skipping member_added events",
+                user_id, channel
             );
         }
-
-        // Lock is released here when _lock_guard goes out of scope
 
         // Always broadcast presence join to all nodes for cluster replication (for every connection)
         // This is done OUTSIDE the lock to avoid holding it during network I/O
@@ -265,36 +255,25 @@ impl PresenceManager {
         );
 
         let lock_key = presence_lock_key(&app_config.id, channel, user_id);
-
-        // FIX: Acquire per-user lock to prevent TOCTOU race between checking connection count
-        // and sending member_removed events. Without this lock:
-        // - Thread A (disconnect socket 1): checks count=1, about to send member_removed
-        // - Thread B (disconnect socket 2): checks count=1, sends member_removed
-        // - Thread A: sends member_removed (duplicate! user still has socket 2... wait, no they don't)
-        //
-        // The real race is:
-        // - Thread A (disconnect): checks count=1 (only this socket), prepares member_removed
-        // - Thread B (connect): checks count=1 (sees socket being disconnected), skips member_added
-        // - Thread A: sends member_removed
-        // Result: User is connected but appears removed!
-        //
-        // With lock:
-        // - Operations are serialized per user+channel, ensuring consistent state
         let presence_lock = self.get_presence_lock(&lock_key);
-        let _lock_guard = presence_lock.lock().await;
 
-        // Check if user has other connections in this presence channel
-        // This check is now protected by the lock
-        let has_other_connections = Self::user_has_other_connections_in_presence_channel(
-            Arc::clone(connection_manager),
-            &app_config.id,
-            channel,
-            user_id,
-            excluding_socket,
-        )
-        .await?;
+        // TOCTOU check under the per-user lock.
+        // The lock is held ONLY for the connection-count check so the decision is atomic.
+        // The lock guard is dropped at the end of this block — BEFORE webhook, broadcast,
+        // and history I/O — keeping the critical section as short as possible.
+        let should_send_event = {
+            let _lock_guard = presence_lock.lock().await;
+            !Self::user_has_other_connections_in_presence_channel(
+                Arc::clone(connection_manager),
+                &app_config.id,
+                channel,
+                user_id,
+                excluding_socket,
+            )
+            .await?
+        }; // _lock_guard dropped here
 
-        if !has_other_connections {
+        if should_send_event {
             debug!(
                 "User {} has no other connections in channel {}, sending member_removed events",
                 user_id, channel
@@ -418,8 +397,6 @@ impl PresenceManager {
                 user_id, channel
             );
         }
-
-        // Lock is released here when _lock_guard goes out of scope
 
         // Always broadcast presence leave to all nodes for cluster replication (for every disconnection)
         // This is done OUTSIDE the lock to avoid holding it during network I/O

--- a/crates/sockudo-adapter/src/replay_buffer.rs
+++ b/crates/sockudo-adapter/src/replay_buffer.rs
@@ -20,8 +20,6 @@ struct ChannelBufferState {
 struct ChannelBuffer {
     state: Mutex<ChannelBufferState>,
     next_serial: AtomicU64,
-    max_size: usize,
-    ttl: Duration,
 }
 
 pub enum ReplayLookup {
@@ -79,8 +77,6 @@ impl ReplayBuffer {
                 current_stream_id: None,
             }),
             next_serial: AtomicU64::new(1),
-            max_size: self.max_buffer_size,
-            ttl: self.buffer_ttl,
         });
         entry.next_serial.fetch_add(1, Ordering::Relaxed)
     }
@@ -101,15 +97,12 @@ impl ReplayBuffer {
                 current_stream_id: stream_id.map(ToString::to_string),
             }),
             next_serial: AtomicU64::new(serial + 1),
-            max_size: self.max_buffer_size,
-            ttl: self.buffer_ttl,
         });
 
-        let max_size = entry.max_size;
         let mut state = entry.state.lock().unwrap();
         state.current_stream_id = stream_id.map(ToString::to_string);
         // Evict oldest if at capacity
-        while state.messages.len() >= max_size {
+        while state.messages.len() >= self.max_buffer_size {
             state.messages.pop_front();
         }
         state.messages.push_back(BufferedMessage {
@@ -149,7 +142,6 @@ impl ReplayBuffer {
             return ReplayLookup::Expired;
         };
 
-        let ttl = entry.ttl;
         let now = Instant::now();
         let mut state = entry.state.lock().unwrap();
 
@@ -161,7 +153,7 @@ impl ReplayBuffer {
             };
         }
 
-        Self::prune_expired_locked(&mut state.messages, ttl, now);
+        Self::prune_expired_locked(&mut state.messages, self.buffer_ttl, now);
 
         if state.messages.is_empty() {
             if stream_id.is_some() {
@@ -206,9 +198,8 @@ impl ReplayBuffer {
         let mut empty_keys = Vec::new();
 
         for entry in self.buffers.iter() {
-            let ttl = entry.value().ttl;
             let mut state = entry.value().state.lock().unwrap();
-            Self::prune_expired_locked(&mut state.messages, ttl, now);
+            Self::prune_expired_locked(&mut state.messages, self.buffer_ttl, now);
             if state.messages.is_empty() {
                 empty_keys.push(entry.key().clone());
             }

--- a/crates/sockudo-adapter/src/replay_buffer.rs
+++ b/crates/sockudo-adapter/src/replay_buffer.rs
@@ -12,10 +12,16 @@ struct BufferedMessage {
     timestamp: Instant,
 }
 
+struct ChannelBufferState {
+    messages: VecDeque<BufferedMessage>,
+    current_stream_id: Option<String>,
+}
+
 struct ChannelBuffer {
-    messages: Mutex<VecDeque<BufferedMessage>>,
+    state: Mutex<ChannelBufferState>,
     next_serial: AtomicU64,
-    current_stream_id: Mutex<Option<String>>,
+    max_size: usize,
+    ttl: Duration,
 }
 
 pub enum ReplayLookup {
@@ -68,9 +74,13 @@ impl ReplayBuffer {
     pub fn next_serial(&self, app_id: &str, channel: &str) -> u64 {
         let key = Self::buffer_key(app_id, channel);
         let entry = self.buffers.entry(key).or_insert_with(|| ChannelBuffer {
-            messages: Mutex::new(VecDeque::with_capacity(self.max_buffer_size)),
+            state: Mutex::new(ChannelBufferState {
+                messages: VecDeque::with_capacity(self.max_buffer_size),
+                current_stream_id: None,
+            }),
             next_serial: AtomicU64::new(1),
-            current_stream_id: Mutex::new(None),
+            max_size: self.max_buffer_size,
+            ttl: self.buffer_ttl,
         });
         entry.next_serial.fetch_add(1, Ordering::Relaxed)
     }
@@ -86,22 +96,23 @@ impl ReplayBuffer {
     ) {
         let key = Self::buffer_key(app_id, channel);
         let entry = self.buffers.entry(key).or_insert_with(|| ChannelBuffer {
-            messages: Mutex::new(VecDeque::with_capacity(self.max_buffer_size)),
+            state: Mutex::new(ChannelBufferState {
+                messages: VecDeque::with_capacity(self.max_buffer_size),
+                current_stream_id: stream_id.map(ToString::to_string),
+            }),
             next_serial: AtomicU64::new(serial + 1),
-            current_stream_id: Mutex::new(stream_id.map(ToString::to_string)),
+            max_size: self.max_buffer_size,
+            ttl: self.buffer_ttl,
         });
 
-        {
-            let mut current_stream_id = entry.current_stream_id.lock().unwrap();
-            *current_stream_id = stream_id.map(ToString::to_string);
-        }
-
-        let mut messages = entry.messages.lock().unwrap();
+        let max_size = entry.max_size;
+        let mut state = entry.state.lock().unwrap();
+        state.current_stream_id = stream_id.map(ToString::to_string);
         // Evict oldest if at capacity
-        while messages.len() >= self.max_buffer_size {
-            messages.pop_front();
+        while state.messages.len() >= max_size {
+            state.messages.pop_front();
         }
-        messages.push_back(BufferedMessage {
+        state.messages.push_back(BufferedMessage {
             stream_id: stream_id.map(ToString::to_string),
             serial,
             message_bytes,
@@ -137,18 +148,22 @@ impl ReplayBuffer {
         let Some(entry) = self.buffers.get(&key) else {
             return ReplayLookup::Expired;
         };
-        let current_stream_id = entry.current_stream_id.lock().unwrap().clone();
+
+        let ttl = entry.ttl;
+        let now = Instant::now();
+        let mut state = entry.state.lock().unwrap();
 
         if let Some(expected_stream_id) = stream_id
-            && current_stream_id.as_deref() != Some(expected_stream_id)
+            && state.current_stream_id.as_deref() != Some(expected_stream_id)
         {
-            return ReplayLookup::StreamReset { current_stream_id };
+            return ReplayLookup::StreamReset {
+                current_stream_id: state.current_stream_id.clone(),
+            };
         }
-        let now = Instant::now();
-        let mut messages = entry.messages.lock().unwrap();
-        Self::prune_expired_locked(&mut messages, self.buffer_ttl, now);
 
-        if messages.is_empty() {
+        Self::prune_expired_locked(&mut state.messages, ttl, now);
+
+        if state.messages.is_empty() {
             if stream_id.is_some() {
                 return ReplayLookup::Expired;
             }
@@ -162,19 +177,19 @@ impl ReplayBuffer {
             };
         }
 
-        let newest_serial = messages.back().map(|m| m.serial).unwrap_or(0);
+        let newest_serial = state.messages.back().map(|m| m.serial).unwrap_or(0);
         if last_serial >= newest_serial {
             return ReplayLookup::Recovered(Vec::new());
         }
 
         // Check if the buffer goes back far enough
-        let oldest_serial = messages.front().map(|m| m.serial).unwrap_or(0);
+        let oldest_serial = state.messages.front().map(|m| m.serial).unwrap_or(0);
         if last_serial > 0 && last_serial < oldest_serial.saturating_sub(1) {
             // The client missed messages that were already evicted
             return ReplayLookup::Expired;
         }
 
-        let contiguous = messages.make_contiguous();
+        let contiguous = state.messages.make_contiguous();
         let start_idx = contiguous.partition_point(|message| message.serial <= last_serial);
         let mut result = Vec::with_capacity(contiguous.len().saturating_sub(start_idx));
         for message in &contiguous[start_idx..] {
@@ -191,9 +206,10 @@ impl ReplayBuffer {
         let mut empty_keys = Vec::new();
 
         for entry in self.buffers.iter() {
-            let mut messages = entry.value().messages.lock().unwrap();
-            Self::prune_expired_locked(&mut messages, self.buffer_ttl, now);
-            if messages.is_empty() {
+            let ttl = entry.value().ttl;
+            let mut state = entry.value().state.lock().unwrap();
+            Self::prune_expired_locked(&mut state.messages, ttl, now);
+            if state.messages.is_empty() {
                 empty_keys.push(entry.key().clone());
             }
         }
@@ -201,7 +217,7 @@ impl ReplayBuffer {
         for key in empty_keys {
             // Only remove if still empty (avoid race with concurrent store)
             self.buffers
-                .remove_if(&key, |_, v| v.messages.lock().unwrap().is_empty());
+                .remove_if(&key, |_, v| v.state.lock().unwrap().messages.is_empty());
         }
     }
 }

--- a/crates/sockudo-adapter/tests/adapter/cluster_presence_registry_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/cluster_presence_registry_tests.rs
@@ -1,0 +1,262 @@
+use crate::adapter::horizontal_adapter_helpers::{MockConfig, MockTransport};
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::horizontal_adapter_base::HorizontalAdapterBase;
+use sockudo_core::channel::PresenceMemberInfo;
+use sonic_rs::json;
+use tokio::task::JoinSet;
+
+#[tokio::test]
+async fn test_local_channel_members_merges_registry() {
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(MockConfig::default())
+        .await
+        .unwrap();
+
+    let app_id = "app-merge";
+    let channel = "presence-merge-ch";
+
+    for (node, socket, user) in &[
+        ("node-A", "sock-A", "alice"),
+        ("node-B", "sock-B", "bob"),
+        ("node-C", "sock-C", "carol"),
+    ] {
+        adapter
+            .horizontal
+            .add_presence_entry(
+                node,
+                channel,
+                socket,
+                user,
+                app_id,
+                Some(json!({"name": user})),
+            )
+            .await;
+    }
+
+    let members = adapter
+        .get_local_channel_members(app_id, channel)
+        .await
+        .unwrap();
+
+    assert!(
+        members.contains_key("alice"),
+        "alice (node-A) must be present"
+    );
+    assert!(members.contains_key("bob"), "bob (node-B) must be present");
+    assert!(
+        members.contains_key("carol"),
+        "carol (node-C) must be present"
+    );
+    assert_eq!(
+        members.len(),
+        3,
+        "exactly 3 distinct users should be merged; got {}",
+        members.len()
+    );
+
+    let requests = adapter.transport.get_published_requests().await;
+    assert!(
+        requests.is_empty(),
+        "get_local_channel_members must issue zero cluster requests; got {}",
+        requests.len()
+    );
+}
+
+#[tokio::test]
+async fn test_local_channel_members_skips_own_node() {
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(MockConfig::default())
+        .await
+        .unwrap();
+
+    let app_id = "app-skip";
+    let channel = "presence-skip-ch";
+    let self_node = adapter.node_id.clone();
+
+    adapter
+        .horizontal
+        .add_presence_entry(&self_node, channel, "sock-self", "user-self", app_id, None)
+        .await;
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "remote-node-1",
+            channel,
+            "sock-remote",
+            "user-remote",
+            app_id,
+            Some(json!({"role": "remote"})),
+        )
+        .await;
+
+    let members = adapter
+        .get_local_channel_members(app_id, channel)
+        .await
+        .unwrap();
+
+    assert!(
+        !members.contains_key("user-self"),
+        "entry registered under own node_id must be excluded from registry scan"
+    );
+    assert!(
+        members.contains_key("user-remote"),
+        "entry from a remote node must be included"
+    );
+}
+
+#[tokio::test]
+async fn test_local_channel_members_filters_by_app_id() {
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(MockConfig::default())
+        .await
+        .unwrap();
+
+    let target_app = "app-target";
+    let other_app = "app-other";
+    let channel = "presence-filter-ch";
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "node-X",
+            channel,
+            "sock-X1",
+            "user-target-1",
+            target_app,
+            Some(json!({"app": "target"})),
+        )
+        .await;
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "node-X",
+            channel,
+            "sock-X2",
+            "user-target-2",
+            target_app,
+            Some(json!({"app": "target"})),
+        )
+        .await;
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "node-X",
+            channel,
+            "sock-Y",
+            "user-other",
+            other_app,
+            Some(json!({"app": "other"})),
+        )
+        .await;
+
+    let members = adapter
+        .get_local_channel_members(target_app, channel)
+        .await
+        .unwrap();
+
+    assert!(
+        members.contains_key("user-target-1"),
+        "user-target-1 must be included"
+    );
+    assert!(
+        members.contains_key("user-target-2"),
+        "user-target-2 must be included"
+    );
+    assert!(
+        !members.contains_key("user-other"),
+        "user-other (app-other) must be excluded when querying target_app"
+    );
+    assert_eq!(
+        members.len(),
+        2,
+        "only target-app members should appear; got {}",
+        members.len()
+    );
+}
+
+#[tokio::test]
+async fn test_concurrent_read_write_registry() {
+    let adapter = HorizontalAdapterBase::<MockTransport>::new(MockConfig::default())
+        .await
+        .unwrap();
+
+    let app_id = "app-concurrent";
+    let channel = "presence-concurrent-ch";
+    let own_node = adapter.node_id.clone();
+    let horizontal = adapter.horizontal.clone();
+
+    for i in 0..5_usize {
+        horizontal
+            .add_presence_entry(
+                &format!("node-init-{i}"),
+                channel,
+                &format!("sock-init-{i}"),
+                &format!("user-init-{i}"),
+                app_id,
+                Some(json!({"seq": i})),
+            )
+            .await;
+    }
+
+    let mut set = JoinSet::new();
+
+    for _ in 0..8_usize {
+        let h = horizontal.clone();
+        let own = own_node.clone();
+        set.spawn(async move {
+            for _ in 0..20_usize {
+                let mut collected: Vec<PresenceMemberInfo> = Vec::new();
+                {
+                    let registry = h.cluster_presence_registry.read().await;
+                    for (node_id, node_data) in registry.iter() {
+                        if node_id == &own {
+                            continue;
+                        }
+                        if let Some(channel_sockets) = node_data.get(channel) {
+                            for entry in channel_sockets.values() {
+                                if entry.app_id != app_id {
+                                    continue;
+                                }
+                                collected.push(PresenceMemberInfo {
+                                    user_id: entry.user_id.clone(),
+                                    user_info: entry.user_info.clone(),
+                                });
+                            }
+                        }
+                    }
+                }
+                let _ = collected;
+            }
+        });
+    }
+
+    {
+        let h = horizontal.clone();
+        set.spawn(async move {
+            for i in 0..20_usize {
+                h.add_presence_entry(
+                    "node-writer",
+                    channel,
+                    &format!("sock-writer-{i}"),
+                    &format!("user-writer-{i}"),
+                    app_id,
+                    Some(json!({"writer": i})),
+                )
+                .await;
+            }
+        });
+    }
+
+    while let Some(res) = set.join_next().await {
+        res.expect("task panicked during concurrent registry read/write");
+    }
+
+    let registry = horizontal.cluster_presence_registry.read().await;
+    let writer_count = registry
+        .get("node-writer")
+        .and_then(|nd| nd.get(channel))
+        .map(|c| c.len())
+        .unwrap_or(0);
+    assert_eq!(
+        writer_count, 20,
+        "all 20 writer entries must be present after concurrent writes; found {writer_count}"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/cluster_presence_registry_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/cluster_presence_registry_tests.rs
@@ -217,7 +217,10 @@ async fn test_concurrent_read_write_registry() {
                                 }
                                 collected.push(PresenceMemberInfo {
                                     user_id: entry.user_id.clone(),
-                                    user_info: entry.user_info.clone(),
+                                    user_info: entry
+                                        .user_info
+                                        .as_ref()
+                                        .map(|info| (**info).clone()),
                                 });
                             }
                         }

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -75,3 +75,6 @@ mod filter_index_disconnect_cleanup_tests;
 
 #[cfg(test)]
 mod replay_buffer_tests;
+
+#[cfg(test)]
+mod cluster_presence_registry_tests;

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -78,3 +78,6 @@ mod replay_buffer_tests;
 
 #[cfg(test)]
 mod cluster_presence_registry_tests;
+
+#[cfg(test)]
+mod presence_concurrency_tests;

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -72,3 +72,6 @@ mod clustered_active_channels_gauge_tests;
 
 #[cfg(test)]
 mod filter_index_disconnect_cleanup_tests;
+
+#[cfg(test)]
+mod replay_buffer_tests;

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -81,3 +81,6 @@ mod cluster_presence_registry_tests;
 
 #[cfg(test)]
 mod presence_concurrency_tests;
+
+#[cfg(test)]
+mod presence_lock_scope_tests;

--- a/crates/sockudo-adapter/tests/adapter/presence_concurrency_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_concurrency_tests.rs
@@ -1,0 +1,692 @@
+use ahash::AHashMap;
+use async_trait::async_trait;
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::connection_manager::{ChannelSocketCount, HorizontalAdapterInterface};
+use sockudo_adapter::presence::PresenceManager;
+use sockudo_core::app::{App, AppPolicy};
+use sockudo_core::channel::PresenceMemberInfo;
+use sockudo_core::error::Result;
+use sockudo_core::namespace::Namespace;
+use sockudo_core::presence_history::{
+    MemoryPresenceHistoryStore, PresenceHistoryDirection, PresenceHistoryEventCause,
+    PresenceHistoryEventKind, PresenceHistoryReadRequest, PresenceHistoryRetentionPolicy,
+    PresenceHistoryStore,
+};
+use sockudo_core::websocket::{SocketId, WebSocketBufferConfig, WebSocketRef};
+use sockudo_protocol::messages::PusherMessage;
+use sockudo_protocol::{ProtocolVersion, WireFormat};
+use sockudo_ws::axum_integration::WebSocketWriter;
+use std::any::Any;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex as StdMutex};
+use tokio::sync::Barrier;
+
+struct ScriptedCM {
+    counts: StdMutex<VecDeque<usize>>,
+}
+
+impl ScriptedCM {
+    fn new(counts: Vec<usize>) -> Self {
+        Self {
+            counts: StdMutex::new(counts.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl ConnectionManager for ScriptedCM {
+    async fn init(&self) {}
+
+    async fn get_namespace(&self, _app_id: &str) -> Option<Arc<Namespace>> {
+        None
+    }
+
+    async fn add_socket(
+        &self,
+        _socket_id: SocketId,
+        _socket: WebSocketWriter,
+        _app_id: &str,
+        _app_manager: Arc<dyn sockudo_core::app::AppManager + Send + Sync>,
+        _buffer_config: WebSocketBufferConfig,
+        _protocol_version: ProtocolVersion,
+        _wire_format: WireFormat,
+        _echo_messages: bool,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_connection(&self, _socket_id: &SocketId, _app_id: &str) -> Option<WebSocketRef> {
+        None
+    }
+
+    async fn remove_connection(&self, _socket_id: &SocketId, _app_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn send_message(
+        &self,
+        _app_id: &str,
+        _socket_id: &SocketId,
+        _message: PusherMessage,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn send(
+        &self,
+        _channel: &str,
+        _message: PusherMessage,
+        _except: Option<&SocketId>,
+        _app_id: &str,
+        _start_time_ms: Option<f64>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_channel_members(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+    ) -> Result<AHashMap<String, PresenceMemberInfo>> {
+        Ok(AHashMap::new())
+    }
+
+    async fn get_channel_sockets(&self, _app_id: &str, _channel: &str) -> Result<Vec<SocketId>> {
+        Ok(Vec::new())
+    }
+
+    async fn remove_channel(&self, _app_id: &str, _channel: &str) {}
+
+    async fn is_in_channel(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn get_user_sockets(&self, _user_id: &str, _app_id: &str) -> Result<Vec<WebSocketRef>> {
+        Ok(Vec::new())
+    }
+
+    async fn cleanup_connection(&self, _app_id: &str, _ws: WebSocketRef) {}
+
+    async fn terminate_connection(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn add_channel_to_sockets(&self, _app_id: &str, _channel: &str, _socket_id: &SocketId) {}
+
+    async fn get_channel_socket_count_info(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+    ) -> ChannelSocketCount {
+        ChannelSocketCount {
+            count: 0,
+            complete: true,
+        }
+    }
+
+    async fn get_channel_socket_count(&self, _app_id: &str, _channel: &str) -> usize {
+        0
+    }
+
+    async fn add_to_channel(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn remove_from_channel(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn get_presence_member(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Option<PresenceMemberInfo> {
+        None
+    }
+
+    async fn terminate_user_connections(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn add_user(&self, _ws: WebSocketRef) -> Result<()> {
+        Ok(())
+    }
+
+    async fn remove_user(&self, _ws: WebSocketRef) -> Result<()> {
+        Ok(())
+    }
+
+    async fn remove_user_socket(
+        &self,
+        _user_id: &str,
+        _socket_id: &SocketId,
+        _app_id: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn count_user_connections_in_channel(
+        &self,
+        _user_id: &str,
+        _app_id: &str,
+        _channel: &str,
+        _excluding_socket: Option<&SocketId>,
+    ) -> Result<usize> {
+        Ok(self.counts.lock().unwrap().pop_front().unwrap_or_default())
+    }
+
+    async fn get_channels_with_socket_count(
+        &self,
+        _app_id: &str,
+    ) -> Result<AHashMap<String, usize>> {
+        Ok(AHashMap::new())
+    }
+
+    async fn get_sockets_count(&self, _app_id: &str) -> Result<usize> {
+        Ok(0)
+    }
+
+    async fn get_namespaces(&self) -> Result<Vec<(String, Arc<Namespace>)>> {
+        Ok(Vec::new())
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    async fn check_health(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn get_node_id(&self) -> String {
+        "test-node".to_string()
+    }
+
+    fn as_horizontal_adapter(&self) -> Option<&dyn HorizontalAdapterInterface> {
+        None
+    }
+}
+
+fn test_app() -> App {
+    App::from_policy(
+        "app-1".to_string(),
+        "key".to_string(),
+        "secret".to_string(),
+        true,
+        AppPolicy::default(),
+    )
+}
+
+fn retention() -> PresenceHistoryRetentionPolicy {
+    PresenceHistoryRetentionPolicy {
+        retention_window_seconds: 3600,
+        max_events_per_channel: None,
+        max_bytes_per_channel: None,
+    }
+}
+
+fn read_request(app: &App, channel: &str) -> PresenceHistoryReadRequest {
+    PresenceHistoryReadRequest {
+        app_id: app.id.clone(),
+        channel: channel.to_string(),
+        direction: PresenceHistoryDirection::OldestFirst,
+        limit: 20,
+        cursor: None,
+        bounds: Default::default(),
+    }
+}
+
+#[tokio::test]
+async fn test_single_member_added_on_first_join() {
+    let manager = PresenceManager::new();
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket = SocketId::new();
+
+    manager
+        .handle_member_added(
+            Arc::clone(&cm),
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "presence-single-join",
+            "user-1",
+            None,
+            Some(&socket),
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    let page = store
+        .read_page(read_request(&app, "presence-single-join"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.items.len(),
+        1,
+        "first join must emit exactly one member_added"
+    );
+    assert_eq!(page.items[0].event, PresenceHistoryEventKind::MemberAdded);
+}
+
+/// A second connection from the same user must NOT emit a duplicate `member_added`.
+///
+/// The scripted counts simulate non-rewind path semantics:
+///   - socket_a joins: count=0 (no other connections) → emits member_added
+///   - socket_b joins: count=1 (socket_a already present) → suppressed
+#[tokio::test]
+async fn test_no_duplicate_member_added_on_second_join() {
+    let manager = PresenceManager::new();
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0, 1]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket_a = SocketId::new();
+    let socket_b = SocketId::new();
+
+    manager
+        .handle_member_added(
+            Arc::clone(&cm),
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "presence-dup-join",
+            "user-1",
+            None,
+            Some(&socket_a),
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    manager
+        .handle_member_added(
+            Arc::clone(&cm),
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "presence-dup-join",
+            "user-1",
+            None,
+            Some(&socket_b),
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    let page = store
+        .read_page(read_request(&app, "presence-dup-join"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.items.len(),
+        1,
+        "second connection from the same user must not emit a duplicate member_added"
+    );
+    assert_eq!(page.items[0].event, PresenceHistoryEventKind::MemberAdded);
+}
+
+#[tokio::test]
+async fn test_single_member_removed_on_last_leave() {
+    let manager = PresenceManager::new();
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0, 0]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket = SocketId::new();
+
+    manager
+        .handle_member_added(
+            Arc::clone(&cm),
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "presence-last-leave",
+            "user-1",
+            None,
+            Some(&socket),
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    manager
+        .handle_member_removed(
+            &cm,
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "presence-last-leave",
+            "user-1",
+            Some(&socket),
+            PresenceHistoryEventCause::Disconnect,
+            None,
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    let page = store
+        .read_page(read_request(&app, "presence-last-leave"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.items.len(),
+        2,
+        "expected exactly one member_added followed by one member_removed"
+    );
+    assert_eq!(page.items[0].event, PresenceHistoryEventKind::MemberAdded);
+    assert_eq!(page.items[1].event, PresenceHistoryEventKind::MemberRemoved);
+}
+
+/// `member_removed` must be suppressed while at least one other connection
+/// for the same user remains active.
+///
+///   - socket_a joins: count=0 → emits member_added
+///   - socket_b joins: count=1 (socket_a present) → suppressed
+///   - socket_a leaves: count=1 (socket_b still present) → member_removed suppressed
+#[tokio::test]
+async fn test_no_member_removed_while_other_connections_exist() {
+    let manager = PresenceManager::new();
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0, 1, 1]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket_a = SocketId::new();
+    let socket_b = SocketId::new();
+
+    manager
+        .handle_member_added(
+            Arc::clone(&cm),
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "presence-early-leave",
+            "user-1",
+            None,
+            Some(&socket_a),
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    manager
+        .handle_member_added(
+            Arc::clone(&cm),
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "presence-early-leave",
+            "user-1",
+            None,
+            Some(&socket_b),
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    manager
+        .handle_member_removed(
+            &cm,
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "presence-early-leave",
+            "user-1",
+            Some(&socket_a),
+            PresenceHistoryEventCause::Disconnect,
+            None,
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    let page = store
+        .read_page(read_request(&app, "presence-early-leave"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.items.len(),
+        1,
+        "member_removed must be suppressed while socket_b is still connected"
+    );
+    assert_eq!(page.items[0].event, PresenceHistoryEventKind::MemberAdded);
+}
+
+/// Two concurrent `handle_member_added` calls for the same user must emit
+/// exactly one `member_added` event.
+///
+/// The per-user `Mutex` inside `PresenceManager` serialises the two tasks,
+/// ensuring only the first caller (who sees count=0) emits the event.
+///
+/// This covers both subscription orderings:
+/// - non-rewind path: socket not yet subscribed when `handle_member_added` is
+///   called — the Mutex ensures the VecDeque is popped [0, 1].
+/// - rewind path: socket already subscribed before the call — same [0, 1]
+///   pop sequence applies because the Mutex still serialises access.
+#[tokio::test]
+async fn test_concurrent_joins_same_user() {
+    let manager = Arc::new(PresenceManager::new());
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0, 1]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket_a = SocketId::new();
+    let socket_b = SocketId::new();
+
+    let barrier = Arc::new(Barrier::new(2));
+
+    let (m_a, cm_a, s_a, app_a, bar_a) = (
+        Arc::clone(&manager),
+        Arc::clone(&cm),
+        Arc::clone(&store),
+        app.clone(),
+        Arc::clone(&barrier),
+    );
+    let task_a = tokio::spawn(async move {
+        bar_a.wait().await;
+        m_a.handle_member_added(
+            cm_a,
+            s_a,
+            true,
+            None,
+            None,
+            &app_a,
+            "presence-concurrent-joins",
+            "user-1",
+            None,
+            Some(&socket_a),
+            Some(retention()),
+        )
+        .await
+        .expect("task A: handle_member_added failed");
+    });
+
+    let (m_b, cm_b, s_b, app_b, bar_b) = (
+        Arc::clone(&manager),
+        Arc::clone(&cm),
+        Arc::clone(&store),
+        app.clone(),
+        Arc::clone(&barrier),
+    );
+    let task_b = tokio::spawn(async move {
+        bar_b.wait().await;
+        m_b.handle_member_added(
+            cm_b,
+            s_b,
+            true,
+            None,
+            None,
+            &app_b,
+            "presence-concurrent-joins",
+            "user-1",
+            None,
+            Some(&socket_b),
+            Some(retention()),
+        )
+        .await
+        .expect("task B: handle_member_added failed");
+    });
+
+    let (ra, rb) = tokio::join!(task_a, task_b);
+    ra.expect("task A panicked");
+    rb.expect("task B panicked");
+
+    let page = store
+        .read_page(read_request(&app, "presence-concurrent-joins"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.items.len(),
+        1,
+        "concurrent joins for the same user must emit exactly one member_added"
+    );
+    assert_eq!(page.items[0].event, PresenceHistoryEventKind::MemberAdded);
+}
+
+/// Concurrent `handle_member_removed` (socket_a disconnecting) and
+/// `handle_member_added` (socket_b reconnecting) for the same user must not
+/// produce phantom state.
+///
+/// With the per-user `Mutex`, the two operations are fully serialised.
+/// Both operations see count=0 in their scripted window, so:
+/// - If leave wins the lock first: last-leave → member_removed; then join: first-join → member_added
+/// - If join wins first:            first-join → member_added; then leave: last-leave → member_removed
+///
+/// Either ordering yields exactly 1 `member_added` + 1 `member_removed`.
+#[tokio::test]
+async fn test_concurrent_leave_join_race() {
+    let manager = Arc::new(PresenceManager::new());
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0, 0]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket_a = SocketId::new();
+    let socket_b = SocketId::new();
+
+    let barrier = Arc::new(Barrier::new(2));
+
+    let (m_leave, cm_leave, s_leave, app_leave, bar_leave) = (
+        Arc::clone(&manager),
+        Arc::clone(&cm),
+        Arc::clone(&store),
+        app.clone(),
+        Arc::clone(&barrier),
+    );
+    let task_leave = tokio::spawn(async move {
+        bar_leave.wait().await;
+        m_leave
+            .handle_member_removed(
+                &cm_leave,
+                s_leave,
+                true,
+                None,
+                None,
+                &app_leave,
+                "presence-race",
+                "user-1",
+                Some(&socket_a),
+                PresenceHistoryEventCause::Disconnect,
+                None,
+                Some(retention()),
+            )
+            .await
+            .expect("leave task: handle_member_removed failed");
+    });
+
+    let (m_join, cm_join, s_join, app_join, bar_join) = (
+        Arc::clone(&manager),
+        Arc::clone(&cm),
+        Arc::clone(&store),
+        app.clone(),
+        Arc::clone(&barrier),
+    );
+    let task_join = tokio::spawn(async move {
+        bar_join.wait().await;
+        m_join
+            .handle_member_added(
+                cm_join,
+                s_join,
+                true,
+                None,
+                None,
+                &app_join,
+                "presence-race",
+                "user-1",
+                None,
+                Some(&socket_b),
+                Some(retention()),
+            )
+            .await
+            .expect("join task: handle_member_added failed");
+    });
+
+    let (rl, rj) = tokio::join!(task_leave, task_join);
+    rl.expect("leave task panicked");
+    rj.expect("join task panicked");
+
+    let page = store
+        .read_page(read_request(&app, "presence-race"))
+        .await
+        .unwrap();
+
+    let added = page
+        .items
+        .iter()
+        .filter(|i| i.event == PresenceHistoryEventKind::MemberAdded)
+        .count();
+    let removed = page
+        .items
+        .iter()
+        .filter(|i| i.event == PresenceHistoryEventKind::MemberRemoved)
+        .count();
+
+    assert_eq!(
+        added, 1,
+        "member_added must fire exactly once in the concurrent leave/join race"
+    );
+    assert_eq!(
+        removed, 1,
+        "member_removed must fire exactly once in the concurrent leave/join race"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/presence_lock_scope_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_lock_scope_tests.rs
@@ -1,0 +1,602 @@
+//! Lock-scope behavioral regression tests for `PresenceManager`.
+//!
+//! These tests document the timing guarantees provided by the per-user
+//! `Mutex` inside `PresenceManager`:
+//!
+//! 1. Two concurrent first-joins for the same user emit exactly one
+//!    `member_added` event.
+//! 2. Two concurrent last-leaves for the same user emit exactly one
+//!    `member_removed` event.
+//! 3. The webhook (proxied by the `PresenceHistoryStore` write) fires as part
+//!    of the atomic check-and-act for the first join.
+//! 4. The broadcast (proxied by the `PresenceHistoryStore` write) fires as
+//!    part of the atomic check-and-act for the last leave.
+//!
+//! P2 (T10) will move webhook and broadcast I/O **outside** the per-user lock
+//! while keeping the TOCTOU decision inside.  These tests must continue to
+//! pass after that change because they assert *what* fires, not the relative
+//! ordering of I/O and lock release.
+
+use ahash::AHashMap;
+use async_trait::async_trait;
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::connection_manager::{ChannelSocketCount, HorizontalAdapterInterface};
+use sockudo_adapter::presence::PresenceManager;
+use sockudo_core::app::{App, AppPolicy};
+use sockudo_core::channel::PresenceMemberInfo;
+use sockudo_core::error::Result;
+use sockudo_core::namespace::Namespace;
+use sockudo_core::presence_history::{
+    MemoryPresenceHistoryStore, PresenceHistoryDirection, PresenceHistoryEventCause,
+    PresenceHistoryEventKind, PresenceHistoryReadRequest, PresenceHistoryRetentionPolicy,
+    PresenceHistoryStore,
+};
+use sockudo_core::websocket::{SocketId, WebSocketBufferConfig, WebSocketRef};
+use sockudo_protocol::messages::PusherMessage;
+use sockudo_protocol::{ProtocolVersion, WireFormat};
+use sockudo_ws::axum_integration::WebSocketWriter;
+use std::any::Any;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex as StdMutex};
+use tokio::sync::Barrier;
+
+/// Scripted connection manager whose `count_user_connections_in_channel`
+/// returns values from a pre-seeded `VecDeque`, popped in FIFO order.
+///
+/// The per-user `Mutex` inside `PresenceManager` serialises all callers,
+/// so the pop order is deterministic regardless of which tokio task reaches
+/// the call first.
+///
+/// `ScriptedCM` is private in `presence_concurrency_tests`, so it is
+/// redefined here rather than imported.
+struct ScriptedCM {
+    counts: StdMutex<VecDeque<usize>>,
+}
+
+impl ScriptedCM {
+    fn new(counts: Vec<usize>) -> Self {
+        Self {
+            counts: StdMutex::new(counts.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl ConnectionManager for ScriptedCM {
+    async fn init(&self) {}
+
+    async fn get_namespace(&self, _app_id: &str) -> Option<Arc<Namespace>> {
+        None
+    }
+
+    async fn add_socket(
+        &self,
+        _socket_id: SocketId,
+        _socket: WebSocketWriter,
+        _app_id: &str,
+        _app_manager: Arc<dyn sockudo_core::app::AppManager + Send + Sync>,
+        _buffer_config: WebSocketBufferConfig,
+        _protocol_version: ProtocolVersion,
+        _wire_format: WireFormat,
+        _echo_messages: bool,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_connection(&self, _socket_id: &SocketId, _app_id: &str) -> Option<WebSocketRef> {
+        None
+    }
+
+    async fn remove_connection(&self, _socket_id: &SocketId, _app_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn send_message(
+        &self,
+        _app_id: &str,
+        _socket_id: &SocketId,
+        _message: PusherMessage,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn send(
+        &self,
+        _channel: &str,
+        _message: PusherMessage,
+        _except: Option<&SocketId>,
+        _app_id: &str,
+        _start_time_ms: Option<f64>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_channel_members(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+    ) -> Result<AHashMap<String, PresenceMemberInfo>> {
+        Ok(AHashMap::new())
+    }
+
+    async fn get_channel_sockets(&self, _app_id: &str, _channel: &str) -> Result<Vec<SocketId>> {
+        Ok(Vec::new())
+    }
+
+    async fn remove_channel(&self, _app_id: &str, _channel: &str) {}
+
+    async fn is_in_channel(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn get_user_sockets(&self, _user_id: &str, _app_id: &str) -> Result<Vec<WebSocketRef>> {
+        Ok(Vec::new())
+    }
+
+    async fn cleanup_connection(&self, _app_id: &str, _ws: WebSocketRef) {}
+
+    async fn terminate_connection(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn add_channel_to_sockets(&self, _app_id: &str, _channel: &str, _socket_id: &SocketId) {}
+
+    async fn get_channel_socket_count_info(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+    ) -> ChannelSocketCount {
+        ChannelSocketCount {
+            count: 0,
+            complete: true,
+        }
+    }
+
+    async fn get_channel_socket_count(&self, _app_id: &str, _channel: &str) -> usize {
+        0
+    }
+
+    async fn add_to_channel(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn remove_from_channel(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn get_presence_member(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Option<PresenceMemberInfo> {
+        None
+    }
+
+    async fn terminate_user_connections(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn add_user(&self, _ws: WebSocketRef) -> Result<()> {
+        Ok(())
+    }
+
+    async fn remove_user(&self, _ws: WebSocketRef) -> Result<()> {
+        Ok(())
+    }
+
+    async fn remove_user_socket(
+        &self,
+        _user_id: &str,
+        _socket_id: &SocketId,
+        _app_id: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn count_user_connections_in_channel(
+        &self,
+        _user_id: &str,
+        _app_id: &str,
+        _channel: &str,
+        _excluding_socket: Option<&SocketId>,
+    ) -> Result<usize> {
+        Ok(self.counts.lock().unwrap().pop_front().unwrap_or_default())
+    }
+
+    async fn get_channels_with_socket_count(
+        &self,
+        _app_id: &str,
+    ) -> Result<AHashMap<String, usize>> {
+        Ok(AHashMap::new())
+    }
+
+    async fn get_sockets_count(&self, _app_id: &str) -> Result<usize> {
+        Ok(0)
+    }
+
+    async fn get_namespaces(&self) -> Result<Vec<(String, Arc<Namespace>)>> {
+        Ok(Vec::new())
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    async fn check_health(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn get_node_id(&self) -> String {
+        "test-node".to_string()
+    }
+
+    fn as_horizontal_adapter(&self) -> Option<&dyn HorizontalAdapterInterface> {
+        None
+    }
+}
+
+fn test_app() -> App {
+    App::from_policy(
+        "app-1".to_string(),
+        "key".to_string(),
+        "secret".to_string(),
+        true,
+        AppPolicy::default(),
+    )
+}
+
+fn retention() -> PresenceHistoryRetentionPolicy {
+    PresenceHistoryRetentionPolicy {
+        retention_window_seconds: 3600,
+        max_events_per_channel: None,
+        max_bytes_per_channel: None,
+    }
+}
+
+fn read_request(app: &App, channel: &str) -> PresenceHistoryReadRequest {
+    PresenceHistoryReadRequest {
+        app_id: app.id.clone(),
+        channel: channel.to_string(),
+        direction: PresenceHistoryDirection::OldestFirst,
+        limit: 20,
+        cursor: None,
+        bounds: Default::default(),
+    }
+}
+
+/// Two concurrent first-joins for the same user must emit exactly one
+/// `member_added` event.
+///
+/// The per-user `Mutex` inside `PresenceManager` serialises the two tasks.
+/// The scripted `VecDeque` pops in FIFO order: the first task to acquire the
+/// lock sees `count=0` (first join → emits), the second sees `count=1`
+/// (another connection already active → suppressed).
+#[tokio::test]
+async fn test_presence_lock_prevents_duplicate_member_added() {
+    let manager = Arc::new(PresenceManager::new());
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0, 1]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket_a = SocketId::new();
+    let socket_b = SocketId::new();
+
+    let barrier = Arc::new(Barrier::new(2));
+
+    let (m_a, cm_a, s_a, app_a, bar_a) = (
+        Arc::clone(&manager),
+        Arc::clone(&cm),
+        Arc::clone(&store),
+        app.clone(),
+        Arc::clone(&barrier),
+    );
+    let task_a = tokio::spawn(async move {
+        bar_a.wait().await;
+        m_a.handle_member_added(
+            cm_a,
+            s_a,
+            true,
+            None,
+            None,
+            &app_a,
+            "lock-scope-dup-added",
+            "user-1",
+            None,
+            Some(&socket_a),
+            Some(retention()),
+        )
+        .await
+        .expect("task A: handle_member_added failed");
+    });
+
+    let (m_b, cm_b, s_b, app_b, bar_b) = (
+        Arc::clone(&manager),
+        Arc::clone(&cm),
+        Arc::clone(&store),
+        app.clone(),
+        Arc::clone(&barrier),
+    );
+    let task_b = tokio::spawn(async move {
+        bar_b.wait().await;
+        m_b.handle_member_added(
+            cm_b,
+            s_b,
+            true,
+            None,
+            None,
+            &app_b,
+            "lock-scope-dup-added",
+            "user-1",
+            None,
+            Some(&socket_b),
+            Some(retention()),
+        )
+        .await
+        .expect("task B: handle_member_added failed");
+    });
+
+    let (ra, rb) = tokio::join!(task_a, task_b);
+    ra.expect("task A panicked");
+    rb.expect("task B panicked");
+
+    let page = store
+        .read_page(read_request(&app, "lock-scope-dup-added"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.items.len(),
+        1,
+        "per-user lock must prevent duplicate member_added: expected exactly 1 event, got {}",
+        page.items.len()
+    );
+    assert_eq!(page.items[0].event, PresenceHistoryEventKind::MemberAdded);
+}
+
+/// Two concurrent last-leaves for the same user must emit exactly one
+/// `member_removed` event.
+///
+/// The per-user `Mutex` serialises the two tasks.  The scripted `VecDeque`
+/// pops in FIFO order: the first task to acquire the lock sees `count=0`
+/// (last leave → emits), the second sees `count=1` (another connection
+/// detected → suppressed).
+///
+/// Scripting `[0, 1]` rather than `[0, 0]` is intentional: with `[0, 0]`
+/// both tasks would see `count=0` and both would emit, defeating the
+/// purpose.  The Mutex guarantees the VecDeque is popped in acquisition
+/// order, so `[0, 1]` correctly models "only the true last-leave emits".
+#[tokio::test]
+async fn test_presence_lock_prevents_duplicate_member_removed() {
+    let manager = Arc::new(PresenceManager::new());
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0, 1]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket_a = SocketId::new();
+    let socket_b = SocketId::new();
+
+    let barrier = Arc::new(Barrier::new(2));
+
+    let (m_a, cm_a, s_a, app_a, bar_a) = (
+        Arc::clone(&manager),
+        Arc::clone(&cm),
+        Arc::clone(&store),
+        app.clone(),
+        Arc::clone(&barrier),
+    );
+    let task_a = tokio::spawn(async move {
+        bar_a.wait().await;
+        m_a.handle_member_removed(
+            &cm_a,
+            s_a,
+            true,
+            None,
+            None,
+            &app_a,
+            "lock-scope-dup-removed",
+            "user-1",
+            Some(&socket_a),
+            PresenceHistoryEventCause::Disconnect,
+            None,
+            Some(retention()),
+        )
+        .await
+        .expect("task A: handle_member_removed failed");
+    });
+
+    let (m_b, cm_b, s_b, app_b, bar_b) = (
+        Arc::clone(&manager),
+        Arc::clone(&cm),
+        Arc::clone(&store),
+        app.clone(),
+        Arc::clone(&barrier),
+    );
+    let task_b = tokio::spawn(async move {
+        bar_b.wait().await;
+        m_b.handle_member_removed(
+            &cm_b,
+            s_b,
+            true,
+            None,
+            None,
+            &app_b,
+            "lock-scope-dup-removed",
+            "user-1",
+            Some(&socket_b),
+            PresenceHistoryEventCause::Disconnect,
+            None,
+            Some(retention()),
+        )
+        .await
+        .expect("task B: handle_member_removed failed");
+    });
+
+    let (ra, rb) = tokio::join!(task_a, task_b);
+    ra.expect("task A panicked");
+    rb.expect("task B panicked");
+
+    let page = store
+        .read_page(read_request(&app, "lock-scope-dup-removed"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.items.len(),
+        1,
+        "per-user lock must prevent duplicate member_removed: expected exactly 1 event, got {}",
+        page.items.len()
+    );
+    assert_eq!(page.items[0].event, PresenceHistoryEventKind::MemberRemoved);
+}
+
+/// The webhook fires as part of the atomic check-and-act for the first join.
+///
+/// `PresenceHistoryStore` is the observable proxy: the history write and the
+/// webhook call both happen inside the per-user `Mutex` scope in the current
+/// implementation.  After `handle_member_added` returns the record must exist,
+/// proving the webhook fired atomically with the connection-count check.
+///
+/// P2 (T10) will move the webhook call outside the lock but keep the TOCTOU
+/// decision inside.  This test must still pass after that change because it
+/// asserts *that* the event fires, not *when* relative to lock release.
+#[tokio::test]
+async fn test_presence_webhook_order_with_member_added() {
+    let manager = PresenceManager::new();
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket = SocketId::new();
+
+    manager
+        .handle_member_added(
+            Arc::clone(&cm),
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "lock-scope-webhook-added",
+            "user-1",
+            None,
+            Some(&socket),
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    let page = store
+        .read_page(read_request(&app, "lock-scope-webhook-added"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.items.len(),
+        1,
+        "member_added webhook must fire exactly once for a first join (count=0): got {} records",
+        page.items.len()
+    );
+    assert_eq!(
+        page.items[0].event,
+        PresenceHistoryEventKind::MemberAdded,
+        "first join must produce a MemberAdded record proving webhook fired inside the lock scope"
+    );
+}
+
+/// The broadcast fires as part of the atomic check-and-act for the last leave.
+///
+/// `PresenceHistoryStore` is the observable proxy: the history write and the
+/// broadcast call both happen inside the per-user `Mutex` scope in the current
+/// implementation.  After `handle_member_removed` returns the record must
+/// exist, proving the broadcast fired atomically with the connection-count
+/// check.
+///
+/// P2 (T10) will move the broadcast call outside the lock but keep the TOCTOU
+/// decision inside.  This test must still pass after that change because it
+/// asserts *that* the event fires, not *when* relative to lock release.
+#[tokio::test]
+async fn test_presence_broadcast_order_with_member_removed() {
+    let manager = PresenceManager::new();
+    // count=0 for the join (first and only connection), count=0 for the
+    // removal (leaving as the last connection).
+    let cm: Arc<dyn ConnectionManager + Send + Sync> = Arc::new(ScriptedCM::new(vec![0, 0]));
+    let store: Arc<dyn PresenceHistoryStore + Send + Sync> =
+        Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
+    let app = test_app();
+    let socket = SocketId::new();
+
+    // First join
+    manager
+        .handle_member_added(
+            Arc::clone(&cm),
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "lock-scope-broadcast-removed",
+            "user-1",
+            None,
+            Some(&socket),
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    // Last leave
+    manager
+        .handle_member_removed(
+            &cm,
+            Arc::clone(&store),
+            true,
+            None,
+            None,
+            &app,
+            "lock-scope-broadcast-removed",
+            "user-1",
+            Some(&socket),
+            PresenceHistoryEventCause::Disconnect,
+            None,
+            Some(retention()),
+        )
+        .await
+        .unwrap();
+
+    let page = store
+        .read_page(read_request(&app, "lock-scope-broadcast-removed"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.items.len(),
+        2,
+        "expected exactly one member_added + one member_removed (broadcast fired inside lock scope): got {} records",
+        page.items.len()
+    );
+    assert_eq!(
+        page.items[0].event,
+        PresenceHistoryEventKind::MemberAdded,
+        "first record must be MemberAdded"
+    );
+    assert_eq!(
+        page.items[1].event,
+        PresenceHistoryEventKind::MemberRemoved,
+        "member_removed broadcast must fire exactly once for a last leave (count=0)"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/presence_lock_scope_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_lock_scope_tests.rs
@@ -12,9 +12,9 @@
 //! 4. The broadcast (proxied by the `PresenceHistoryStore` write) fires as
 //!    part of the atomic check-and-act for the last leave.
 //!
-//! P2 (T10) will move webhook and broadcast I/O **outside** the per-user lock
-//! while keeping the TOCTOU decision inside.  These tests must continue to
-//! pass after that change because they assert *what* fires, not the relative
+//! The member broadcasts run inside the per-user lock (so wire order matches
+//! decision order) while the webhook enqueue and history recording happen
+//! after lock release.  These tests assert *what* fires, not the relative
 //! ordering of I/O and lock release.
 
 use ahash::AHashMap;
@@ -465,15 +465,12 @@ async fn test_presence_lock_prevents_duplicate_member_removed() {
     assert_eq!(page.items[0].event, PresenceHistoryEventKind::MemberRemoved);
 }
 
-/// The webhook fires as part of the atomic check-and-act for the first join.
+/// The webhook fires as part of the check-and-act for the first join.
 ///
-/// `PresenceHistoryStore` is the observable proxy: the history write and the
-/// webhook call both happen inside the per-user `Mutex` scope in the current
-/// implementation.  After `handle_member_added` returns the record must exist,
-/// proving the webhook fired atomically with the connection-count check.
-///
-/// P2 (T10) will move the webhook call outside the lock but keep the TOCTOU
-/// decision inside.  This test must still pass after that change because it
+/// `PresenceHistoryStore` is the observable proxy: after `handle_member_added`
+/// returns the record must exist, proving the webhook fired for the
+/// connection-count decision made under the per-user lock.  The webhook
+/// enqueue and history write themselves run after lock release — this test
 /// asserts *that* the event fires, not *when* relative to lock release.
 #[tokio::test]
 async fn test_presence_webhook_order_with_member_added() {
@@ -515,21 +512,17 @@ async fn test_presence_webhook_order_with_member_added() {
     assert_eq!(
         page.items[0].event,
         PresenceHistoryEventKind::MemberAdded,
-        "first join must produce a MemberAdded record proving webhook fired inside the lock scope"
+        "first join must produce a MemberAdded record proving the webhook fired for the locked decision"
     );
 }
 
-/// The broadcast fires as part of the atomic check-and-act for the last leave.
+/// The broadcast fires as part of the check-and-act for the last leave.
 ///
-/// `PresenceHistoryStore` is the observable proxy: the history write and the
-/// broadcast call both happen inside the per-user `Mutex` scope in the current
-/// implementation.  After `handle_member_removed` returns the record must
-/// exist, proving the broadcast fired atomically with the connection-count
-/// check.
-///
-/// P2 (T10) will move the broadcast call outside the lock but keep the TOCTOU
-/// decision inside.  This test must still pass after that change because it
-/// asserts *that* the event fires, not *when* relative to lock release.
+/// `PresenceHistoryStore` is the observable proxy: after `handle_member_removed`
+/// returns the record must exist, proving the broadcast fired for the
+/// connection-count decision made under the per-user lock.  The broadcast runs
+/// inside the lock; the history write runs after release — this test asserts
+/// *that* the event fires, not *when* relative to lock release.
 #[tokio::test]
 async fn test_presence_broadcast_order_with_member_removed() {
     let manager = PresenceManager::new();

--- a/crates/sockudo-adapter/tests/adapter/presence_state_consistency_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_state_consistency_tests.rs
@@ -32,7 +32,7 @@ async fn test_sequence_number_conflict_resolution() {
 
     // Create two presence entries with different sequence numbers
     let entry1 = sockudo_adapter::horizontal_adapter::PresenceEntry {
-        user_info: Some(json!({"version": 1})),
+        user_info: Some(std::sync::Arc::new(json!({"version": 1}))),
         node_id: "node-1".to_string(),
         app_id: app_id.to_string(),
         user_id: user_id.to_string(),
@@ -41,7 +41,7 @@ async fn test_sequence_number_conflict_resolution() {
     };
 
     let entry2 = sockudo_adapter::horizontal_adapter::PresenceEntry {
-        user_info: Some(json!({"version": 2})),
+        user_info: Some(std::sync::Arc::new(json!({"version": 2}))),
         node_id: "node-2".to_string(),
         app_id: app_id.to_string(),
         user_id: user_id.to_string(),
@@ -77,7 +77,10 @@ async fn test_sequence_number_conflict_resolution() {
 
     assert!(node2_entry.is_some());
     assert_eq!(node2_entry.unwrap().sequence_number, 200);
-    assert_eq!(node2_entry.unwrap().user_info, Some(json!({"version": 2})));
+    assert_eq!(
+        node2_entry.unwrap().user_info,
+        Some(std::sync::Arc::new(json!({"version": 2})))
+    );
 }
 
 /// Test handling of presence updates with clock skew
@@ -174,7 +177,7 @@ async fn test_bulk_presence_cleanup() {
                 let socket_id = format!("socket-{}-{}", c, u);
 
                 let entry = sockudo_adapter::horizontal_adapter::PresenceEntry {
-                    user_info: Some(json!({"bulk": true})),
+                    user_info: Some(std::sync::Arc::new(json!({"bulk": true}))),
                     node_id: "bulk-node".to_string(),
                     app_id: app_id.to_string(),
                     user_id,

--- a/crates/sockudo-adapter/tests/adapter/presence_synchronization_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_synchronization_tests.rs
@@ -231,7 +231,7 @@ async fn test_presence_local_registry_update_always_happens() {
         let socket_entry = &channel_data["socket-789"];
         assert_eq!(socket_entry.user_id, "user-456");
         assert_eq!(socket_entry.app_id, "test-app");
-        assert_eq!(socket_entry.user_info, Some(user_info));
+        assert_eq!(socket_entry.user_info, Some(std::sync::Arc::new(user_info)));
     }
 
     // Now test leave
@@ -342,7 +342,10 @@ async fn test_multiple_presence_members_same_channel() {
                 .get(*socket_id)
                 .unwrap_or_else(|| panic!("Socket {} should exist", socket_id));
             assert_eq!(entry.user_id, *user_id);
-            assert_eq!(entry.user_info, Some(user_info.clone()));
+            assert_eq!(
+                entry.user_info,
+                Some(std::sync::Arc::new(user_info.clone()))
+            );
         }
     }
 

--- a/crates/sockudo-adapter/tests/adapter/replay_buffer_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/replay_buffer_tests.rs
@@ -1,0 +1,175 @@
+#[cfg(feature = "recovery")]
+mod replay_buffer_regression {
+    use bytes::Bytes;
+    use sockudo_adapter::replay_buffer::{ReplayBuffer, ReplayLookup};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[test]
+    fn test_store_and_retrieve_messages() {
+        let buf = ReplayBuffer::new(100, Duration::from_secs(60));
+
+        buf.store("app1", "ch", None, 1, Bytes::from("msg1"));
+        buf.store("app1", "ch", None, 2, Bytes::from("msg2"));
+        buf.store("app1", "ch", None, 3, Bytes::from("msg3"));
+
+        let msgs = buf
+            .get_messages_after("app1", "ch", 0)
+            .expect("should recover from 0");
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0], Bytes::from("msg1"));
+        assert_eq!(msgs[1], Bytes::from("msg2"));
+        assert_eq!(msgs[2], Bytes::from("msg3"));
+
+        let msgs = buf
+            .get_messages_after("app1", "ch", 1)
+            .expect("should recover from 1");
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0], Bytes::from("msg2"));
+        assert_eq!(msgs[1], Bytes::from("msg3"));
+
+        let msgs = buf
+            .get_messages_after("app1", "ch", 3)
+            .expect("caught-up client should get Recovered(empty)");
+        assert!(msgs.is_empty());
+
+        assert!(buf.get_messages_after("app1", "unknown-ch", 0).is_none());
+    }
+
+    #[test]
+    fn test_store_updates_stream_id() {
+        let buf = ReplayBuffer::new(100, Duration::from_secs(60));
+
+        buf.store("app1", "ch", Some("stream-1"), 1, Bytes::from("msg1"));
+        buf.store("app1", "ch", Some("stream-2"), 2, Bytes::from("msg2"));
+
+        match buf.get_messages_after_position("app1", "ch", Some("stream-1"), 0) {
+            ReplayLookup::StreamReset { current_stream_id } => {
+                assert_eq!(current_stream_id.as_deref(), Some("stream-2"));
+            }
+            other => panic!("expected StreamReset, got {}", variant_name(&other)),
+        }
+
+        match buf.get_messages_after_position("app1", "ch", Some("stream-2"), 0) {
+            ReplayLookup::Recovered(msgs) => assert_eq!(msgs.len(), 2),
+            other => panic!("expected Recovered, got {}", variant_name(&other)),
+        }
+
+        buf.store("app1", "ch", None, 3, Bytes::from("msg3"));
+
+        match buf.get_messages_after_position("app1", "ch", Some("stream-2"), 0) {
+            ReplayLookup::StreamReset { current_stream_id } => {
+                assert!(current_stream_id.is_none());
+            }
+            other => panic!(
+                "expected StreamReset after clearing stream, got {}",
+                variant_name(&other)
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_store_and_read() {
+        let buf = Arc::new(ReplayBuffer::new(500, Duration::from_secs(60)));
+        let mut handles = Vec::new();
+
+        for task_idx in 0..10_u64 {
+            let buf = Arc::clone(&buf);
+            handles.push(tokio::spawn(async move {
+                for j in 0..100_u64 {
+                    let serial = task_idx * 100 + j + 1;
+                    buf.store(
+                        "app1",
+                        "concurrent-ch",
+                        Some("stream-1"),
+                        serial,
+                        Bytes::from(format!("msg-{}", serial)),
+                    );
+                }
+            }));
+        }
+
+        for _ in 0..5 {
+            let buf = Arc::clone(&buf);
+            handles.push(tokio::spawn(async move {
+                let _ = buf.get_messages_after("app1", "concurrent-ch", 0);
+                let _ =
+                    buf.get_messages_after_position("app1", "concurrent-ch", Some("stream-1"), 0);
+            }));
+        }
+
+        for handle in handles {
+            handle.await.expect("task panicked under concurrent access");
+        }
+
+        let _ = buf.get_messages_after("app1", "concurrent-ch", 0);
+    }
+
+    #[test]
+    fn test_eviction_under_capacity() {
+        let buf = ReplayBuffer::new(5, Duration::from_secs(60));
+
+        for i in 1..=7_u64 {
+            buf.store("app1", "ch", None, i, Bytes::from(format!("msg-{}", i)));
+        }
+
+        let msgs = buf
+            .get_messages_after("app1", "ch", 0)
+            .expect("buffer should retain 5 messages");
+        assert_eq!(msgs.len(), 5);
+
+        assert!(
+            buf.get_messages_after("app1", "ch", 1).is_none(),
+            "client that missed evicted messages must get None"
+        );
+
+        let msgs = buf
+            .get_messages_after("app1", "ch", 2)
+            .expect("boundary client should recover");
+        assert_eq!(msgs.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_ttl_expiry() {
+        let buf = ReplayBuffer::new(100, Duration::from_millis(50));
+        buf.store("app1", "ttl-ch", None, 1, Bytes::from("fresh"));
+
+        assert_eq!(
+            buf.get_messages_after("app1", "ttl-ch", 0)
+                .expect("readable before TTL")
+                .len(),
+            1
+        );
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+
+        assert!(buf.get_messages_after("app1", "ttl-ch", 0).is_none());
+
+        let buf2 = ReplayBuffer::new(100, Duration::from_millis(50));
+        buf2.store("app2", "ttl-ch", None, 1, Bytes::from("will-expire"));
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        buf2.evict_expired();
+
+        assert!(buf2.get_messages_after("app2", "ttl-ch", 0).is_none());
+    }
+
+    #[test]
+    fn test_next_serial_monotonic() {
+        let buf = ReplayBuffer::new(100, Duration::from_secs(60));
+
+        assert_eq!(buf.next_serial("app1", "ch"), 1);
+        assert_eq!(buf.next_serial("app1", "ch"), 2);
+        assert_eq!(buf.next_serial("app1", "ch"), 3);
+
+        assert_eq!(buf.next_serial("app1", "other-ch"), 1);
+        assert_eq!(buf.next_serial("app2", "ch"), 1);
+    }
+
+    fn variant_name(lookup: &ReplayLookup) -> &'static str {
+        match lookup {
+            ReplayLookup::Recovered(_) => "Recovered",
+            ReplayLookup::Expired => "Expired",
+            ReplayLookup::StreamReset { .. } => "StreamReset",
+        }
+    }
+}

--- a/crates/sockudo-adapter/tests/adapter/transports/nats_transport_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/nats_transport_test.rs
@@ -736,11 +736,11 @@ mod chunk_builder_tests {
         let mut reg = build_registry(100, 5);
         for sockets in reg.values_mut() {
             for entry in sockets.values_mut() {
-                entry.user_info = Some(sonic_rs::json!({
+                entry.user_info = Some(std::sync::Arc::new(sonic_rs::json!({
                     "name": "Test User Realistic",
                     "email": "user@example.com",
                     "tier": "premium",
-                }));
+                })));
             }
         }
         let chunks = build_presence_state_chunks(&reg, 100).unwrap();

--- a/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
@@ -1,6 +1,7 @@
 use crate::adapter::horizontal_adapter_helpers::MockConfig;
 use sockudo_adapter::ConnectionManager;
 use sockudo_adapter::horizontal_adapter::RequestType;
+use sockudo_core::channel::PresenceMemberInfo;
 use sockudo_core::error::Result;
 use sockudo_core::namespace::Namespace;
 use sockudo_core::websocket::{SocketId, WebSocket, WebSocketRef};
@@ -61,7 +62,19 @@ async fn seed_local_user_connection(
         .users
         .entry(user_id.to_string())
         .or_default()
-        .insert(ws_ref);
+        .insert(ws_ref.clone());
+
+    namespace
+        .presence_data
+        .entry(socket_id)
+        .or_default()
+        .insert(
+            channel.to_string(),
+            PresenceMemberInfo {
+                user_id: user_id.to_string(),
+                user_info: None,
+            },
+        );
 }
 
 /// Test that local connections short-circuit without a cross-cluster request

--- a/crates/sockudo-core/src/namespace.rs
+++ b/crates/sockudo-core/src/namespace.rs
@@ -18,6 +18,7 @@ pub struct Namespace {
     pub channels: DashMap<String, DashSet<SocketId>>,
     wildcard_channels: DashSet<String>,
     pub users: DashMap<String, DashSet<WebSocketRef>>,
+    pub presence_data: DashMap<SocketId, HashMap<String, PresenceMemberInfo>>,
 }
 
 pub struct SocketInitOptions {
@@ -35,6 +36,7 @@ impl Namespace {
             channels: DashMap::new(),
             wildcard_channels: DashSet::new(),
             users: DashMap::new(),
+            presence_data: DashMap::new(),
         }
     }
 
@@ -86,30 +88,21 @@ impl Namespace {
             .map(|conn_ref| conn_ref.value().clone())
     }
 
-    pub async fn get_channel_members(
+    pub fn get_channel_members(
         &self,
         channel: &str,
     ) -> Result<HashMap<String, PresenceMemberInfo>> {
         let mut presence_members = HashMap::new();
 
         if let Some(socket_ids_ref) = self.channels.get(channel) {
-            let socket_ids_snapshot = socket_ids_ref.clone();
-            drop(socket_ids_ref);
-
-            for socket_id_entry in socket_ids_snapshot.iter() {
+            for socket_id_entry in socket_ids_ref.iter() {
                 let socket_id = socket_id_entry.key();
-                if let Some(connection) = self.get_connection(socket_id) {
-                    let presence_data = {
-                        let conn_guard = connection.inner.lock().await;
-                        conn_guard
-                            .state
-                            .presence
-                            .as_ref()
-                            .and_then(|p_map| p_map.get(channel).cloned())
-                    };
-                    if let Some(presence_info) = presence_data {
-                        presence_members.insert(presence_info.user_id.clone(), presence_info);
-                    }
+                if let Some(per_socket) = self.presence_data.get(socket_id)
+                    && let Some(info) = per_socket.get(channel)
+                {
+                    presence_members
+                        .entry(info.user_id.clone())
+                        .or_insert_with(|| info.clone());
                 }
             }
         } else {
@@ -438,6 +431,8 @@ impl Namespace {
             }
         }
 
+        self.presence_data.remove(&socket_id);
+
         if self.sockets.remove(&socket_id).is_some() {
             debug!("Removed socket {} from main map.", socket_id);
         } else {
@@ -544,22 +539,14 @@ impl Namespace {
             .is_some_and(|channel_sockets| channel_sockets.contains(socket_id))
     }
 
-    pub async fn get_presence_member(
+    pub fn get_presence_member(
         &self,
         channel: &str,
         socket_id: &SocketId,
     ) -> Option<PresenceMemberInfo> {
-        if let Some(connection) = self.get_connection(socket_id) {
-            let conn_guard = connection.inner.lock().await;
-            conn_guard
-                .state
-                .presence
-                .as_ref()
-                .and_then(|presence_map| presence_map.get(channel))
-                .cloned()
-        } else {
-            None
-        }
+        self.presence_data
+            .get(socket_id)
+            .and_then(|per_socket| per_socket.get(channel).cloned())
     }
 
     pub async fn add_user(&self, ws_ref: WebSocketRef) -> Result<()> {
@@ -640,7 +627,7 @@ impl Namespace {
         Ok(())
     }
 
-    pub async fn count_user_connections_in_channel(
+    pub fn count_user_connections_in_channel(
         &self,
         user_id: &str,
         channel: &str,
@@ -650,13 +637,16 @@ impl Namespace {
 
         if let Some(user_sockets_ref) = self.users.get(user_id) {
             for ws_ref in user_sockets_ref.iter() {
-                let socket_state_guard = ws_ref.inner.lock().await;
-                let socket_id = &socket_state_guard.state.socket_id;
-                let is_subscribed = socket_state_guard.state.is_subscribed(channel);
-
-                let should_exclude = excluding_socket == Some(socket_id);
-
-                if is_subscribed && !should_exclude {
+                let socket_id = ws_ref.get_socket_id_sync();
+                if excluding_socket == Some(socket_id) {
+                    continue;
+                }
+                if self
+                    .presence_data
+                    .get(socket_id)
+                    .map(|m| m.contains_key(channel))
+                    .unwrap_or(false)
+                {
                     count += 1;
                 }
             }

--- a/crates/sockudo-core/src/websocket.rs
+++ b/crates/sockudo-core/src/websocket.rs
@@ -849,6 +849,10 @@ impl MessageSender {
             code, reason,
         ))))
     }
+
+    pub(crate) fn sender_handle(&self) -> MessageSenderHandle {
+        self.sender.clone()
+    }
 }
 
 pub struct WebSocket {
@@ -1041,6 +1045,7 @@ impl Hash for WebSocket {
 #[derive(Clone)]
 pub struct WebSocketRef {
     pub broadcast_tx: SizedMessageSenderHandle,
+    pub message_sender: MessageSenderHandle,
     pub channel_filters: Arc<DashMap<String, Option<Arc<FilterNode>>>>,
     /// V2 event name filters per channel. None = receive all events.
     pub event_name_filters: Arc<DashMap<String, Option<Vec<String>>>>,
@@ -1061,6 +1066,7 @@ pub struct WebSocketRef {
 impl WebSocketRef {
     pub fn new(websocket: WebSocket) -> Self {
         let broadcast_tx = websocket.broadcast_tx.clone();
+        let message_sender = websocket.message_sender.sender_handle();
         let socket_id = *websocket.get_socket_id();
         let buffer_config = websocket.buffer_config;
         let byte_counter = websocket.byte_counter.clone();
@@ -1080,6 +1086,7 @@ impl WebSocketRef {
 
         Self {
             broadcast_tx,
+            message_sender,
             channel_filters,
             event_name_filters,
             annotation_subscriptions,
@@ -1159,14 +1166,43 @@ impl WebSocketRef {
         }
     }
 
-    pub async fn send_message(&self, message: &PusherMessage) -> Result<()> {
-        let ws = self.inner.lock().await;
-        ws.send_message(message)
+    pub fn send_message(&self, message: &PusherMessage) -> Result<()> {
+        if self.shutdown_token.is_cancelled() {
+            return Err(Error::ConnectionClosed("Connection shutting down".into()));
+        }
+        let payload = sockudo_protocol::wire::serialize_message(message, self.wire_format)
+            .map_err(|e| Error::InvalidMessageFormat(format!("Serialization failed: {e}")))?;
+        if self.wire_format.is_binary() {
+            self.message_sender
+                .try_send(Message::Binary(Bytes::from(payload)))
+                .map_err(|e| match e {
+                    TrySendError::Full(_) => Error::BufferFull("Message buffer full".into()),
+                    TrySendError::Disconnected(_) => {
+                        Error::ConnectionClosed("Channel closed".into())
+                    }
+                })
+        } else {
+            let text = String::from_utf8(payload).map_err(|e| {
+                Error::InvalidMessageFormat(format!("JSON payload is not UTF-8: {e}"))
+            })?;
+            self.message_sender
+                .try_send(Message::text(text))
+                .map_err(|e| match e {
+                    TrySendError::Full(_) => Error::BufferFull("Message buffer full".into()),
+                    TrySendError::Disconnected(_) => {
+                        Error::ConnectionClosed("Channel closed".into())
+                    }
+                })
+        }
     }
 
     pub async fn close(&self, code: u16, reason: String) -> Result<()> {
-        let mut ws = self.inner.lock().await;
-        ws.close(code, reason).await
+        let result = {
+            let mut ws = self.inner.lock().await;
+            ws.close(code, reason).await
+        };
+        self.shutdown_token.cancel();
+        result
     }
 
     /// Signal both reader and writer tasks to shut down.
@@ -1356,17 +1392,17 @@ pub trait WebSocketExt {
 
 impl WebSocketExt for WebSocketRef {
     async fn send_pusher_message(&self, message: PusherMessage) -> Result<()> {
-        self.send_message(&message).await
+        self.send_message(&message)
     }
 
     async fn send_error(&self, code: u16, message: String, channel: Option<String>) -> Result<()> {
         let error_msg = PusherMessage::error(code, message, channel);
-        self.send_message(&error_msg).await
+        self.send_message(&error_msg)
     }
 
     async fn send_pong(&self) -> Result<()> {
         let pong_msg = PusherMessage::pong();
-        self.send_message(&pong_msg).await
+        self.send_message(&pong_msg)
     }
 }
 
@@ -1713,6 +1749,212 @@ mod tests {
         assert!(
             matches!(second, Message::Close(_)),
             "expected close frame second, got: {second:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_message_serializes_and_delivers() {
+        use sockudo_ws::Message;
+
+        let socket_id = SocketId::new();
+        let (writer, mut client) = create_server_writer_with_client().await;
+        let ws = WebSocket::new(socket_id, writer);
+        let ws_ref = WebSocketRef::new(ws);
+
+        let msg = PusherMessage::pong();
+        let result = ws_ref.send_message(&msg);
+        assert!(
+            result.is_ok(),
+            "send_message should succeed on active connection: {result:?}"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(1), client.next())
+            .await
+            .expect("timed out waiting for frame")
+            .expect("client stream ended unexpectedly")
+            .expect("frame read error");
+
+        assert!(
+            matches!(frame, Message::Text(_)),
+            "Json wire format must deliver as Text frame, got: {frame:?}"
+        );
+        if let Message::Text(payload) = &frame {
+            let text = std::str::from_utf8(payload).expect("payload is not UTF-8");
+            assert!(
+                text.contains("pong"),
+                "serialized payload should contain 'pong', got: {text}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_broadcast_delivers_without_lock() {
+        use sockudo_ws::Message;
+
+        let socket_id = SocketId::new();
+        let (writer, mut client) = create_server_writer_with_client().await;
+        let ws = WebSocket::new(socket_id, writer);
+        let ws_ref = WebSocketRef::new(ws);
+
+        let payload = Bytes::from_static(b"{\"event\":\"broadcast-test\"}");
+        let result = ws_ref.send_broadcast(payload);
+        assert!(
+            result.is_ok(),
+            "send_broadcast should succeed without acquiring the inner lock: {result:?}"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(1), client.next())
+            .await
+            .expect("timed out waiting for broadcast frame")
+            .expect("client stream ended unexpectedly")
+            .expect("frame read error");
+
+        assert!(
+            matches!(frame, Message::Text(_)),
+            "broadcast must arrive at client as a Text frame, got: {frame:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_after_close_returns_error() {
+        use crate::error::Error;
+
+        let socket_id = SocketId::new();
+        let (writer, _client) = create_server_writer_with_client().await;
+        let ws = WebSocket::new(socket_id, writer);
+        let ws_ref = WebSocketRef::new(ws);
+
+        let close_result = ws_ref.close(1000, "normal closure".to_string()).await;
+        assert!(
+            close_result.is_ok(),
+            "close() should succeed: {close_result:?}"
+        );
+
+        let msg = PusherMessage::pong();
+        let send_result = ws_ref.send_message(&msg);
+
+        assert!(
+            send_result.is_err(),
+            "send_message after close must return an error, not succeed"
+        );
+        assert!(
+            matches!(send_result.unwrap_err(), Error::ConnectionClosed(_)),
+            "error variant must be Error::ConnectionClosed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_message_respects_wire_format() {
+        use sockudo_protocol::WireFormat;
+        use sockudo_ws::Message;
+
+        {
+            let socket_id = SocketId::new();
+            let (writer, mut client) = create_server_writer_with_client().await;
+            let ws = WebSocket::new(socket_id, writer);
+            let ws_ref = WebSocketRef::new(ws);
+
+            ws_ref.send_message(&PusherMessage::pong()).unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(1), client.next())
+                .await
+                .expect("timed out (json)")
+                .expect("stream ended (json)")
+                .expect("read error (json)");
+            assert!(
+                matches!(frame, Message::Text(_)),
+                "WireFormat::Json must produce a Text frame, got: {frame:?}"
+            );
+        }
+
+        {
+            let socket_id = SocketId::new();
+            let (writer, mut client) = create_server_writer_with_client().await;
+            let mut ws = WebSocket::new(socket_id, writer);
+            ws.state.wire_format = WireFormat::MessagePack;
+            let ws_ref = WebSocketRef::new(ws);
+
+            ws_ref.send_message(&PusherMessage::pong()).unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(1), client.next())
+                .await
+                .expect("timed out (msgpack)")
+                .expect("stream ended (msgpack)")
+                .expect("read error (msgpack)");
+            assert!(
+                matches!(frame, Message::Binary(_)),
+                "WireFormat::MessagePack must produce a Binary frame, got: {frame:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_sends_preserve_ordering() {
+        let socket_id = SocketId::new();
+        let (writer, mut client) = create_server_writer_with_client().await;
+        let buffer_config = WebSocketBufferConfig::new(2000, true);
+        let ws = WebSocket::with_buffer_config(socket_id, writer, buffer_config);
+        let ws_ref = WebSocketRef::new(ws);
+
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let clone = ws_ref.clone();
+            handles.push(tokio::spawn(async move {
+                let mut ok_count = 0usize;
+                for _ in 0..100 {
+                    if clone.send_message(&PusherMessage::pong()).is_ok() {
+                        ok_count += 1;
+                    }
+                }
+                ok_count
+            }));
+        }
+
+        let mut total_sent = 0usize;
+        for h in handles {
+            total_sent += h.await.expect("sender task panicked");
+        }
+        assert_eq!(total_sent, 1000, "all 1000 sends must succeed (no drops)");
+
+        let mut received = 0usize;
+        while received < total_sent {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), client.next()).await {
+                Ok(Some(Ok(_))) => received += 1,
+                Ok(Some(Err(e))) => panic!("client read error after {received} messages: {e}"),
+                Ok(None) => break,
+                Err(_) => panic!("timed out after {received}/{total_sent} messages"),
+            }
+        }
+        assert_eq!(
+            received, total_sent,
+            "every sent message must arrive at client (no drops)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_token_cancels_receiver() {
+        let socket_id = SocketId::new();
+        let (writer, _client) = create_server_writer_with_client().await;
+        let ws = WebSocket::new(socket_id, writer);
+        let ws_ref = WebSocketRef::new(ws);
+
+        let token = ws_ref.cancellation_token();
+        assert!(
+            !token.is_cancelled(),
+            "token must not be cancelled before shutdown()"
+        );
+
+        ws_ref.shutdown();
+
+        assert!(
+            token.is_cancelled(),
+            "shutdown() must cancel the CancellationToken so the receiver task exits"
         );
     }
 }

--- a/crates/sockudo-core/src/websocket.rs
+++ b/crates/sockudo-core/src/websocket.rs
@@ -1056,6 +1056,10 @@ pub struct WebSocketRef {
     pub buffer_config: WebSocketBufferConfig,
     pub byte_counter: Option<Arc<ByteCounter>>,
     pub shutdown_token: CancellationToken,
+    // Set at the start of close(), before the close frame is queued, so no data
+    // frame can slip in behind it. The shutdown_token is only cancelled after the
+    // close frame is queued (cancelling earlier would make the writer task drop it)
+    closing: Arc<std::sync::atomic::AtomicBool>,
     pub inner: Arc<Mutex<WebSocket>>,
     pub protocol_version: ProtocolVersion,
     pub wire_format: WireFormat,
@@ -1095,6 +1099,7 @@ impl WebSocketRef {
             buffer_config,
             byte_counter,
             shutdown_token,
+            closing: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             protocol_version,
             wire_format,
             echo_messages,
@@ -1167,7 +1172,7 @@ impl WebSocketRef {
     }
 
     pub fn send_message(&self, message: &PusherMessage) -> Result<()> {
-        if self.shutdown_token.is_cancelled() {
+        if self.closing.load(Ordering::Acquire) || self.shutdown_token.is_cancelled() {
             return Err(Error::ConnectionClosed("Connection shutting down".into()));
         }
         let payload = sockudo_protocol::wire::serialize_message(message, self.wire_format)
@@ -1197,6 +1202,10 @@ impl WebSocketRef {
     }
 
     pub async fn close(&self, code: u16, reason: String) -> Result<()> {
+        // Reject new sends before queueing the close frame so no data frame can be
+        // enqueued behind it. Token cancellation must stay AFTER ws.close(): the
+        // writer task breaks on cancellation and would drop the queued close frame
+        self.closing.store(true, Ordering::Release);
         let result = {
             let mut ws = self.inner.lock().await;
             ws.close(code, reason).await

--- a/crates/sockudo-server/src/http_handler.rs
+++ b/crates/sockudo-server/src/http_handler.rs
@@ -1173,7 +1173,7 @@ pub async fn stats(
                 app_stat.occupancy.presence_subscriptions +=
                     namespace.get_channel_socket_count(&channel_name);
                 app_stat.occupancy.presence_members +=
-                    namespace.get_channel_members(&channel_name).await?.len();
+                    namespace.get_channel_members(&channel_name)?.len();
             }
         }
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Removes the async-Mutex convoys identified on the horizontal adapter hot path: under load, every broadcast send, presence read, and recovery store was serializing on per-connection or shared locks while CPU sat
  idle. Five targeted fixes, each preceded by behavioral regression tests proving the invariants they must preserve. No wire-visible changes: event names, payloads, and serialization formats are untouched, and V1/V2
  protocol behavior is identical.

  **Lock fixes**
  - **Outbound `send_message` is lock-free** — the message sender handle is extracted from the per-connection `Mutex<WebSocket>` onto `WebSocketRef`; sends are now a sync `try_send` guarded by an atomic closing flag
  + shutdown token instead of a lock acquisition per recipient. A dedicated `closing` flag (set before the close frame is queued) prevents a send racing `close()` from enqueueing a data frame behind the close
  frame.
  - **Presence reads are lock-free** — presence membership is mirrored into a per-namespace `DashMap`, so `get_channel_members` no longer takes N sequential connection locks per call. Mirror writes are encapsulated
  in two `ConnectionHandler` helpers that warn if the mirror is unavailable and drop empty per-socket entries.
  - **Presence manager lock scope shrunk without losing ordering** — the per-(app, channel, user) lock covers the first-join/last-leave decision *and* the member broadcasts (so `member_added`/`member_removed` wire
  order always matches decision order, even in a same-user leave/rejoin race), while webhook enqueue and history recording run after lock release.
  - **Cluster presence registry hold times reduced** — `PresenceEntry.user_info` is `Arc`-wrapped, so readers clone pointers under the registry `RwLock` and deep-clone the `sonic_rs::Value` after release. Dead-node
  cleanup drops the write lock immediately after removing the node's data.
  - **Replay buffer TOCTOU fixed** — the nested `stream_id`/`messages` Mutexes are flattened into one lock, eliminating the window where a reader could pair a new stream_id with stale messages.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->