### PR TITLE
docs: use registry installs for SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ SwiftPM packages are published from this monorepo through the root `Package.swif
 | --- | --- |
 | JavaScript / TypeScript | `@sockudo/client` |
 | AI Transport TypeScript | `@sockudo/ai-transport` |
-| Swift / Apple platforms | `SockudoSwift` from `https://github.com/sockudo/sockudo` |
+| Swift / Apple platforms | `SockudoSwift` via SwiftPM (`https://github.com/sockudo/sockudo`) |
 | Kotlin / JVM / Android | `io.sockudo:sockudo-kotlin` |
 | Flutter / Dart | `sockudo_flutter` |
 | .NET | `Sockudo.Client` |
@@ -214,7 +214,7 @@ modules and SwiftPM publish from this monorepo with package-manager-native tags 
 | Rust | `sockudo-http` |
 | Java | `io.sockudo:sockudo-http-java` |
 | .NET | `SockudoServer` |
-| Swift | `Sockudo` from `https://github.com/sockudo/sockudo` |
+| Swift | `Sockudo` via SwiftPM (`https://github.com/sockudo/sockudo`) |
 
 Node.js example:
 

--- a/client-sdks/README.md
+++ b/client-sdks/README.md
@@ -20,4 +20,4 @@ in this monorepo.
 | `@sockudo/client` | `client-sdks/sockudo-js` |
 | `io.sockudo:sockudo-kotlin` | `client-sdks/sockudo-kotlin` |
 | `sockudo-python` | `client-sdks/sockudo-python` |
-| `SockudoSwift` | `client-sdks/sockudo-swift` |
+| `SockudoSwift` via SwiftPM | `client-sdks/sockudo-swift` |

--- a/client-sdks/sockudo-ai-transport-js/README.md
+++ b/client-sdks/sockudo-ai-transport-js/README.md
@@ -15,21 +15,17 @@ For apps, install the published packages:
 pnpm add @sockudo/client @sockudo/ai-transport
 ```
 
-For local monorepo development, build this SDK and `@sockudo/client`, then install them from local
-paths:
+For contributors working inside this repository, build this SDK and `@sockudo/client` from their
+package directories:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-cd sockudo/client-sdks/sockudo-js
+cd client-sdks/sockudo-js
 bun install
 bun run build:all
 
 cd ../sockudo-ai-transport-js
 pnpm install
 pnpm build
-
-# From your app:
-pnpm add ../sockudo/client-sdks/sockudo-js ../sockudo/client-sdks/sockudo-ai-transport-js
 ```
 
 React and Vercel helpers use optional peers:

--- a/client-sdks/sockudo-dotnet/README.md
+++ b/client-sdks/sockudo-dotnet/README.md
@@ -19,17 +19,20 @@ Official .NET client SDK for Sockudo.
 
 ## Installation
 
-Clone the Sockudo monorepo and reference the project directly until the NuGet package is published:
+Install the published NuGet package:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
+dotnet add package Sockudo.Client --version 2.0.0
 ```
+
+Or add it directly to your project file:
 
 ```xml
-<ProjectReference Include="../sockudo/client-sdks/sockudo-dotnet/src/Sockudo.Client/Sockudo.Client.csproj" />
+<PackageReference Include="Sockudo.Client" Version="2.0.0" />
 ```
 
-From this monorepo, use `client-sdks/sockudo-dotnet/src/Sockudo.Client/Sockudo.Client.csproj`.
+For local monorepo development, reference
+`client-sdks/sockudo-dotnet/src/Sockudo.Client/Sockudo.Client.csproj` directly.
 
 ## Quick Start
 

--- a/client-sdks/sockudo-js/README.md
+++ b/client-sdks/sockudo-js/README.md
@@ -19,18 +19,12 @@ npm install @sockudo/client
 # or: pnpm add @sockudo/client
 ```
 
-For local monorepo development, build the SDK, then install it from the local checkout:
+For contributors working inside this repository, build the SDK from its package directory:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-cd sockudo/client-sdks/sockudo-js
+cd client-sdks/sockudo-js
 bun install
 bun run build:all
