### PR TITLE
Fix monorepo-native Go and Swift SDK publishing

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -45,7 +45,7 @@ on:
       - "server-php-v*"
       - "v*"
       - "server-ruby-v*"
-      - "server-go-v*"
+      - "server-sdks/sockudo-http-go/v*"
       - "server-rust-v*"
       - "server-java-v*"
       - "server-dotnet-v*"
@@ -676,7 +676,7 @@ jobs:
     if: >-
       ${{
         (github.event_name == 'workflow_dispatch' && (inputs.package == 'all' || inputs.package == 'server-go')) ||
-        startsWith(github.ref_name, 'server-go-v')
+        startsWith(github.ref_name, 'server-sdks/sockudo-http-go/v')
       }}
     defaults:
       run:
@@ -702,7 +702,7 @@ jobs:
       - name: Go module publish notice
         if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
         run: |
-          echo "Go modules publish from VCS tags. Ensure the module path repository has the matching semantic version tag."
+          echo "Go modules publish from VCS tags. Push tags like server-sdks/sockudo-http-go/v5.0.0 for the monorepo module path."
 
   client-swift:
     name: Gate SockudoSwift
@@ -710,7 +710,8 @@ jobs:
     if: >-
       ${{
         (github.event_name == 'workflow_dispatch' && (inputs.package == 'all' || inputs.package == 'client-swift')) ||
-        startsWith(github.ref_name, 'client-swift-v')
+        startsWith(github.ref_name, 'client-swift-v') ||
+        startsWith(github.ref_name, 'v')
       }}
     defaults:
       run:
@@ -734,7 +735,7 @@ jobs:
       - name: Swift package publish notice
         if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
         run: |
-          echo "SwiftPM packages publish from Git tags. Ensure the package repository has the matching semantic version tag."
+          echo "SwiftPM packages publish from root SemVer Git tags like v1.0.0 through https://github.com/sockudo/sockudo."
 
   server-swift:
     name: Gate Sockudo HTTP Swift
@@ -742,7 +743,8 @@ jobs:
     if: >-
       ${{
         (github.event_name == 'workflow_dispatch' && (inputs.package == 'all' || inputs.package == 'server-swift')) ||
-        startsWith(github.ref_name, 'server-swift-v')
+        startsWith(github.ref_name, 'server-swift-v') ||
+        startsWith(github.ref_name, 'v')
       }}
     defaults:
       run:
@@ -766,4 +768,4 @@ jobs:
       - name: Swift package publish notice
         if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
         run: |
-          echo "SwiftPM packages publish from Git tags. Ensure the package repository has the matching semantic version tag."
+          echo "SwiftPM packages publish from root SemVer Git tags like v1.0.0 through https://github.com/sockudo/sockudo."

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 **/target
 target-codex-*/
