### PR TITLE
Fix Flutter sodium dependency

### DIFF
--- a/client-sdks/sockudo-flutter/lib/src/client.dart
+++ b/client-sdks/sockudo-flutter/lib/src/client.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:sodium/sodium.dart' as sodium;
-import 'package:sodium_libs/sodium_libs.dart';
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/status.dart' as ws_status;
 
@@ -283,7 +282,7 @@ class SockudoClient {
     if (existing != null) {
       return existing;
     }
-    final created = SodiumInit.init();
+    final created = Future<sodium.Sodium>.value(sodium.SodiumInit.init());
     _sodium = created;
     return created;
   }

--- a/client-sdks/sockudo-flutter/pubspec.yaml
+++ b/client-sdks/sockudo-flutter/pubspec.yaml
@@ -25,8 +25,7 @@ dependencies:
   messagepack: ^0.2.1
   meta: ^1.17.0
   protobuf: ^6.0.0
-  sodium: ^3.4.5
-  sodium_libs: ^3.4.5
+  sodium: ^4.0.2+1
   web_socket_channel: ^3.0.3
 
 dev_dependencies:

--- a/client-sdks/sockudo-flutter/test/sockudo_flutter_test.dart
+++ b/client-sdks/sockudo-flutter/test/sockudo_flutter_test.dart
@@ -11,7 +11,6 @@ import 'package:sockudo_flutter/src/delta_compression.dart';
 import 'package:sockudo_flutter/src/fossil_delta.dart';
 import 'package:sockudo_flutter/src/protocol_codec.dart';
 import 'package:sodium/sodium.dart' as sodium;
-import 'package:sodium_libs/sodium_libs.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -635,7 +634,7 @@ void main() {
 
     sodium.Sodium sodiumInstance;
     try {
-      sodiumInstance = await SodiumInit.init();
+      sodiumInstance = await sodium.SodiumInit.init();
     } catch (_) {
       return;
     }


### PR DESCRIPTION
## Summary

- updates the Flutter client from the discontinued `sodium_libs` split package to `sodium` v4 native assets
- removes the stale `sodium_libs` import path and namespaces `SodiumInit` through `package:sodium/sodium.dart`
- keeps encrypted-channel behavior covered by the existing Flutter test suite

## Verification

- `cd client-sdks/sockudo-flutter && flutter pub get`
- `cd client-sdks/sockudo-flutter && dart format --set-exit-if-changed lib test`
- `cd client-sdks/sockudo-flutter && flutter analyze`
- `cd client-sdks/sockudo-flutter && flutter test` using full Xcode path for the `sodium` native asset hook
- `cd client-sdks/sockudo-flutter && flutter pub publish --dry-run`
- `cd client-sdks/sockudo-flutter && dart pub outdated --json` showed no affected advisories, retractions, or discontinued current dependencies

## Notes

The local default `xcode-select` points at CommandLineTools, and `sodium` v4 expects the full Xcode platform SDK layout for macOS native asset builds. Tests pass when the hook sees `/Applications/Xcode.app/Contents/Developer`, which is what the GitHub macOS runner should provide.