-
-# From your app:
-npm install ../sockudo/client-sdks/sockudo-js
-# or: bun add ../sockudo/client-sdks/sockudo-js
-# or: pnpm add ../sockudo/client-sdks/sockudo-js
 ```
 
 ## Runtime Imports
@@ -226,7 +220,7 @@ const history = await channel.channelHistory({
 Install the framework peer dependencies:
 
 ```bash
-npm install ../sockudo/client-sdks/sockudo-js react react-dom
+npm install @sockudo/client react react-dom
 ```
 
 ```ts
@@ -274,7 +268,7 @@ Available React exports:
 Install the framework peer dependency:
 
 ```bash
-npm install ../sockudo/client-sdks/sockudo-js vue
+npm install @sockudo/client vue
 ```
 
 ```ts
@@ -326,7 +320,7 @@ Available Vue exports:
 - Install the NativeScript websocket polyfill:
 
 ```bash
-npm install ../sockudo/client-sdks/sockudo-js @valor/nativescript-websockets
+npm install @sockudo/client @valor/nativescript-websockets
 ```
 
 - Import `@sockudo/client/nativescript` to automatically load the websocket polyfill before the SDK.

--- a/client-sdks/sockudo-kotlin/README.md
+++ b/client-sdks/sockudo-kotlin/README.md
@@ -16,24 +16,29 @@ Official Kotlin client for Sockudo.
 - User sign-in and watchlist event handling
 - Continuity-aware connection recovery and subscribe-time rewind on Protocol V2
 - Live integration tests against Sockudo on `127.0.0.1:6001`
-- Gradle CI and planned Maven publication workflow
+- Gradle CI and Maven Central publication workflow
 
 ## Installation
 
-Clone the Sockudo monorepo and publish the SDK to your local Maven repository until the package is
-published:
-
-```bash
-git clone https://github.com/sockudo/sockudo.git
-cd sockudo/client-sdks/sockudo-kotlin
-./gradlew :lib:publishToMavenLocal
-```
+Install the published package from Maven Central:
 
 ```kotlin
 dependencies {
     implementation("io.sockudo:sockudo-kotlin:2.0.0")
 }
 ```
+
+For Maven projects:
+
+```xml
+<dependency>
+  <groupId>io.sockudo</groupId>
+  <artifactId>sockudo-kotlin</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
+For local monorepo development, run `./gradlew :lib:publishToMavenLocal` from this directory.
 
 ## Quick Start
 

--- a/client-sdks/sockudo-python/README.md
+++ b/client-sdks/sockudo-python/README.md
@@ -24,17 +24,10 @@ For apps, install the published package:
 pip install sockudo-python
 ```
 
-For local monorepo development, install from the local path:
+For contributors working inside this repository:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-pip install -e sockudo/client-sdks/sockudo-python
-```
-
-Using `requirements.txt` for local development:
-
-```
--e ../sockudo/client-sdks/sockudo-python
+pip install -e client-sdks/sockudo-python
 ```
 
 Using `pyproject.toml` for local development:

--- a/client-sdks/sockudo-swift/README.md
+++ b/client-sdks/sockudo-swift/README.md
@@ -311,7 +311,7 @@ Swift packages are distributed by git tag rather than a central package registry
 
 - CI: root workflow `.github/workflows/sdk-ci.yml`
 - Release gate: root workflow `.github/workflows/sdk-release.yml` with root tag `vX.Y.Z`
-- Distribution: root `Package.swift` from `https://github.com/sockudo/sockudo`
+- Distribution: SwiftPM package in the root `Package.swift`
 
 ## Status
 

--- a/docs/content/docs/clients/dotnet.mdx
+++ b/docs/content/docs/clients/dotnet.mdx
@@ -8,17 +8,18 @@ icon: MonitorSmartphone
 
 ## Install
 
-Clone the monorepo and reference the project directly until the NuGet package is published:
+Install the published NuGet package:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
+dotnet add package Sockudo.Client --version 2.0.0
 ```
+
+Or add it directly to your project file:
 
 ```xml
-<ProjectReference Include="../sockudo/client-sdks/sockudo-dotnet/src/Sockudo.Client/Sockudo.Client.csproj" />
+<PackageReference Include="Sockudo.Client" Version="2.0.0" />
 ```
 
-From this monorepo, use `client-sdks/sockudo-dotnet/src/Sockudo.Client/Sockudo.Client.csproj`.
 ## Connect
 
 ```csharp

