### PR TITLE
fix: multijson deprecation warning in sockudo-http-ruby

### DIFF
--- a/server-sdks/sockudo-http-ruby/lib/sockudo/channel.rb
+++ b/server-sdks/sockudo-http-ruby/lib/sockudo/channel.rb
@@ -230,7 +230,7 @@ module Sockudo
     # @private Custom data is sent to server as JSON-encoded string
     #
     def authenticate(socket_id, custom_data = nil)
-      custom_data = MultiJson.encode(custom_data) if custom_data
+      custom_data = MultiJson.dump(custom_data) if custom_data
       auth = authentication_string(socket_id, custom_data)
       r = { auth: auth }
       r[:channel_data] = custom_data if custom_data

--- a/server-sdks/sockudo-http-ruby/lib/sockudo/client.rb
+++ b/server-sdks/sockudo-http-ruby/lib/sockudo/client.rb
@@ -593,7 +593,7 @@ module Sockudo
     def authenticate_user(socket_id, user_data)
       validate_user_data(user_data)
 
-      custom_data = MultiJson.encode(user_data)
+      custom_data = MultiJson.dump(user_data)
       auth = authentication_string(socket_id, custom_data)
 
       { auth: auth, user_data: custom_data }
@@ -729,7 +729,7 @@ module Sockudo
     def encode_data(data)
       return data if data.is_a? String
 
-      MultiJson.encode(data)
+      MultiJson.dump(data)
     end
 
     # Encrypts a message with a key derived from the master key and channel
@@ -748,10 +748,10 @@ module Sockudo
       nonce = RbNaCl::Random.random_bytes(secret_box.nonce_bytes)
       ciphertext = secret_box.encrypt(nonce, encoded_data)
 
-      MultiJson.encode({
-                         'nonce' => Base64.strict_encode64(nonce),
-                         'ciphertext' => Base64.strict_encode64(ciphertext)
-                       })
+      MultiJson.dump({
+                       'nonce' => Base64.strict_encode64(nonce),
+                       'ciphertext' => Base64.strict_encode64(ciphertext)
+                     })
     end
 
     def configured?

--- a/server-sdks/sockudo-http-ruby/lib/sockudo/request.rb
+++ b/server-sdks/sockudo-http-ruby/lib/sockudo/request.rb
@@ -105,9 +105,9 @@ module Sockudo
     def handle_response(status_code, body)
       case status_code
       when 200, 201
-        symbolize_first_level(MultiJson.decode(body))
+        symbolize_first_level(MultiJson.load(body))
       when 202
-        body.empty? || symbolize_first_level(MultiJson.decode(body))
+        body.empty? || symbolize_first_level(MultiJson.load(body))
       when 204
         {}
       when 400

--- a/server-sdks/sockudo-http-ruby/lib/sockudo/resource.rb
+++ b/server-sdks/sockudo-http-ruby/lib/sockudo/resource.rb
@@ -16,12 +16,12 @@ module Sockudo
     end
 
     def post(params, headers = {})
-      body = MultiJson.encode(params)
+      body = MultiJson.dump(params)
       create_request(:post, {}, body, headers).send_sync
     end
 
     def post_async(params, headers = {})
-      body = MultiJson.encode(params)
+      body = MultiJson.dump(params)
       create_request(:post, {}, body, headers).send_async
     end
 

--- a/server-sdks/sockudo-http-ruby/lib/sockudo/webhook.rb
+++ b/server-sdks/sockudo-http-ruby/lib/sockudo/webhook.rb
@@ -88,7 +88,7 @@ module Sockudo
     def data
       @data ||= case @content_type
                 when 'application/json'
-                  MultiJson.decode(@body)
+                  MultiJson.load(@body)
                 else
                   raise "Unknown Content-Type (#{@content_type})"
                 end

--- a/server-sdks/sockudo-http-ruby/sockudo.gemspec
+++ b/server-sdks/sockudo-http-ruby/sockudo.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'httpclient', '~> 2.8'
   s.add_dependency 'jruby-openssl' if defined?(JRUBY_VERSION)
   s.add_dependency 'logger', '~> 1.7'
