### PR TITLE
feat: Add dashboard Helm chart support

### DIFF
--- a/charts/sockudo/README.md
+++ b/charts/sockudo/README.md
@@ -1,0 +1,89 @@
+# Sockudo Helm Chart
+
+This chart deploys the Sockudo server and can optionally deploy the Sockudo
+operator dashboard.
+
+## Dashboard
+
+The dashboard is disabled by default:
+
+```yaml
+dashboard:
+  enabled: false
+```
+
+To enable it in production:
+
+- use a durable app manager: `mysql`, `pgsql`/`postgres`, or `dynamodb`
+- keep `HTTP_API_USAGE_ENABLED` and Prometheus metrics enabled
+- provide a strong `DASHBOARD_SESSION_SECRET` through an existing Kubernetes Secret
+- seed the first admin through an existing Secret or create users after install
+- expose the dashboard through TLS and restrict network access
+
+Example:
+
+```yaml
+config:
+  appManagerDriver: pgsql
+  httpApi:
+    usageEnabled: true
+  metrics:
+    enabled: true
+
+database:
+  postgres:
+    host: postgres.default.svc
+    port: 5432
+    username: sockudo
+    database: sockudo
+    tableName: applications
+  existingSecret: sockudo-postgres
+
+dashboard:
+  enabled: true
+  sessionSecret:
+    existingSecret: sockudo-dashboard-session
+  seedAdmin:
+    enabled: true
+    existingSecret: sockudo-dashboard-seed
+  ingress:
+    enabled: true
+    hosts:
+      - host: sockudo-admin.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: sockudo-admin-tls
+        hosts:
+          - sockudo-admin.example.com
+```
+
+Expected secret keys:
+
+```bash
+kubectl create secret generic sockudo-dashboard-session \
+  --from-literal=dashboard-session-secret="$(openssl rand -base64 32)"
+
+kubectl create secret generic sockudo-dashboard-seed \
+  --from-literal=dashboard-seed-email="admin@example.com" \
+  --from-literal=dashboard-seed-password="change-me-with-a-long-random-password" \
+  --from-literal=dashboard-seed-name="Administrator"
+```
+
+`dashboard.seedAdmin` is only used when the dashboard user table is empty. After
+bootstrap, manage operators from the Users page.
+
+The chart creates:
+
+- `Deployment` and `Service` for `dashboard-api`
+- `Deployment` and `Service` for `dashboard-web`
+- optional dashboard `Ingress`
+- optional dashboard `HorizontalPodAutoscaler`, `PodDisruptionBudget`, and `NetworkPolicy`
+- optional PVC for `/app/data`; required when `dashboard.databaseDriver=sqlite`
+- Helm test hook that checks the dashboard API `/health` and web root
+
+Dashboard images default to `sockudo/dashboard-api:<chart appVersion>` and
+`sockudo/dashboard-web:<chart appVersion>`. Override
+`dashboard.api.image.*` and `dashboard.web.image.*` if your registry publishes
+different image names or tags.

--- a/charts/sockudo/templates/NOTES.txt
+++ b/charts/sockudo/templates/NOTES.txt
@@ -37,3 +37,20 @@ Sockudo has been deployed successfully!
   Note: `defaultApp` is an env-bootstrap subset only. For full per-app policy,
   provide `configJson` or use an external app manager backend.
 {{- end }}
+
+{{- if .Values.dashboard.enabled }}
+
+{{- if .Values.defaultApp.enabled }}5{{ else }}4{{ end }}. Dashboard admin:
+{{- if .Values.dashboard.ingress.enabled }}
+{{- range $host := .Values.dashboard.ingress.hosts }}
+  http{{ if $.Values.dashboard.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "sockudo.dashboardWebName" . }} {{ .Values.dashboard.web.service.port }}:{{ .Values.dashboard.web.service.port }}
+  echo "Visit http://127.0.0.1:{{ .Values.dashboard.web.service.port }}"
+{{- end }}
+
+  API health:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "sockudo.dashboardApiName" . }} {{ .Values.dashboard.api.service.port }}:{{ .Values.dashboard.api.service.port }}
+  curl http://127.0.0.1:{{ .Values.dashboard.api.service.port }}/health
+{{- end }}