--- a/docs/content/docs/clients/flutter.mdx
+++ b/docs/content/docs/clients/flutter.mdx
@@ -8,12 +8,12 @@ icon: Smartphone
 
 ## Install
 
-Clone the monorepo and use a local path dependency until the package is published on `pub.dev`:
+Install the published package from `pub.dev`:
 
-```yaml
-dependencies:
-  sockudo_flutter:
-    path: ../sockudo/client-sdks/sockudo-flutter
+```bash
+flutter pub add sockudo_flutter
+# or, for pure Dart apps:
+dart pub add sockudo_flutter
 ```
 
 ```dart

--- a/docs/content/docs/clients/index.mdx
+++ b/docs/content/docs/clients/index.mdx
@@ -14,7 +14,7 @@ archived/legacy mirrors.
 | SDK | Package | Runtime | Default |
 | --- | --- | --- | --- |
 | JavaScript / TypeScript | `@sockudo/client` | Web, Node, worker, React, Vue, React Native, NativeScript | Protocol V1 compatibility |
-| Swift | `SockudoSwift` | iOS, macOS, tvOS, watchOS, visionOS | Protocol V1 compatibility |
+| Swift | `SockudoSwift` via SwiftPM | iOS, macOS, tvOS, watchOS, visionOS | Protocol V1 compatibility |
 | Kotlin | `io.sockudo:sockudo-kotlin` | Android and JVM | Protocol V1 compatibility |
 | Flutter / Dart | `sockudo_flutter` | Flutter and Dart | Protocol V1 compatibility |
 | .NET realtime | `Sockudo.Client` | .NET apps | Protocol V2 by default |

--- a/docs/content/docs/clients/javascript.mdx
+++ b/docs/content/docs/clients/javascript.mdx
@@ -8,21 +8,14 @@ icon: Braces
 
 ## Install
 
-Clone the monorepo, build the SDK, then install it from the local checkout until npm publishing is enabled:
+Install the published package from npm:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-cd sockudo/client-sdks/sockudo-js
-bun install
-bun run build:all
-
-# From your app:
-npm install ../sockudo/client-sdks/sockudo-js
-# or: bun add ../sockudo/client-sdks/sockudo-js
-# or: pnpm add ../sockudo/client-sdks/sockudo-js
+npm install @sockudo/client
+# or: bun add @sockudo/client
+# or: pnpm add @sockudo/client
+# or: yarn add @sockudo/client
 ```
-
-The package will be installable as `@sockudo/client` once package publishing is enabled.
 
 ## Runtime imports
 

--- a/docs/content/docs/clients/kotlin.mdx
+++ b/docs/content/docs/clients/kotlin.mdx
@@ -8,18 +8,22 @@ icon: Smartphone
 
 ## Install
 
-Clone the monorepo and publish the SDK to your local Maven repository until the package is published:
-
-```bash
-git clone https://github.com/sockudo/sockudo.git
-cd sockudo/client-sdks/sockudo-kotlin
-./gradlew :lib:publishToMavenLocal
-```
+Install the published package from Maven Central:
 
 ```kotlin
 dependencies {
-    implementation("io.sockudo:sockudo-kotlin:0.1.0")
+    implementation("io.sockudo:sockudo-kotlin:2.0.0")
 }
+```
+
+For Maven projects:
+
+```xml
+<dependency>
+  <groupId>io.sockudo</groupId>
+  <artifactId>sockudo-kotlin</artifactId>
+  <version>2.0.0</version>
+</dependency>
 ```
 
 ## Connect

--- a/docs/content/docs/clients/swift.mdx
+++ b/docs/content/docs/clients/swift.mdx
@@ -8,8 +8,11 @@ icon: Smartphone
 
 ## Install
 
+Install through Swift Package Manager from the Sockudo monorepo package. SwiftPM resolves this from
+the `v2.0.0` Git tag and the root `Package.swift` manifest:
+
 ```swift
-.package(url: "https://github.com/sockudo/sockudo", from: "1.0.0")
+.package(url: "https://github.com/sockudo/sockudo", from: "2.0.0")
 ```
 
 ```swift

--- a/docs/content/docs/server-sdks/dotnet.mdx
+++ b/docs/content/docs/server-sdks/dotnet.mdx
@@ -6,17 +6,18 @@ icon: FileCode
 
 ## Install
 