-  s.add_dependency 'multi_json', '~> 1.15'
+  s.add_dependency 'multi_json', '~> 1.21.1'
   s.add_dependency 'pusher-signature', '~> 0.1.8'
 
   s.add_development_dependency 'addressable', '~> 2.7'

--- a/server-sdks/sockudo-http-ruby/spec/channel_spec.rb
+++ b/server-sdks/sockudo-http-ruby/spec/channel_spec.rb
@@ -127,10 +127,6 @@ describe Sockudo::Channel do
   end
 
   describe '#authentication_string' do
-    def authentication_string(*data)
-      -> { @channel.authentication_string(*data) }
-    end
-
     it 'should return an authentication string given a socket id' do
       auth = @channel.authentication_string('1.1')
 
@@ -139,17 +135,17 @@ describe Sockudo::Channel do
 
     it 'should raise error if authentication is invalid' do
       [nil, ''].each do |invalid|
-        expect(authentication_string(invalid)).to raise_error Sockudo::Error
+        expect { @channel.authentication_string(invalid) }.to raise_error Sockudo::Error
       end
     end
 
     describe 'with extra string argument' do
       it 'should be a string or nil' do
-        expect(authentication_string('1.1', 123)).to raise_error Sockudo::Error
-        expect(authentication_string('1.1', {})).to raise_error Sockudo::Error
+        expect { @channel.authentication_string('1.1', 123) }.to raise_error Sockudo::Error
+        expect { @channel.authentication_string('1.1', {}) }.to raise_error Sockudo::Error
 
-        expect(authentication_string('1.1', 'boom')).not_to raise_error
-        expect(authentication_string('1.1', nil)).not_to raise_error
+        expect { @channel.authentication_string('1.1', 'boom') }.not_to raise_error
+        expect { @channel.authentication_string('1.1', nil) }.not_to raise_error
       end
 
       it 'should return an authentication string given a socket id and custom args' do
@@ -166,7 +162,7 @@ describe Sockudo::Channel do
     end
 
     it 'should return a hash with signature including custom data and data as json string' do
-      allow(MultiJson).to receive(:encode).with(@custom_data).and_return 'a json string'
+      allow(MultiJson).to receive(:dump).with(@custom_data).and_return 'a json string'
 
       response = @channel.authenticate('1.1', @custom_data)
 