+.build/
 **/node_modules
 .env
 .DS_Store

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,77 @@
+{
+  "originHash" : "929fca62a9a0ffec8ddb96070325cf7f9cce4dadc22be69a2faa38a477f924e1",
+  "pins" : [
+    {
+      "identity" : "anycodable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Flight-School/AnyCodable",
+      "state" : {
+        "revision" : "862808b2070cd908cb04f9aafe7de83d35f81b05",
+        "version" : "0.6.7"
+      }
+    },
+    {
+      "identity" : "apiota",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/danielrbrowne/APIota",
+      "state" : {
+        "revision" : "590dd92231b0428f2b6910f856845d1895c58af9",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "delta-codec-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ably/delta-codec-cocoa.git",
+      "state" : {
+        "revision" : "d53eec08f9443c6160d941327a6f9d8bbb93cea2",
+        "version" : "1.3.5"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto",
+      "state" : {
+        "revision" : "ddb07e896a2a8af79512543b1c7eb9797f8898a5",
+        "version" : "1.1.7"
+      }
+    },
+    {
+      "identity" : "swift-sodium",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jedisct1/swift-sodium.git",
+      "state" : {
+        "revision" : "cfd195c76882aa9b997560ca7cb95d72fbf5db00",
+        "version" : "0.11.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-testing.git",
+      "state" : {
+        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
+        "version" : "0.99.0"
+      }
+    },
+    {
+      "identity" : "tweetnacl-swiftwrap",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/bitmark-inc/tweetnacl-swiftwrap",
+      "state" : {
+        "revision" : "f8fd111642bf2336b11ef9ea828510693106e954"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,95 @@
+// swift-tools-version: 6.2
+
+import PackageDescription
+
+let package = Package(
+  name: "sockudo",
+  platforms: [
+    .iOS(.v13),
+    .macOS(.v10_15),
+    .tvOS(.v13),
+    .watchOS(.v6),
+    .visionOS(.v1),
+  ],
+  products: [
+    .library(
+      name: "SockudoSwift",
+      targets: ["SockudoSwift"]
+    ),
+    .library(
+      name: "Sockudo",
+      targets: ["Sockudo"]
+    ),
+    .library(
+      name: "Pusher",
+      targets: ["Pusher"]
+    ),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/jedisct1/swift-sodium.git", from: "0.9.1"),
+    .package(url: "https://github.com/ably/delta-codec-cocoa.git", from: "1.0.0"),
+    .package(url: "https://github.com/danielrbrowne/APIota", .upToNextMajor(from: "0.2.0")),
+    .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.4.0")),
+    .package(url: "https://github.com/apple/swift-crypto", .upToNextMajor(from: "1.1.6")),
+    .package(
+      url: "https://github.com/bitmark-inc/tweetnacl-swiftwrap",
+      revision: "f8fd111642bf2336b11ef9ea828510693106e954"
+    ),
+    .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.12.0"),
+  ],
+  targets: [
+    .target(
+      name: "SockudoSwift",
+      dependencies: [
+        .product(name: "Sodium", package: "swift-sodium"),
+        .product(name: "AblyDeltaCodec", package: "delta-codec-cocoa"),
+      ],
+      path: "client-sdks/sockudo-swift/Sources/SockudoSwift",
+      swiftSettings: [
+        .unsafeFlags(["-Xfrontend", "-strict-concurrency=minimal"])
+      ]
+    ),
+    .target(
+      name: "Sockudo",
+      dependencies: [
+        "APIota",
+        "AnyCodable",
+        .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "TweetNacl", package: "tweetnacl-swiftwrap"),
+      ],
+      path: "server-sdks/sockudo-http-swift/Sources/Sockudo",
+      swiftSettings: [
+        .swiftLanguageMode(.v5),
+        .unsafeFlags(["-Xfrontend", "-strict-concurrency=minimal"])
+      ]
+    ),
+    .target(
+      name: "Pusher",
+      dependencies: [
+        "APIota",
+        "AnyCodable",
+        .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "TweetNacl", package: "tweetnacl-swiftwrap"),
+      ],
+      path: "server-sdks/sockudo-http-swift/Sources/Pusher",
+      swiftSettings: [
+        .swiftLanguageMode(.v5),
+        .unsafeFlags(["-Xfrontend", "-strict-concurrency=minimal"])
+      ]
+    ),
+    .testTarget(
+      name: "SockudoSwiftTests",
+      dependencies: [
+        "SockudoSwift",
+        .product(name: "Testing", package: "swift-testing"),
+      ],
+      path: "client-sdks/sockudo-swift/Tests/SockudoSwiftTests",
+      swiftSettings: [
+        .unsafeFlags([
+          "-Xfrontend", "-strict-concurrency=minimal",
+          "-suppress-warnings",
+        ])
+      ]
+    ),
+  ]
+)

--- a/README.md
+++ b/README.md
@@ -150,19 +150,18 @@ Realtime clients live under [client-sdks/](client-sdks/).
 
 SDK CI and publishing are managed from root workflows. See the
 [2026 SDK publishing runbook](docs/sdk-publishing-2026.md) before releasing packages or changing
-registry setup. Registry-native packages publish through protected workflows where supported;
-VCS-tagged ecosystems such as SwiftPM still require package repository/subtree-split handling unless
-their public package URL changes intentionally.
+registry setup. Registry-native packages publish through protected workflows where supported.
+SwiftPM packages are published from this monorepo through the root `Package.swift`.
 
-| Runtime | Directory | Package |
-| --- | --- | --- |
-| JavaScript / TypeScript | [`client-sdks/sockudo-js`](client-sdks/sockudo-js) | `@sockudo/client` |
-| AI Transport TypeScript | [`client-sdks/sockudo-ai-transport-js`](client-sdks/sockudo-ai-transport-js) | `@sockudo/ai-transport` |
-| Swift / Apple platforms | [`client-sdks/sockudo-swift`](client-sdks/sockudo-swift) | `SockudoSwift` |
-| Kotlin / JVM / Android | [`client-sdks/sockudo-kotlin`](client-sdks/sockudo-kotlin) | `io.sockudo:sockudo-kotlin` |
-| Flutter / Dart | [`client-sdks/sockudo-flutter`](client-sdks/sockudo-flutter) | `sockudo_flutter` |
-| .NET | [`client-sdks/sockudo-dotnet`](client-sdks/sockudo-dotnet) | `Sockudo.Client` |
-| Python | [`client-sdks/sockudo-python`](client-sdks/sockudo-python) | `sockudo-python` |
+| Runtime | Package |
+| --- | --- |
+| JavaScript / TypeScript | `@sockudo/client` |
+| AI Transport TypeScript | `@sockudo/ai-transport` |
+| Swift / Apple platforms | `SockudoSwift` from `https://github.com/sockudo/sockudo` |
+| Kotlin / JVM / Android | `io.sockudo:sockudo-kotlin` |
+| Flutter / Dart | `sockudo_flutter` |
+| .NET | `Sockudo.Client` |
+| Python | `sockudo-python` |
 
 JavaScript example:
 
@@ -202,21 +201,20 @@ where implemented.
 
 SDK CI and publishing are managed from root workflows. See the
 [2026 SDK publishing runbook](docs/sdk-publishing-2026.md) before releasing packages or changing
-registry setup. Registry-native packages publish through protected workflows where supported;
-VCS-tagged ecosystems such as Go modules, SwiftPM, and Packagist still require package
-repository/subtree-split handling unless their public package URL changes intentionally.
+registry setup. Registry-native packages publish through protected workflows where supported. Go
+modules and SwiftPM publish from this monorepo with package-manager-native tags and manifests.
 
-| Language | Directory | Package |
-| --- | --- | --- |
-| Node.js | [`server-sdks/sockudo-http-node`](server-sdks/sockudo-http-node) | `sockudo` |
-| Python | [`server-sdks/sockudo-http-python`](server-sdks/sockudo-http-python) | `sockudo-http-python` |
-| PHP | [`server-sdks/sockudo-http-php`](server-sdks/sockudo-http-php) | `sockudo/sockudo-php-server` |
-| Ruby | [`server-sdks/sockudo-http-ruby`](server-sdks/sockudo-http-ruby) | `sockudo` |
-| Go | [`server-sdks/sockudo-http-go`](server-sdks/sockudo-http-go) | `github.com/sockudo/sockudo-http-go/v5` |
-| Rust | [`server-sdks/sockudo-http-rust`](server-sdks/sockudo-http-rust) | `sockudo-http` |
-| Java | [`server-sdks/sockudo-http-java`](server-sdks/sockudo-http-java) | `io.sockudo:sockudo-http-java` |
-| .NET | [`server-sdks/sockudo-http-dotnet`](server-sdks/sockudo-http-dotnet) | `SockudoServer` |
-| Swift | [`server-sdks/sockudo-http-swift`](server-sdks/sockudo-http-swift) | `Sockudo` |
+| Language | Package |
+| --- | --- |
+| Node.js | `sockudo` |
+| Python | `sockudo-http-python` |
+| PHP | `sockudo/sockudo-php-server` |
+| Ruby | `sockudo` |
+| Go | `github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5` |
+| Rust | `sockudo-http` |
+| Java | `io.sockudo:sockudo-http-java` |
+| .NET | `SockudoServer` |
+| Swift | `Sockudo` from `https://github.com/sockudo/sockudo` |
 
 Node.js example:
 

--- a/client-sdks/README.md
+++ b/client-sdks/README.md
@@ -7,18 +7,17 @@ and issue references recognizable.
 SDK CI and package publishing are managed from the monorepo root through
 `.github/workflows/sdk-ci.yml` and `.github/workflows/sdk-release.yml`. See the
 [2026 SDK publishing runbook](../docs/sdk-publishing-2026.md) before publishing
-or changing registry setup. VCS-tagged ecosystems such as SwiftPM still require
-package repository/subtree-split handling unless their public package URL is
-changed intentionally.
+or changing registry setup. SwiftPM distribution uses the root `Package.swift`
+in this monorepo.
 
-## Imports
+## Packages
 
-| Directory | Current source | Legacy repo |
-| --- | --- | --- |
-| `sockudo-ai-transport-js` | `client-sdks/sockudo-ai-transport-js` | <https://github.com/sockudo/sockudo-ai-transport-js> imported at `d87253f74613` |
-| `sockudo-dotnet` | `client-sdks/sockudo-dotnet` | <https://github.com/sockudo/sockudo-dotnet> imported at `b4abfe67e195` |
-| `sockudo-flutter` | `client-sdks/sockudo-flutter` | <https://github.com/sockudo/sockudo-flutter> imported at `dc1b886b191f` |
-| `sockudo-js` | `client-sdks/sockudo-js` | <https://github.com/sockudo/sockudo-js> imported at `a304b0df04d7` |
-| `sockudo-kotlin` | `client-sdks/sockudo-kotlin` | <https://github.com/sockudo/sockudo-kotlin> imported at `adb338e1ef7a` |
-| `sockudo-python` | `client-sdks/sockudo-python` | <https://github.com/sockudo/sockudo-python> imported at `6a9f6de7830e` |
-| `sockudo-swift` | `client-sdks/sockudo-swift` | <https://github.com/sockudo/sockudo-swift> imported at `cb3fc23d0e94` |
+| Package | Directory |
+| --- | --- |
+| `@sockudo/ai-transport` | `client-sdks/sockudo-ai-transport-js` |
+| `Sockudo.Client` | `client-sdks/sockudo-dotnet` |
+| `sockudo_flutter` | `client-sdks/sockudo-flutter` |
+| `@sockudo/client` | `client-sdks/sockudo-js` |
+| `io.sockudo:sockudo-kotlin` | `client-sdks/sockudo-kotlin` |
+| `sockudo-python` | `client-sdks/sockudo-python` |
+| `SockudoSwift` | `client-sdks/sockudo-swift` |

--- a/client-sdks/sockudo-swift/README.md
+++ b/client-sdks/sockudo-swift/README.md
@@ -28,23 +28,19 @@ Official Swift client for Sockudo.
 
 ## Installation
 
-For local monorepo development, use a Swift Package Manager path:
+Use Swift Package Manager with the monorepo package URL:
 
 ```swift
-.package(path: "../sockudo/client-sdks/sockudo-swift")
+.package(url: "https://github.com/sockudo/sockudo", from: "1.0.0")
 ```
 
-Public SwiftPM distribution requires the package repository or subtree split described in
-`docs/sdk-publishing-2026.md`, because SwiftPM expects `Package.swift` at the package repository
-root.
-
-Then depend on `SockudoSwift`:
+Then depend on the `SockudoSwift` product:
 
 ```swift
 .target(
     name: "YourApp",
     dependencies: [
-        .product(name: "SockudoSwift", package: "sockudo-swift"),
+        .product(name: "SockudoSwift", package: "sockudo"),
     ]
 )
 ```
@@ -52,7 +48,7 @@ Then depend on `SockudoSwift`:
 For local development:
 
 ```swift
-.package(path: "../sockudo-swift")
+.package(path: "../sockudo")
 ```
 
 ## Quick Start
@@ -314,9 +310,8 @@ The live suite covers:
 Swift packages are distributed by git tag rather than a central package registry by default.
 
 - CI: root workflow `.github/workflows/sdk-ci.yml`
-- Release gate: root workflow `.github/workflows/sdk-release.yml` with tag `client-swift-vX.Y.Z`
-- Distribution: SwiftPM still requires a package repository or subtree split whose root contains
-  `Package.swift`
+- Release gate: root workflow `.github/workflows/sdk-release.yml` with root tag `vX.Y.Z`
+- Distribution: root `Package.swift` from `https://github.com/sockudo/sockudo`
 
 ## Status
 

--- a/docs/content/docs/clients/index.mdx
+++ b/docs/content/docs/clients/index.mdx
@@ -6,7 +6,8 @@ icon: Smartphone
 
 Realtime client SDKs connect to Sockudo over WebSocket, subscribe to channels, receive events, authorize protected channels through your backend, and expose Protocol V2 features.
 
-Until SDK publishing CI is stable, install client SDKs from local paths in this monorepo checkout. The old per-SDK repositories should be treated as archived/legacy mirrors. Package names below are the intended registry names, but the language guides use monorepo path install instructions for now.
+Install client SDKs from the package names below. The old per-SDK repositories should be treated as
+archived/legacy mirrors.
 
 ## Official clients
 

--- a/docs/content/docs/clients/swift.mdx
+++ b/docs/content/docs/clients/swift.mdx
@@ -8,17 +8,15 @@ icon: Smartphone
 
 ## Install
 
-Clone the monorepo and use a local Swift Package Manager path until package publishing is enabled:
-
 ```swift
-.package(path: "../sockudo/client-sdks/sockudo-swift")
+.package(url: "https://github.com/sockudo/sockudo", from: "1.0.0")
 ```
 
 ```swift
 .target(
     name: "YourApp",
     dependencies: [
-        .product(name: "SockudoSwift", package: "sockudo-swift"),
+        .product(name: "SockudoSwift", package: "sockudo"),
     ]
 )
 ```

--- a/docs/content/docs/server-sdks/go.mdx
+++ b/docs/content/docs/server-sdks/go.mdx
@@ -6,13 +6,8 @@ icon: FileCode
 
 ## Install
 
-Clone the Sockudo monorepo and use a local `replace` until this module is published from the
-monorepo:
-
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-go get github.com/sockudo/sockudo-http-go/v5
-go mod edit -replace github.com/sockudo/sockudo-http-go/v5=../sockudo/server-sdks/sockudo-http-go
+go get github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5
 ```
 
 ## Configure
@@ -20,7 +15,7 @@ go mod edit -replace github.com/sockudo/sockudo-http-go/v5=../sockudo/server-sdk
 ```go
 package main
 
-import sockudo "github.com/sockudo/sockudo-http-go/v5"
+import sockudo "github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5"
 
 var client = sockudo.Client{
     AppID:  "app-id",

--- a/docs/content/docs/server-sdks/index.mdx
+++ b/docs/content/docs/server-sdks/index.mdx
@@ -6,7 +6,8 @@ icon: Blocks
 
 Server SDKs are trusted backend libraries. They hold app secrets, sign HTTP requests, sign private and presence channel auth responses, validate webhooks, publish realtime events, and manage push notifications.
 
-Until SDK publishing CI is stable, install server SDKs from local paths in this monorepo checkout. The old per-SDK repositories should be treated as archived/legacy mirrors. Package names below are the intended registry names, but the language guides use monorepo path install instructions for now.
+Install server SDKs from the package names below. The old per-SDK repositories should be treated as
+archived/legacy mirrors.
 
 ## Official SDKs
 
@@ -16,7 +17,7 @@ Until SDK publishing CI is stable, install server SDKs from local paths in this 
 | Python | `sockudo-http-python` | [Python](/docs/server-sdks/python) |
 | PHP | `sockudo/sockudo-php-server` | [PHP](/docs/server-sdks/php) |
 | Ruby | `sockudo` | [Ruby](/docs/server-sdks/ruby) |
-| Go | `github.com/sockudo/sockudo-http-go/v5` | [Go](/docs/server-sdks/go) |
+| Go | `github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5` | [Go](/docs/server-sdks/go) |
 | Rust | `sockudo-http` | [Rust](/docs/server-sdks/rust) |
 | Java | `io.sockudo:sockudo-http-java` | [Java](/docs/server-sdks/java) |
 | .NET | `SockudoServer` | [.NET](/docs/server-sdks/dotnet) |

--- a/docs/content/docs/server-sdks/swift.mdx
+++ b/docs/content/docs/server-sdks/swift.mdx
@@ -6,14 +6,12 @@ icon: FileCode
 
 ## Install
 
-Clone the monorepo and use a local Swift Package Manager path until package publishing is enabled:
-
 ```swift
-.package(path: "../sockudo/server-sdks/sockudo-http-swift")
+.package(url: "https://github.com/sockudo/sockudo", from: "1.0.0")
 ```
 
 ```swift
-.product(name: "Sockudo", package: "sockudo-http-swift")
+.product(name: "Sockudo", package: "sockudo")
 ```
 
 ## Configure

--- a/docs/sdk-publishing-2026.md
+++ b/docs/sdk-publishing-2026.md
@@ -158,19 +158,29 @@ gh workflow run sdk-release.yml -f package=server-php -f dry_run=true
 
 ### Go Modules
 
-Package: `github.com/sockudo/sockudo-http-go/v5`
+Package: `github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5`
 
-Go modules publish from semantic VCS tags. The current module path points at the legacy package
-repository, so push matching `v5.x.y` tags to that repository or intentionally change the module
-path in a separate breaking change.
+Go modules publish from semantic VCS tags. This monorepo uses a subdirectory module path, so release
+tags must include the module directory prefix:
+
+```bash
+git tag server-sdks/sockudo-http-go/v5.0.0
+git push origin server-sdks/sockudo-http-go/v5.0.0
+```
 
 ### SwiftPM
 
 Packages: `SockudoSwift`, `Sockudo`
 
-SwiftPM packages publish from Git tags on repositories whose root contains `Package.swift`. These
-SDKs currently live under monorepo subdirectories, so publish via package repositories/subtree
-splits or intentionally migrate consumers to a new package URL in a separate breaking change.
+SwiftPM packages publish from Git tags on repositories whose root contains `Package.swift`. The root
+`Package.swift` exposes `SockudoSwift`, `Sockudo`, and the compatibility `Pusher` product from this
+monorepo package URL:
+
+```text
+https://github.com/sockudo/sockudo
+```
+
+SwiftPM consumers only see root SemVer tags, so Swift releases use root tags such as `v1.0.0`.
 
 ## Package Commands
 
@@ -182,16 +192,16 @@ splits or intentionally migrate consumers to a new package URL in a separate bre
 | `sockudo_flutter` | `dart format`, analyze, test, publish dry-run | `client-flutter-vX.Y.Z` |
 | `io.sockudo:sockudo-kotlin` | Gradle check and `publishToMavenLocal` | `client-kotlin-vX.Y.Z` |
 | `sockudo-python` | Ruff format/check, pytest, build, twine check | `client-python-vX.Y.Z` |
-| `SockudoSwift` | Swift build/test and SwiftLint | `client-swift-vX.Y.Z` |
+| `SockudoSwift` | Swift build/test and SwiftLint | `vX.Y.Z` |
 | `sockudo` Node server SDK | npm lint/typecheck/local-test and `npm pack --dry-run` | `server-node-vX.Y.Z` |
 | `sockudo-http-python` | Ruff format/check, pytest, build, twine check | `server-python-vX.Y.Z` |
 | `sockudo/sockudo-php-server` | Composer validate, PHP-CS-Fixer, PHPLint, PHPUnit | `vX.Y.Z` |
 | `sockudo` Ruby gem | RuboCop, RSpec, gem build | `server-ruby-vX.Y.Z` |
-| `github.com/sockudo/sockudo-http-go/v5` | gofmt, go vet, go test | `server-go-vX.Y.Z` |
+| `github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5` | gofmt, go vet, go test | `server-sdks/sockudo-http-go/vX.Y.Z` |
 | `sockudo-http` | cargo fmt, clippy, test, package | `server-rust-vX.Y.Z` |
 | `io.sockudo:sockudo-http-java` | Gradle check and `publishToMavenLocal` | `server-java-vX.Y.Z` |
 | `SockudoServer`, `PusherServer` | `dotnet format`, build, test, pack | `server-dotnet-vX.Y.Z` |
-| `Sockudo` Swift server SDK | Swift build/test and SwiftLint | `server-swift-vX.Y.Z` |
+| `Sockudo` Swift server SDK | Swift build/test and SwiftLint | `vX.Y.Z` |
 
 ## Release Procedure
 

--- a/server-sdks/README.md
+++ b/server-sdks/README.md
@@ -7,20 +7,19 @@ scripts, and issue references recognizable.
 SDK CI and package publishing are managed from the monorepo root through
 `.github/workflows/sdk-ci.yml` and `.github/workflows/sdk-release.yml`. See the
 [2026 SDK publishing runbook](../docs/sdk-publishing-2026.md) before publishing
-or changing registry setup. VCS-tagged ecosystems such as Go modules, SwiftPM,
-and Packagist still require package repository/subtree-split handling unless
-their public package URLs are changed intentionally.
+or changing registry setup. Go modules, SwiftPM, and Packagist now publish from
+this monorepo using their package-manager-native release rules.
 
-## Imports
+## Packages
 
-| Directory | Current source | Legacy repo |
-| --- | --- | --- |
-| `sockudo-http-dotnet` | `server-sdks/sockudo-http-dotnet` | <https://github.com/sockudo/sockudo-http-dotnet> imported at `1132a9b8dfda` |
-| `sockudo-http-go` | `server-sdks/sockudo-http-go` | <https://github.com/sockudo/sockudo-http-go> imported at `7dc33e0c07b6` |
-| `sockudo-http-java` | `server-sdks/sockudo-http-java` | <https://github.com/sockudo/sockudo-http-java> imported at `0d756cc7434d` |
-| `sockudo-http-node` | `server-sdks/sockudo-http-node` | <https://github.com/sockudo/sockudo-http-node> imported at `dd821836f0a4` |
-| `sockudo-http-php` | `server-sdks/sockudo-http-php` | <https://github.com/sockudo/sockudo-http-php> imported at `8c2db8c661b5` |
-| `sockudo-http-python` | `server-sdks/sockudo-http-python` | <https://github.com/sockudo/sockudo-http-python> imported at `3892adefae8f` |
-| `sockudo-http-ruby` | `server-sdks/sockudo-http-ruby` | <https://github.com/sockudo/sockudo-http-ruby> imported at `c57e48a16f85` |
-| `sockudo-http-rust` | `server-sdks/sockudo-http-rust` | <https://github.com/sockudo/sockudo-http-rust> imported at `1e45c001db1e` |
-| `sockudo-http-swift` | `server-sdks/sockudo-http-swift` | <https://github.com/sockudo/sockudo-http-swift> imported at `6f8c710bcd5b` |
+| Package | Directory |
+| --- | --- |
+| `SockudoServer` | `server-sdks/sockudo-http-dotnet` |
+| `github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5` | `server-sdks/sockudo-http-go` |
+| `io.sockudo:sockudo-http-java` | `server-sdks/sockudo-http-java` |
+| `sockudo` | `server-sdks/sockudo-http-node` |
+| `sockudo/sockudo-php-server` | `server-sdks/sockudo-http-php` |
+| `sockudo-http-python` | `server-sdks/sockudo-http-python` |
+| `sockudo` | `server-sdks/sockudo-http-ruby` |
+| `sockudo-http` | `server-sdks/sockudo-http-rust` |
+| `Sockudo` | `server-sdks/sockudo-http-swift` |

--- a/server-sdks/sockudo-http-go/README.md
+++ b/server-sdks/sockudo-http-go/README.md
@@ -28,9 +28,7 @@ Clone the Sockudo monorepo and use a local `replace` until this module is publis
 monorepo:
 
 ```sh
-git clone https://github.com/sockudo/sockudo.git
-go get github.com/sockudo/sockudo-http-go/v5
-go mod edit -replace github.com/sockudo/sockudo-http-go/v5=../sockudo/server-sdks/sockudo-http-go
+go get github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5
 ```
 
 ## Getting Started
@@ -39,7 +37,7 @@ go mod edit -replace github.com/sockudo/sockudo-http-go/v5=../sockudo/server-sdk
 package main
 
 import (
-    sockudo "github.com/sockudo/sockudo-http-go/v5"
+    sockudo "github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5"
 )
 
 func main() {
@@ -341,7 +339,7 @@ import (
     "appengine/urlfetch"
     "fmt"
     "net/http"
-    sockudo "github.com/sockudo/sockudo-http-go/v5"
+    sockudo "github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5"
 )
 
 func init() {

--- a/server-sdks/sockudo-http-go/go.mod
+++ b/server-sdks/sockudo-http-go/go.mod
@@ -1,4 +1,4 @@
-module github.com/sockudo/sockudo-http-go/v5
+module github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v5
 
 go 1.21
 

--- a/server-sdks/sockudo-http-swift/README.md
+++ b/server-sdks/sockudo-http-swift/README.md
@@ -20,7 +20,7 @@ A Swift server SDK for interacting with the [Sockudo](https://github.com/sockudo
 
 ## Installation
 
-For local monorepo development, add it as a path dependency in your `Package.swift` file:
+Use Swift Package Manager with the monorepo package URL:
 
 ```swift
 // swift-tools-version:5.9
@@ -34,21 +34,17 @@ let package = Package(
             targets: ["YourPackage"]),
     ],
     dependencies: [
-        .package(path: "../sockudo/server-sdks/sockudo-http-swift"),
+        .package(url: "https://github.com/sockudo/sockudo", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "YourPackage",
             dependencies: [
-                .product(name: "Sockudo", package: "sockudo-http-swift")
+                .product(name: "Sockudo", package: "sockudo")
             ]),
     ]
 )
 ```
-
-Public SwiftPM distribution requires the package repository or subtree split described in
-`docs/sdk-publishing-2026.md`, because SwiftPM expects `Package.swift` at the package repository
-root.
 
 Then include `import Sockudo` in any source file where you want to use the native Sockudo module.
 
@@ -57,7 +53,7 @@ This package exports both products:
 - `Sockudo`: native Sockudo module and recommended default for new integrations
 - `Pusher`: compatibility module for existing Pusher-shaped integrations
 
-Examples in this README use the native `Sockudo` module. If you are migrating an existing Pusher integration, you can depend on `.product(name: "Pusher", package: "sockudo-http-swift")` and keep `import Pusher`.
+Examples in this README use the native `Sockudo` module. If you are migrating an existing Pusher integration, you can depend on `.product(name: "Pusher", package: "sockudo")` and keep `import Pusher`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- change the Go server SDK module path to the monorepo subdirectory module path
- add a root SwiftPM manifest exposing `SockudoSwift`, `Sockudo`, and compatibility `Pusher` products from this repo
- update release workflow/docs so Go uses subdirectory tags and Swift uses root SemVer tags
- replace legacy SDK repo/path wording with actual package names and install snippets

## Verification
- `test -z "$(gofmt -l .)" && go vet ./... && go test ./... && go list -m all` in `server-sdks/sockudo-http-go`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sdk-release.yml"); puts "workflow yaml ok"'`\n- `actionlint .github/workflows/sdk-release.yml`\n- `npm run types:check` in `docs`\n- `swift package describe >/tmp/sockudo-swift-describe.txt && swift build`\n- `swift package describe >/tmp/sockudo-swift-describe.txt && swift test`