-Clone the monorepo and reference the project directly until the NuGet package is published:
+Install the published NuGet package:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
+dotnet add package SockudoServer --version 2.0.0
 ```
+
+Or add it directly to your project file:
 
 ```xml
-<ProjectReference Include="../sockudo/server-sdks/sockudo-http-dotnet/SockudoServer/SockudoServer.csproj" />
+<PackageReference Include="SockudoServer" Version="2.0.0" />
 ```
 
-From this monorepo, use `server-sdks/sockudo-http-dotnet/SockudoServer/SockudoServer.csproj`.
 ## Configure
 
 ```csharp

--- a/docs/content/docs/server-sdks/go.mdx
+++ b/docs/content/docs/server-sdks/go.mdx
@@ -6,6 +6,8 @@ icon: FileCode
 
 ## Install
 
+Install the v2 Go module. Go resolves this package through the module path and the `v2.0.0` Git tag:
+
 ```bash
 go get github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v2
 ```

--- a/docs/content/docs/server-sdks/index.mdx
+++ b/docs/content/docs/server-sdks/index.mdx
@@ -21,7 +21,7 @@ archived/legacy mirrors.
 | Rust | `sockudo-http` | [Rust](/docs/server-sdks/rust) |
 | Java | `io.sockudo:sockudo-http-java` | [Java](/docs/server-sdks/java) |
 | .NET | `SockudoServer` | [.NET](/docs/server-sdks/dotnet) |
-| Swift | `Sockudo` | [Swift](/docs/server-sdks/swift) |
+| Swift | `Sockudo` via SwiftPM | [Swift](/docs/server-sdks/swift) |
 
 ## What belongs on the server
 

--- a/docs/content/docs/server-sdks/java.mdx
+++ b/docs/content/docs/server-sdks/java.mdx
@@ -6,24 +6,18 @@ icon: FileCode
 
 ## Install
 
-Clone the monorepo and publish the SDK to your local Maven repository until the package is published:
-
-```bash
-git clone https://github.com/sockudo/sockudo.git
-cd sockudo/server-sdks/sockudo-http-java
-./gradlew publishToMavenLocal
-```
+Install the published package from Maven Central:
 
 ```xml
 <dependency>
   <groupId>io.sockudo</groupId>
   <artifactId>sockudo-http-java</artifactId>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 
 ```kotlin
-implementation("io.sockudo:sockudo-http-java:1.0.0")
+implementation("io.sockudo:sockudo-http-java:2.0.0")
 ```
 
 ## Configure

--- a/docs/content/docs/server-sdks/node.mdx
+++ b/docs/content/docs/server-sdks/node.mdx
@@ -6,21 +6,14 @@ icon: FileCode
 
 ## Install
 
-Clone the monorepo, build the SDK, then install it from the local checkout until npm publishing is enabled:
+Install the published package from npm:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-cd sockudo/server-sdks/sockudo-http-node
-npm install
-npm run build
-
-# From your app:
-npm install ../sockudo/server-sdks/sockudo-http-node
-# or: bun add ../sockudo/server-sdks/sockudo-http-node
-# or: pnpm add ../sockudo/server-sdks/sockudo-http-node
+npm install sockudo
+# or: bun add sockudo
+# or: pnpm add sockudo
+# or: yarn add sockudo
 ```
-
-The package will be installable as `sockudo` once package publishing is enabled.
 
 ## Configure
 

--- a/docs/content/docs/server-sdks/php.mdx
+++ b/docs/content/docs/server-sdks/php.mdx
@@ -6,12 +6,8 @@ icon: FileCode
 
 ## Install
 
-Clone the monorepo and configure Composer to read the local package path until the package is published on Packagist:
-
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-composer config repositories.sockudo-php-server path ../sockudo/server-sdks/sockudo-http-php
-composer require sockudo/sockudo-php-server:dev-main
+composer require sockudo/sockudo-php-server:^2.0
 ```
 
 ## Configure

--- a/docs/content/docs/server-sdks/python.mdx
+++ b/docs/content/docs/server-sdks/python.mdx
@@ -7,11 +7,8 @@ icon: FileCode
 ## Install
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-pip install -e sockudo/server-sdks/sockudo-http-python
+pip install sockudo-http-python
 ```