--- a/server-sdks/sockudo-http-ruby/spec/client_spec.rb
+++ b/server-sdks/sockudo-http-ruby/spec/client_spec.rb
@@ -236,10 +236,10 @@ describe Sockudo do
           api_path = %r{/apps/20/channels}
           stub_request(:get, api_path).to_return({
                                                    status: 200,
-                                                   body: MultiJson.encode('channels' => {
-                                                                            'channel1' => {},
-                                                                            'channel2' => {}
-                                                                          })
+                                                   body: MultiJson.dump('channels' => {
+                                                                          'channel1' => {},
+                                                                          'channel2' => {}
+                                                                        })
                                                  })
           expect(@client.channels).to eq({
                                            channels: {
@@ -255,9 +255,9 @@ describe Sockudo do
           api_path = %r{/apps/20/channels/mychannel}
           stub_request(:get, api_path).to_return({
                                                    status: 200,
-                                                   body: MultiJson.encode({
-                                                                            'occupied' => false
-                                                                          })
+                                                   body: MultiJson.dump({
+                                                                          'occupied' => false
+                                                                        })
                                                  })
           expect(@client.channel_info('mychannel')).to eq({
                                                             occupied: false
@@ -270,9 +270,9 @@ describe Sockudo do
           api_path = %r{/apps/20/channels/mychannel/users}
           stub_request(:get, api_path).to_return({
                                                    status: 200,
-                                                   body: MultiJson.encode({
-                                                                            'users' => [{ 'id' => 1 }]
-                                                                          })
+                                                   body: MultiJson.dump({
+                                                                          'users' => [{ 'id' => 1 }]
+                                                                        })
                                                  })
           expect(@client.channel_users('mychannel')).to eq({
                                                              users: [{ id: 1 }]
@@ -290,13 +290,13 @@ describe Sockudo do
             )
           ).to_return({
                         status: 200,
-                        body: MultiJson.encode({
-                                                 'items' => [
-                                                   { 'serial' => 2 },
-                                                   { 'serial' => 1 }
-                                                 ],
-                                                 'has_more' => false
-                                               })
+                        body: MultiJson.dump({
+                                               'items' => [
+                                                 { 'serial' => 2 },
+                                                 { 'serial' => 1 }
+                                               ],
+                                               'has_more' => false
+                                             })
                       })
 
           expect(@client.channel_history('mychannel', direction: 'newest_first', limit: 2)).to eq({
@@ -319,13 +319,13 @@ describe Sockudo do
             )
           ).to_return({
                         status: 200,
-                        body: MultiJson.encode({
-                                                 'items' => [
-                                                   { 'serial' => 2, 'event' => 'member_removed' },
-                                                   { 'serial' => 1, 'event' => 'member_added' }
-                                                 ],
-                                                 'has_more' => false
-                                               })
+                        body: MultiJson.dump({
+                                               'items' => [
+                                                 { 'serial' => 2, 'event' => 'member_removed' },
+                                                 { 'serial' => 1, 'event' => 'member_added' }
+                                               ],
+                                               'has_more' => false
+                                             })
                       })
 
           expect(@client.channel_presence_history('presence-mychannel', direction: 'newest_first', limit: 2)).to eq({
@@ -351,11 +351,11 @@ describe Sockudo do
             )
           ).to_return({
                         status: 200,
-                        body: MultiJson.encode({
-                                                 'channel' => 'presence-mychannel',
-                                                 'members' => [{ 'user_id' => 'u-1' }],
-                                                 'member_count' => 1
-                                               })
+                        body: MultiJson.dump({
+                                               'channel' => 'presence-mychannel',
+                                               'members' => [{ 'user_id' => 'u-1' }],
+                                               'member_count' => 1
+                                             })
                       })
 
           expect(@client.channel_presence_snapshot('presence-mychannel', at_serial: 4)).to eq({
@@ -371,10 +371,10 @@ describe Sockudo do
           api_path = %r{/apps/20/push/deviceRegistrations}
           stub_request(:post, api_path).to_return({
                                                     status: 201,
-                                                    body: MultiJson.encode({
-                                                                             'change' => 'inserted',
-                                                                             'deviceIdentityToken' => 'identity'
-                                                                           })
+                                                    body: MultiJson.dump({
+                                                                           'change' => 'inserted',
+                                                                           'deviceIdentityToken' => 'identity'
+                                                                         })
                                                   })
 
           expect(@client.activate_device({
@@ -387,7 +387,7 @@ describe Sockudo do
                                                                                        })
 
           expect(WebMock).to(have_requested(:post, api_path).with do |req|
-            parsed = MultiJson.decode(req.body)
+            parsed = MultiJson.load(req.body)
             expect(parsed['id']).to eq('device-1')
             expect(req.headers['X-Sockudo-Push-Capability']).to eq('push-admin')
             expect(req.headers['X-Sockudo-Rotate-Device-Identity-Token']).to eq('true')
@@ -400,11 +400,11 @@ describe Sockudo do
           api_path = %r{/apps/20/push/deviceRegistrations}
           stub_request(:get, api_path).to_return({
                                                    status: 200,
-                                                   body: MultiJson.encode({
-                                                                            'items' => [],
-                                                                            'has_more' => false,
-                                                                            'next_cursor' => nil
-                                                                          })
+                                                   body: MultiJson.dump({
+                                                                          'items' => [],
+                                                                          'has_more' => false,
+                                                                          'next_cursor' => nil
+                                                                        })
                                                  })
 
           expect(@client.list_device_registrations(limit: 10, cursor: 'c1')).to eq({
@@ -426,11 +426,11 @@ describe Sockudo do
           api_path = %r{/apps/20/push/channelSubscriptions}
           stub_request(:get, api_path).to_return({
                                                    status: 200,
-                                                   body: MultiJson.encode({
-                                                                            'items' => [],
-                                                                            'has_more' => false,
-                                                                            'next_cursor' => nil
-                                                                          })
+                                                   body: MultiJson.dump({
+                                                                          'items' => [],
+                                                                          'has_more' => false,
+                                                                          'next_cursor' => nil
+                                                                        })
                                                  })
 
           expect(@client.list_channel_push_subscriptions({
@@ -457,10 +457,10 @@ describe Sockudo do
           api_path = %r{/apps/20/push/publish}
           stub_request(:post, api_path).to_return({
                                                     status: 202,
-                                                    body: MultiJson.encode({
-                                                                             'publish_id' => 'pub_123',
-                                                                             'status' => 'queued'
-                                                                           })
+                                                    body: MultiJson.dump({
+                                                                           'publish_id' => 'pub_123',
+                                                                           'status' => 'queued'
+                                                                         })
                                                   })
 
           expect(@client.publish_push({
@@ -473,7 +473,7 @@ describe Sockudo do
                                                 })
 
           expect(WebMock).to(have_requested(:post, api_path).with do |req|
-            parsed = MultiJson.decode(req.body)
+            parsed = MultiJson.load(req.body)
             expect(parsed['sync']).to eq(false)
             expect(parsed['providerOverrides'][0]['provider']).to eq('fcm')
             expect(req.headers['X-Sockudo-Push-Capability']).to eq('push-admin')
@@ -498,7 +498,7 @@ describe Sockudo do
         end
 
         it 'should return a hash with signature including custom data and data as json string' do
-          allow(MultiJson).to receive(:encode).with(@custom_data).and_return 'a json string'
+          allow(MultiJson).to receive(:dump).with(@custom_data).and_return 'a json string'
 
           response = @client.authenticate('test_channel', '1.1', @custom_data)
 
@@ -509,7 +509,7 @@ describe Sockudo do
         end
 
         it 'should include a shared_secret if the private-encrypted channel' do
-          allow(MultiJson).to receive(:encode).with(@custom_data).and_return 'a json string'
+          allow(MultiJson).to receive(:dump).with(@custom_data).and_return 'a json string'
           @client.instance_variable_set(:@encryption_master_key, '3W1pfB/Etr+ZIlfMWwZP3gz8jEeCt4s2pe6Vpr+2c3M=')
 
           response = @client.authenticate('private-encrypted-test_channel', '1.1', @custom_data)
@@ -529,7 +529,7 @@ describe Sockudo do
         end
 
         it 'should return a hash with signature including custom data and data as json string' do
-          allow(MultiJson).to receive(:encode).with(@user_data).and_return 'a json string'
+          allow(MultiJson).to receive(:dump).with(@user_data).and_return 'a json string'
 
           response = @client.authenticate_user('1.1', @user_data)
 
@@ -545,7 +545,7 @@ describe Sockudo do
           @api_path = %r{/apps/20/events}
           stub_request(:post, @api_path).to_return({
                                                      status: 200,
-                                                     body: MultiJson.encode({})
+                                                     body: MultiJson.dump({})
                                                    })
         end
 
@@ -568,7 +568,7 @@ describe Sockudo do
                             socket_id: '12.34'
                           })
           expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-            parsed = MultiJson.decode(req.body)
+            parsed = MultiJson.load(req.body)
             expect(parsed['name']).to eq('event')
             expect(parsed['channels']).to eq(%w[mychannel c2])
             expect(parsed['socket_id']).to eq('12.34')
@@ -578,14 +578,14 @@ describe Sockudo do
         it 'should convert non string data to JSON before posting' do
           @client.trigger(['mychannel'], 'event', { 'some' => 'data' })
           expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-            expect(MultiJson.decode(req.body)['data']).to eq('{"some":"data"}')
+            expect(MultiJson.load(req.body)['data']).to eq('{"some":"data"}')
           end)
         end
 
         it 'should accept a single channel as well as an array' do
           @client.trigger('mychannel', 'event', { 'some' => 'data' })
           expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-            expect(MultiJson.decode(req.body)['channels']).to eq(['mychannel'])
+            expect(MultiJson.load(req.body)['channels']).to eq(['mychannel'])
           end)
         end
 
@@ -596,7 +596,7 @@ describe Sockudo do
               @client.trigger('mychannel', 'event', { 'some' => 'data' })
             end.to raise_error(Sockudo::ConfigurationError)
             expect(WebMock).not_to(have_requested(:post, @api_path).with do |req|
-              expect(MultiJson.decode(req.body)['channels']).to eq(['mychannel'])
+              expect(MultiJson.load(req.body)['channels']).to eq(['mychannel'])
             end)
           end
         end
@@ -628,16 +628,16 @@ describe Sockudo do
           )
 
           expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-            data = MultiJson.decode(MultiJson.decode(req.body)['data'])
+            data = MultiJson.load(MultiJson.load(req.body)['data'])
 
             key = RbNaCl::Hash.sha256(
               "private-encrypted-channel#{encryption_master_key}"
             )
 
-            expect(MultiJson.decode(RbNaCl::SecretBox.new(key).decrypt(
-                                      Base64.strict_decode64(data['nonce']),
-                                      Base64.strict_decode64(data['ciphertext'])
-                                    ))).to eq({ 'some' => 'data' })
+            expect(MultiJson.load(RbNaCl::SecretBox.new(key).decrypt(
+                                    Base64.strict_decode64(data['nonce']),
+                                    Base64.strict_decode64(data['ciphertext'])
+                                  ))).to eq({ 'some' => 'data' })
           end)
         end
 
@@ -646,7 +646,7 @@ describe Sockudo do
                             idempotency_key: 'test-key-123'
                           })
           expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-            parsed = MultiJson.decode(req.body)
+            parsed = MultiJson.load(req.body)
             expect(parsed['idempotency_key']).to eq('test-key-123')
             expect(req.headers['X-Idempotency-Key']).to eq('test-key-123')
           end)
@@ -655,7 +655,7 @@ describe Sockudo do
         it 'should auto-generate idempotency_key when not provided' do
           @client.trigger('mychannel', 'event', { 'some' => 'data' })
           expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-            parsed = MultiJson.decode(req.body)
+            parsed = MultiJson.load(req.body)
             expect(parsed['idempotency_key']).to match(/\A[\w-]+:\d+\z/)
             expect(req.headers['X-Idempotency-Key']).to eq(parsed['idempotency_key'])
           end)
@@ -667,7 +667,7 @@ describe Sockudo do
           @api_path = %r{/apps/20/batch_events}
           stub_request(:post, @api_path).to_return({
                                                      status: 200,
-                                                     body: MultiJson.encode({})
+                                                     body: MultiJson.dump({})
                                                    })
         end
 
@@ -682,7 +682,7 @@ describe Sockudo do
             { channel: 'mychannel', name: 'event', data: 'already encoded' }
           )
           expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-            parsed = MultiJson.decode(req.body)
+            parsed = MultiJson.load(req.body)
             batch = parsed['batch']
             expect(batch[0]['channel']).to eq('mychannel')
             expect(batch[0]['name']).to eq('event')
@@ -721,22 +721,22 @@ describe Sockudo do
           )
 
           expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-            batch = MultiJson.decode(req.body)['batch']
+            batch = MultiJson.load(req.body)['batch']
             expect(batch.length).to eq(2)
 
             expect(batch[0]['channel']).to eq('private-encrypted-channel')
             expect(batch[0]['name']).to eq('event')
 
-            data = MultiJson.decode(batch[0]['data'])
+            data = MultiJson.load(batch[0]['data'])
 
             key = RbNaCl::Hash.sha256(
               "private-encrypted-channel#{encryption_master_key}"
             )
 
-            expect(MultiJson.decode(RbNaCl::SecretBox.new(key).decrypt(
-                                      Base64.strict_decode64(data['nonce']),
-                                      Base64.strict_decode64(data['ciphertext'])
-                                    ))).to eq({ 'some' => 'data' })
+            expect(MultiJson.load(RbNaCl::SecretBox.new(key).decrypt(
+                                    Base64.strict_decode64(data['nonce']),
+                                    Base64.strict_decode64(data['ciphertext'])
+                                  ))).to eq({ 'some' => 'data' })
 
             expect(batch[1]['channel']).to eq('mychannel')
             expect(batch[1]['name']).to eq('event')
@@ -750,7 +750,7 @@ describe Sockudo do
             { channel: 'mychannel', name: 'event2', data: 'bar' }
           )
           expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-            batch = MultiJson.decode(req.body)['batch']
+            batch = MultiJson.load(req.body)['batch']
             expect(batch[0]['idempotency_key']).to eq('key-1')
             expect(batch[1]['idempotency_key']).to match(/\A[\w-]+:\d+:1\z/)
           end)
@@ -762,7 +762,7 @@ describe Sockudo do
           @api_path = %r{/apps/20/events}
           stub_request(:post, @api_path).to_return({
                                                      status: 200,
-                                                     body: MultiJson.encode({})
+                                                     body: MultiJson.dump({})
                                                    })
         end
 
@@ -781,7 +781,7 @@ describe Sockudo do
                                     socket_id: '12.34'
                                   }).callback do
               expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-                expect(MultiJson.decode(req.body)['socket_id']).to eq('12.34')