--- a/charts/sockudo/templates/_helpers.tpl
+++ b/charts/sockudo/templates/_helpers.tpl
@@ -72,3 +72,45 @@ Secret name
 {{- define "sockudo.secretName" -}}
 {{- printf "%s-secret" (include "sockudo.fullname" .) }}
 {{- end }}
+
+{{/*
+Dashboard API deployment/service name
+*/}}
+{{- define "sockudo.dashboardApiName" -}}
+{{- printf "%s-dashboard-api" (include "sockudo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Dashboard web deployment/service name
+*/}}
+{{- define "sockudo.dashboardWebName" -}}
+{{- printf "%s-dashboard-web" (include "sockudo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Dashboard secret name
+*/}}
+{{- define "sockudo.dashboardSecretName" -}}
+{{- printf "%s-dashboard-secret" (include "sockudo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Dashboard component selector labels
+*/}}
+{{- define "sockudo.dashboardSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "sockudo.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/*
+Dashboard component labels
+*/}}
+{{- define "sockudo.dashboardLabels" -}}
+helm.sh/chart: {{ include "sockudo.chart" .root }}
+{{ include "sockudo.dashboardSelectorLabels" . }}
+{{- if .root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-api-deployment.yaml
+++ b/charts/sockudo/templates/dashboard-api-deployment.yaml
@@ -1,0 +1,203 @@
+{{- if .Values.dashboard.enabled -}}
+{{- $apiName := include "sockudo.dashboardApiName" . -}}
+{{- $appManagerDriver := default .Values.config.appManagerDriver .Values.dashboard.appManagerDriver -}}
+{{- $dashboardDbDriver := .Values.dashboard.databaseDriver -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $apiName }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-api") | nindent 4 }}
+spec:
+  {{- if not .Values.dashboard.autoscaling.api.enabled }}
+  replicas: {{ .Values.dashboard.api.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-api") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/dashboard-secret: {{ include (print $.Template.BasePath "/dashboard-secret.yaml") . | sha256sum }}
+        {{- with .Values.dashboard.api.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-api") | nindent 8 }}
+        {{- with .Values.dashboard.api.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sockudo.serviceAccountName" . }}
+      {{- with .Values.dashboard.api.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dashboard.api.priorityClassName }}
+      priorityClassName: {{ .Values.dashboard.api.priorityClassName }}
+      {{- end }}
+      containers:
+        - name: dashboard-api
+          {{- with .Values.dashboard.api.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.dashboard.api.image.repository }}:{{ .Values.dashboard.api.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.dashboard.api.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3460
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: DASHBOARD_API_PORT
+              value: "3460"
+            - name: DASHBOARD_CORS_ORIGIN
+              value: {{ .Values.dashboard.api.corsOrigin | default (printf "http://%s.%s.svc:%v" (include "sockudo.dashboardWebName" .) .Release.Namespace .Values.dashboard.web.service.port) | quote }}
+            - name: DASHBOARD_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.dashboard.sessionSecret.existingSecret | default (include "sockudo.dashboardSecretName" .) }}
+                  key: {{ .Values.dashboard.sessionSecret.key }}
+            - name: APP_MANAGER_DRIVER
+              value: {{ $appManagerDriver | quote }}
+            {{- if $dashboardDbDriver }}
+            - name: DASHBOARD_DATABASE_DRIVER
+              value: {{ $dashboardDbDriver | quote }}
+            {{- end }}
+            - name: SOCKUDO_HTTP_URL
+              value: {{ .Values.dashboard.api.sockudoHttpUrl | default (printf "http://%s:%v" (include "sockudo.fullname" .) .Values.service.port) | quote }}
+            - name: SOCKUDO_METRICS_URL
+              value: {{ .Values.dashboard.api.sockudoMetricsUrl | default (printf "http://%s-metrics:%v" (include "sockudo.fullname" .) .Values.metricsService.port) | quote }}
+            {{- if .Values.database.mysql.host }}
+            - name: DATABASE_MYSQL_HOST
+              value: {{ .Values.database.mysql.host | quote }}
+            - name: DATABASE_MYSQL_PORT
+              value: {{ .Values.database.mysql.port | quote }}
+            - name: DATABASE_MYSQL_DATABASE
+              value: {{ .Values.database.mysql.database | quote }}
+            - name: DATABASE_MYSQL_TABLE_NAME
+              value: {{ .Values.database.mysql.tableName | quote }}
+            {{- if or .Values.database.existingSecret .Values.database.mysql.username }}
+            - name: DATABASE_MYSQL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: database-username
+            {{- end }}
+            {{- if or .Values.database.existingSecret .Values.database.mysql.password }}
+            - name: DATABASE_MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: database-password
+            {{- end }}
+            {{- end }}
+            {{- if .Values.database.postgres.host }}
+            - name: DATABASE_POSTGRES_HOST
+              value: {{ .Values.database.postgres.host | quote }}
+            - name: DATABASE_POSTGRES_PORT
+              value: {{ .Values.database.postgres.port | quote }}
+            - name: DATABASE_POSTGRES_DATABASE
+              value: {{ .Values.database.postgres.database | quote }}
+            - name: DATABASE_POSTGRES_TABLE_NAME
+              value: {{ .Values.database.postgres.tableName | default "applications" | quote }}
+            {{- if or .Values.database.existingSecret .Values.database.postgres.username }}
+            - name: DATABASE_POSTGRES_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: database-username
+            {{- end }}
+            {{- if or .Values.database.existingSecret .Values.database.postgres.password }}
+            - name: DATABASE_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret | default (include "sockudo.secretName" .) }}
+                  key: database-password
+            {{- end }}
+            {{- end }}
+            {{- if .Values.dashboard.seedAdmin.enabled }}
+            - name: DASHBOARD_SEED_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.dashboard.seedAdmin.existingSecret | default (include "sockudo.dashboardSecretName" .) }}
+                  key: {{ .Values.dashboard.seedAdmin.emailKey }}
+            - name: DASHBOARD_SEED_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.dashboard.seedAdmin.existingSecret | default (include "sockudo.dashboardSecretName" .) }}
+                  key: {{ .Values.dashboard.seedAdmin.passwordKey }}
+            - name: DASHBOARD_SEED_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.dashboard.seedAdmin.existingSecret | default (include "sockudo.dashboardSecretName" .) }}
+                  key: {{ .Values.dashboard.seedAdmin.nameKey }}
+                  optional: true
+            {{- end }}
+            {{- with .Values.dashboard.api.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.dashboard.api.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dashboard.api.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dashboard.api.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dashboard.api.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dashboard.api.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.dashboard.api.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.dashboard.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.dashboard.persistence.existingClaim | default (printf "%s-data" $apiName) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.dashboard.api.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.dashboard.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.api.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-hpa.yaml
+++ b/charts/sockudo/templates/dashboard-hpa.yaml
@@ -1,0 +1,73 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.autoscaling.api.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "sockudo.dashboardApiName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-api") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "sockudo.dashboardApiName" . }}
+  minReplicas: {{ .Values.dashboard.autoscaling.api.minReplicas }}
+  maxReplicas: {{ .Values.dashboard.autoscaling.api.maxReplicas }}
+  metrics:
+    {{- if .Values.dashboard.autoscaling.api.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.dashboard.autoscaling.api.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.dashboard.autoscaling.api.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.dashboard.autoscaling.api.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- with .Values.dashboard.autoscaling.api.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.dashboard.enabled .Values.dashboard.autoscaling.web.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "sockudo.dashboardWebName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-web") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "sockudo.dashboardWebName" . }}
+  minReplicas: {{ .Values.dashboard.autoscaling.web.minReplicas }}
+  maxReplicas: {{ .Values.dashboard.autoscaling.web.maxReplicas }}
+  metrics:
+    {{- if .Values.dashboard.autoscaling.web.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.dashboard.autoscaling.web.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.dashboard.autoscaling.web.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.dashboard.autoscaling.web.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- with .Values.dashboard.autoscaling.web.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-ingress.yaml
+++ b/charts/sockudo/templates/dashboard-ingress.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sockudo.dashboardWebName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-web") | nindent 4 }}
+  {{- with .Values.dashboard.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.dashboard.ingress.className }}
+  ingressClassName: {{ .Values.dashboard.ingress.className }}
+  {{- end }}
+  {{- if .Values.dashboard.ingress.tls }}
+  tls:
+    {{- range .Values.dashboard.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.dashboard.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "sockudo.dashboardWebName" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-networkpolicy.yaml
+++ b/charts/sockudo/templates/dashboard-networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sockudo.dashboardApiName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-api") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-api") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- with .Values.dashboard.networkPolicy.api.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.dashboard.networkPolicy.api.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sockudo.dashboardWebName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-web") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-web") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- with .Values.dashboard.networkPolicy.web.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.dashboard.networkPolicy.web.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-pdb.yaml
+++ b/charts/sockudo/templates/dashboard-pdb.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.pdb.api.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "sockudo.dashboardApiName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-api") | nindent 4 }}
+spec:
+  {{- if .Values.dashboard.pdb.api.minAvailable }}
+  minAvailable: {{ .Values.dashboard.pdb.api.minAvailable }}
+  {{- end }}
+  {{- if .Values.dashboard.pdb.api.maxUnavailable }}
+  maxUnavailable: {{ .Values.dashboard.pdb.api.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-api") | nindent 6 }}
+{{- end }}
+{{- if and .Values.dashboard.enabled .Values.dashboard.pdb.web.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "sockudo.dashboardWebName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-web") | nindent 4 }}
+spec:
+  {{- if .Values.dashboard.pdb.web.minAvailable }}
+  minAvailable: {{ .Values.dashboard.pdb.web.minAvailable }}
+  {{- end }}
+  {{- if .Values.dashboard.pdb.web.maxUnavailable }}
+  maxUnavailable: {{ .Values.dashboard.pdb.web.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-web") | nindent 6 }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-pvc.yaml
+++ b/charts/sockudo/templates/dashboard-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.persistence.enabled (not .Values.dashboard.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sockudo.dashboardApiName" . }}-data
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-api") | nindent 4 }}
+  {{- with .Values.dashboard.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.dashboard.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.dashboard.persistence.size | quote }}
+  {{- if .Values.dashboard.persistence.storageClass }}
+  storageClassName: {{ .Values.dashboard.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-secret.yaml
+++ b/charts/sockudo/templates/dashboard-secret.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.dashboard.enabled -}}
+{{- $driver := default .Values.config.appManagerDriver .Values.dashboard.appManagerDriver -}}
+{{- if eq $driver "memory" -}}
+{{- fail "dashboard.enabled requires dashboard.appManagerDriver or config.appManagerDriver to be mysql, pgsql/postgres, or dynamodb; memory is not supported" -}}
+{{- end -}}
+{{- $dashboardDbDriver := .Values.dashboard.databaseDriver -}}
+{{- $usesSqlite := or (eq $dashboardDbDriver "sqlite") (and (eq $dashboardDbDriver "") (eq $driver "dynamodb")) -}}
+{{- if and $usesSqlite (not .Values.dashboard.persistence.enabled) (not .Values.dashboard.persistence.existingClaim) -}}
+{{- fail "dashboard sqlite storage requires dashboard.persistence.enabled=true or dashboard.persistence.existingClaim" -}}
+{{- end -}}
+{{- if and $usesSqlite (or (gt (int .Values.dashboard.api.replicaCount) 1) (and .Values.dashboard.autoscaling.api.enabled (gt (int .Values.dashboard.autoscaling.api.maxReplicas) 1))) -}}
+{{- fail "dashboard sqlite storage supports only one dashboard API replica; set dashboard.databaseDriver to mysql/pgsql or keep dashboard.api.replicaCount and dashboard.autoscaling.api.maxReplicas at 1" -}}
+{{- end -}}
+{{- $managedSession := not .Values.dashboard.sessionSecret.existingSecret -}}
+{{- $managedSeed := and .Values.dashboard.seedAdmin.enabled (not .Values.dashboard.seedAdmin.existingSecret) -}}
+{{- if or $managedSession $managedSeed }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sockudo.dashboardSecretName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard") | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if $managedSession }}
+  {{ .Values.dashboard.sessionSecret.key }}: {{ required "dashboard.sessionSecret.value is required when dashboard.enabled=true and dashboard.sessionSecret.existingSecret is empty" .Values.dashboard.sessionSecret.value | quote }}
+  {{- end }}
+  {{- if $managedSeed }}
+  {{ .Values.dashboard.seedAdmin.emailKey }}: {{ required "dashboard.seedAdmin.email is required when dashboard.seedAdmin.enabled=true and dashboard.seedAdmin.existingSecret is empty" .Values.dashboard.seedAdmin.email | quote }}
+  {{ .Values.dashboard.seedAdmin.passwordKey }}: {{ required "dashboard.seedAdmin.password is required when dashboard.seedAdmin.enabled=true and dashboard.seedAdmin.existingSecret is empty" .Values.dashboard.seedAdmin.password | quote }}
+  {{ .Values.dashboard.seedAdmin.nameKey }}: {{ .Values.dashboard.seedAdmin.name | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-service.yaml
+++ b/charts/sockudo/templates/dashboard-service.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.dashboard.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sockudo.dashboardApiName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-api") | nindent 4 }}
+  {{- with .Values.dashboard.api.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.dashboard.api.service.type }}
+  ports:
+    - port: {{ .Values.dashboard.api.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-api") | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sockudo.dashboardWebName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-web") | nindent 4 }}
+  {{- with .Values.dashboard.web.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.dashboard.web.service.type }}
+  ports:
+    - port: {{ .Values.dashboard.web.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-web") | nindent 4 }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-web-deployment.yaml
+++ b/charts/sockudo/templates/dashboard-web-deployment.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.dashboard.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sockudo.dashboardWebName" . }}
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-web") | nindent 4 }}
+spec:
+  {{- if not .Values.dashboard.autoscaling.web.enabled }}
+  replicas: {{ .Values.dashboard.web.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-web") | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.dashboard.web.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-web") | nindent 8 }}
+        {{- with .Values.dashboard.web.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sockudo.serviceAccountName" . }}
+      {{- with .Values.dashboard.web.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dashboard.web.priorityClassName }}
+      priorityClassName: {{ .Values.dashboard.web.priorityClassName }}
+      {{- end }}
+      containers:
+        - name: dashboard-web
+          {{- with .Values.dashboard.web.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.dashboard.web.image.repository }}:{{ .Values.dashboard.web.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.dashboard.web.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: DASHBOARD_API_UPSTREAM
+              value: {{ printf "http://%s:%v" (include "sockudo.dashboardApiName" .) .Values.dashboard.api.service.port | quote }}
+            {{- with .Values.dashboard.web.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.dashboard.web.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dashboard.web.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dashboard.web.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dashboard.web.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.dashboard.web.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.dashboard.web.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.web.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.web.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dashboard.web.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/tests/test-dashboard.yaml
+++ b/charts/sockudo/templates/tests/test-dashboard.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "sockudo.fullname" . }}-test-dashboard"
+  labels:
+    {{- include "sockudo.dashboardLabels" (dict "root" . "component" "dashboard-test") | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['sh', '-c']
+      args:
+        - >
+          wget -q -O - {{ include "sockudo.dashboardApiName" . }}:{{ .Values.dashboard.api.service.port }}/health &&
+          wget -q -O /dev/null {{ include "sockudo.dashboardWebName" . }}:{{ .Values.dashboard.web.service.port }}/
+  restartPolicy: Never
+{{- end }}

--- a/charts/sockudo/values.yaml
+++ b/charts/sockudo/values.yaml
@@ -194,6 +194,7 @@ database:
     username: ""
     password: ""
     database: "sockudo"
+    tableName: "applications"
   # -- Use an existing secret for database credentials
   # Must contain keys matching: database-username, database-password
   existingSecret: ""
@@ -229,6 +230,207 @@ metricsService:
   enabled: true
   port: 9601
   annotations: {}
+
+# -- Sockudo operator dashboard/admin UI.
+# Requires config.appManagerDriver to be mysql, pgsql/postgres, or dynamodb.
+dashboard:
+  enabled: false
+
+  # -- App manager driver used by the dashboard API. Empty defaults to config.appManagerDriver.
+  appManagerDriver: ""
+  # -- Dashboard user database driver. Empty lets the API choose mysql/pgsql from APP_MANAGER_DRIVER,
+  # or sqlite for dynamodb.
+  databaseDriver: ""
+
+  # -- Secret used to sign dashboard session cookies.
+  sessionSecret:
+    # -- Existing secret name. Must contain the key configured below.
+    existingSecret: ""
+    key: dashboard-session-secret
+    # -- Plain value for chart-managed secret. Required when dashboard.enabled=true and no existingSecret is set.
+    value: ""
+
+  # -- Optional first admin seed. The API only creates this user when no dashboard users exist.
+  seedAdmin:
+    enabled: false
+    existingSecret: ""
+    emailKey: dashboard-seed-email
+    passwordKey: dashboard-seed-password
+    nameKey: dashboard-seed-name
+    email: ""
+    password: ""
+    name: Administrator
+
+  api:
+    replicaCount: 1
+    image:
+      repository: sockudo/dashboard-api
+      pullPolicy: IfNotPresent
+      tag: ""
+    service:
+      type: ClusterIP
+      port: 3460
+      annotations: {}
+    # -- CORS origin for direct API access. Empty defaults to the dashboard web service URL.
+    corsOrigin: ""
+    # -- Optional override for Sockudo HTTP URL. Empty uses the in-chart Sockudo service.
+    sockudoHttpUrl: ""
+    # -- Optional override for Sockudo metrics URL. Empty uses the in-chart metrics service.
+    sockudoMetricsUrl: ""
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities:
+        drop:
+          - ALL
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: http
+      initialDelaySeconds: 20
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    startupProbe:
+      httpGet:
+        path: /health
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 5
+      failureThreshold: 24
+    extraEnv: []
+    extraEnvFrom: []
+    extraVolumes: []
+    extraVolumeMounts: []
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    topologySpreadConstraints: []
+    priorityClassName: ""
+
+  web:
+    replicaCount: 1
+    image:
+      repository: sockudo/dashboard-web
+      pullPolicy: IfNotPresent
+      tag: ""
+    service:
+      type: ClusterIP
+      port: 80
+      annotations: {}
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext: {}
+    securityContext: {}
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+    livenessProbe:
+      httpGet:
+        path: /
+        port: http
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    extraEnv: []
+    extraEnvFrom: []
+    extraVolumes: []
+    extraVolumeMounts: []
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    topologySpreadConstraints: []
+    priorityClassName: ""
+
+  # -- Persistent storage for /app/data. Needed when dashboard.databaseDriver=sqlite.
+  persistence:
+    enabled: false
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    annotations: {}
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: sockudo-admin.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+
+  autoscaling:
+    api:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: 80
+      behavior: {}
+    web:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: 80
+      behavior: {}
+
+  pdb:
+    api:
+      enabled: false
+      minAvailable: 1
+    web:
+      enabled: false
+      minAvailable: 1
+
+  networkPolicy:
+    enabled: false
+    api:
+      ingress: []
+      egress: []
+    web:
+      ingress: []
+      egress: []
 
 ingress:
   enabled: false

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -61,8 +61,10 @@ RUN bun run build
 # -----------------------------------------------------------------------------
 FROM nginx:alpine AS web
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 COPY --from=web-build /app/dist /usr/share/nginx/html
+
+ENV DASHBOARD_API_UPSTREAM=http://dashboard-api:3460
 
 EXPOSE 80
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -119,6 +119,66 @@ optional admin seed run automatically on API startup.
 **Cargo / Rust:** the dashboard is not part of the Rust workspace; no `Cargo.toml` changes
 are required.
 
+## Helm
+
+The `charts/sockudo` chart can deploy the operator dashboard alongside Sockudo.
+The dashboard is disabled by default and must be backed by a durable app manager
+(`mysql`, `pgsql`/`postgres`, or `dynamodb`).
+
+Create the dashboard session secret outside the chart for production:
+
+```bash
+kubectl create secret generic sockudo-dashboard-session \
+  --from-literal=dashboard-session-secret="$(openssl rand -base64 32)"
+```
+
+Example values:
+
+```yaml
+config:
+  appManagerDriver: pgsql
+  httpApi:
+    usageEnabled: true
+  metrics:
+    enabled: true
+
+database:
+  postgres:
+    host: postgres.default.svc
+    port: 5432
+    username: sockudo
+    password: ""
+    database: sockudo
+    tableName: applications
+  existingSecret: sockudo-postgres
+
+dashboard:
+  enabled: true
+  sessionSecret:
+    existingSecret: sockudo-dashboard-session
+  seedAdmin:
+    enabled: true
+    existingSecret: sockudo-dashboard-seed
+  ingress:
+    enabled: true
+    hosts:
+      - host: sockudo-admin.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: sockudo-admin-tls
+        hosts:
+          - sockudo-admin.example.com
+```
+
+`dashboard-api` and `dashboard-web` images default to the chart app version and
+can be overridden with `dashboard.api.image.*` and `dashboard.web.image.*`.
+The web image proxies `/api/*` to the release-scoped dashboard API service at
+runtime. If you use `dashboard.databaseDriver=sqlite`, also set
+`dashboard.persistence.enabled=true` or provide `dashboard.persistence.existingClaim`;
+SQLite mode supports only one dashboard API replica.
+
 ## Dashboard database
 
 Dashboard users live in separate tables (`dashboard_users`, `dashboard_migrations`):

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -6,7 +6,7 @@ server {
     index index.html;
 
     location /api/ {
-        proxy_pass http://dashboard-api:3460;
+        proxy_pass ${DASHBOARD_API_UPSTREAM};
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Add first-class Helm support for deploying the Sockudo operator dashboard/admin from charts/sockudo.

Summary:
- Adds dashboard API/web Deployments and Services, optional Ingress, PVC, Secret, HPA, PDB, NetworkPolicy, and Helm test hook.
- Adds production guardrails for unsupported memory app manager, missing session secret, SQLite persistence, and unsafe SQLite API scaling.
- Makes the dashboard web nginx API upstream configurable through DASHBOARD_API_UPSTREAM for release-scoped Helm service names.
- Documents dashboard Helm deployment in dashboard/README.md and charts/sockudo/README.md.

Validation:
- helm lint charts/sockudo via alpine/helm:3.15.4 passed during implementation.
- helm template default, Postgres dashboard, and SQLite+persistence renders passed during implementation.
- kubeconform strict validation passed on those rendered manifests during implementation.
- dashboard web image build and nginx template smoke test passed during implementation.
- git diff --cached --check passed before commit.

Note: final Docker-backed reruns were blocked because the local Docker socket was unavailable in the current sandbox.