-
-From this monorepo, use `pip install -e server-sdks/sockudo-http-python`.
 
 ## Configure
 

--- a/docs/content/docs/server-sdks/ruby.mdx
+++ b/docs/content/docs/server-sdks/ruby.mdx
@@ -7,11 +7,17 @@ icon: FileCode
 ## Install
 
 ```ruby
-gem "sockudo", path: "../sockudo/server-sdks/sockudo-http-ruby"
+gem "sockudo", "~> 2.0"
 ```
 
 ```bash
 bundle install
+```
+
+For one-off scripts, install the gem directly:
+
+```bash
+gem install sockudo -v "~> 2.0"
 ```
 
 ## Configure

--- a/docs/content/docs/server-sdks/rust.mdx
+++ b/docs/content/docs/server-sdks/rust.mdx
@@ -8,12 +8,10 @@ icon: FileCode
 
 ```toml
 [dependencies]
-sockudo-http = { path = "../sockudo/server-sdks/sockudo-http-rust" }
+sockudo-http = "2.0.0"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```
-
-From this monorepo, use `sockudo-http = { path = "server-sdks/sockudo-http-rust" }`.
 
 ## Configure
 

--- a/docs/content/docs/server-sdks/swift.mdx
+++ b/docs/content/docs/server-sdks/swift.mdx
@@ -6,8 +6,11 @@ icon: FileCode
 
 ## Install
 
+Install through Swift Package Manager from the Sockudo monorepo package. SwiftPM resolves this from
+the `v2.0.0` Git tag and the root `Package.swift` manifest:
+
 ```swift
-.package(url: "https://github.com/sockudo/sockudo", from: "1.0.0")
+.package(url: "https://github.com/sockudo/sockudo", from: "2.0.0")
 ```
 
 ```swift

--- a/server-sdks/README.md
+++ b/server-sdks/README.md
@@ -22,4 +22,4 @@ this monorepo using their package-manager-native release rules.
 | `sockudo-http-python` | `server-sdks/sockudo-http-python` |
 | `sockudo` | `server-sdks/sockudo-http-ruby` |
 | `sockudo-http` | `server-sdks/sockudo-http-rust` |
-| `Sockudo` | `server-sdks/sockudo-http-swift` |
+| `Sockudo` via SwiftPM | `server-sdks/sockudo-http-swift` |

--- a/server-sdks/sockudo-http-dotnet/README.md
+++ b/server-sdks/sockudo-http-dotnet/README.md
@@ -32,17 +32,20 @@ A .NET server SDK for interacting with the [Sockudo](https://github.com/sockudo/
 
 ## Installation
 
-Clone the Sockudo monorepo and reference the project directly until the NuGet package is published:
+Install the published NuGet package:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
+dotnet add package SockudoServer --version 2.0.0
 ```
+
+Or add it directly to your project file:
 
 ```xml
-<ProjectReference Include="../sockudo/server-sdks/sockudo-http-dotnet/SockudoServer/SockudoServer.csproj" />
+<PackageReference Include="SockudoServer" Version="2.0.0" />
 ```
 
-From this monorepo, use `server-sdks/sockudo-http-dotnet/SockudoServer/SockudoServer.csproj`.
+For local monorepo development, reference
+`server-sdks/sockudo-http-dotnet/SockudoServer/SockudoServer.csproj` directly.
 
 ## Getting started
 