+                expect(MultiJson.load(req.body)['socket_id']).to eq('12.34')
               end)
               EM.stop
             end
@@ -792,7 +792,7 @@ describe Sockudo do
           EM.run do
             @client.trigger_async('mychannel', 'event', { 'some' => 'data' }).callback do
               expect(WebMock).to(have_requested(:post, @api_path).with do |req|
-                expect(MultiJson.decode(req.body)['data']).to eq('{"some":"data"}')
+                expect(MultiJson.load(req.body)['data']).to eq('{"some":"data"}')
               end)
               EM.stop
             end
@@ -824,7 +824,7 @@ describe Sockudo do
           it 'should format the respose hash with symbols at first level' do
             stub_request(verb, @url_regexp).to_return({
                                                         status: 200,
-                                                        body: MultiJson.encode({ 'something' => { 'a' => 'hash' } })
+                                                        body: MultiJson.dump({ 'something' => { 'a' => 'hash' } })
                                                       })
             expect(call_api).to eq({
                                      something: { a: 'hash' }
@@ -953,7 +953,7 @@ describe Sockudo do
               EM.run do
                 stub_request(verb, @url_regexp).to_return({
                                                             status: 200,
-                                                            body: MultiJson.encode({ 'something' => { 'a' => 'hash' } })
+                                                            body: MultiJson.dump({ 'something' => { 'a' => 'hash' } })
                                                           })
                 call_api.callback do |response|
                   expect(response).to eq({

--- a/server-sdks/sockudo-http-ruby/spec/web_hook_spec.rb
+++ b/server-sdks/sockudo-http-ruby/spec/web_hook_spec.rb
@@ -21,7 +21,7 @@ describe Sockudo::WebHook do
                                     'HTTP_X_PUSHER_KEY' => '1234',
                                     'HTTP_X_PUSHER_SIGNATURE' => 'asdf',
                                     'CONTENT_TYPE' => 'application/json',
-                                    'rack.input' => StringIO.new(MultiJson.encode(@hook_data))
+                                    'rack.input' => StringIO.new(MultiJson.dump(@hook_data))
                                   })
       wh = Sockudo::WebHook.new(request)
       expect(wh.key).to eq('1234')
@@ -34,7 +34,7 @@ describe Sockudo::WebHook do
         key: '1234',
         signature: 'asdf',
         content_type: 'application/json',
-        body: MultiJson.encode(@hook_data)
+        body: MultiJson.dump(@hook_data)
       }
       wh = Sockudo::WebHook.new(request)
       expect(wh.key).to eq('1234')
@@ -45,7 +45,7 @@ describe Sockudo::WebHook do
 
   describe 'after initialization' do
     before :each do
-      @body = MultiJson.encode(@hook_data)
+      @body = MultiJson.dump(@hook_data)
       request = {
         key: '1234',
         signature: hmac('asdf', @body),


### PR DESCRIPTION
## Description

Fix mulijson and rspec warnings

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