--- a/server-sdks/sockudo-http-go/README.md
+++ b/server-sdks/sockudo-http-go/README.md
@@ -24,8 +24,7 @@ Official Go server SDK for [Sockudo](https://github.com/sockudo/sockudo) — a f
 
 ## Installation
 
-Clone the Sockudo monorepo and use a local `replace` until this module is published from the
-monorepo:
+Install the v2 Go module. Go resolves this package through the module path and the `v2.0.0` Git tag:
 
 ```sh
 go get github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v2

--- a/server-sdks/sockudo-http-java/README.md
+++ b/server-sdks/sockudo-http-java/README.md
@@ -10,14 +10,7 @@ A Java server SDK for interacting with the [Sockudo](https://github.com/sockudo/
 
 ## Installation
 
-Clone the Sockudo monorepo and publish the SDK to your local Maven repository until the package is
-published:
-
-```bash
-git clone https://github.com/sockudo/sockudo.git
-cd sockudo/server-sdks/sockudo-http-java
-./gradlew publishToMavenLocal
-```
+Install the published package from Maven Central:
 
 ### Maven
 
@@ -34,6 +27,8 @@ cd sockudo/server-sdks/sockudo-http-java
 ```kotlin
 implementation("io.sockudo:sockudo-http-java:2.0.0")
 ```
+
+For local monorepo development, run `./gradlew publishToMavenLocal` from this directory.
 
 ## Synchronous vs asynchronous
 

--- a/server-sdks/sockudo-http-node/README.md
+++ b/server-sdks/sockudo-http-node/README.md
@@ -16,18 +16,12 @@ npm install sockudo
 # or: bun add sockudo
 ```
 
-For local monorepo development, build the SDK, then install it from the local checkout:
+For contributors working inside this repository, build the SDK from its package directory:
 
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-cd sockudo/server-sdks/sockudo-http-node
+cd server-sdks/sockudo-http-node
 npm install
 npm run build
-
-# From your app:
-npm install ../sockudo/server-sdks/sockudo-http-node
-# or: yarn add ../sockudo/server-sdks/sockudo-http-node
-# or: bun add ../sockudo/server-sdks/sockudo-http-node
 ```
 
 ## Importing

--- a/server-sdks/sockudo-http-php/README.md
+++ b/server-sdks/sockudo-http-php/README.md
@@ -10,16 +10,11 @@ Official PHP server SDK for [Sockudo](https://github.com/sockudo/sockudo) — a 
 
 ## Installation
 
-Clone the Sockudo monorepo and configure Composer to read the local package path until the package
-is published on Packagist:
-
 ```bash
-git clone https://github.com/sockudo/sockudo.git
-composer config repositories.sockudo-php-server path ../sockudo/server-sdks/sockudo-http-php
-composer require sockudo/sockudo-php-server:dev-main
+composer require sockudo/sockudo-php-server:^2.0
 ```
 
-Or add to `composer.json`:
+For local monorepo development, add a path repository to `composer.json`:
 
 ```json
 {
@@ -30,12 +25,12 @@ Or add to `composer.json`:
         }
     ],
     "require": {
-        "sockudo/sockudo-php-server": "dev-main"
+        "sockudo/sockudo-php-server": "*"
     }
 }
 ```
 
-Then run `composer update`.
+Then run `composer update sockudo/sockudo-php-server`.
 
 ## Constructor
 

--- a/server-sdks/sockudo-http-python/README.md
+++ b/server-sdks/sockudo-http-python/README.md
@@ -24,14 +24,7 @@ For apps, install the published package:
 pip install sockudo-http-python
 ```
 
-For local monorepo development, install from the local path:
-
-```bash
-git clone https://github.com/sockudo/sockudo.git
-pip install -e sockudo/server-sdks/sockudo-http-python
-```
-
-For local development from this monorepo:
+For contributors working inside this repository:
 
 ```bash
 pip install -e server-sdks/sockudo-http-python[dev]

--- a/server-sdks/sockudo-http-rust/README.md
+++ b/server-sdks/sockudo-http-rust/README.md
@@ -23,16 +23,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sockudo-http = { path = "../sockudo/server-sdks/sockudo-http-rust" }
-sonic-rs = "0.5"
-tokio = { version = "1", features = ["full"] }
-```
-
-If your application lives inside this monorepo, use:
-
-```toml
-[dependencies]
-sockudo-http = { path = "server-sdks/sockudo-http-rust" }
+sockudo-http = "2.0.0"
 sonic-rs = "0.5"
 tokio = { version = "1", features = ["full"] }
 ```


### PR DESCRIPTION
## Summary

- Replace local clone/path install guidance in public SDK docs with registry-native install commands for npm, NuGet, pub.dev, Maven Central, Packagist, RubyGems, crates.io, PyPI, Go modules, and SwiftPM.
- Clarify that Go and Swift still use package-manager-native Git-tag based distribution through the module path / SwiftPM package manifest.
- Align SDK README install sections with the docs site and keep local monorepo guidance scoped to contributor workflows.

## Verification

- `git diff --check`
- `cd docs && npm run types:check`
- `cd docs && npm run build`

Note: `next build` passed with the existing workspace-root warning about multiple lockfiles.