### PR TITLE
fix: prevent active_channels gauge from drifting negative under churn

### DIFF
--- a/crates/sockudo-adapter/src/channel_manager.rs
+++ b/crates/sockudo-adapter/src/channel_manager.rs
@@ -18,6 +18,7 @@ struct ChannelLeave {
     channel_name: String,
     app_id: String,
     was_removed: bool,
+    local_vacated: bool,
     local_remaining: usize,
 }
 
@@ -54,6 +55,9 @@ pub struct LeaveResponse {
     pub(crate) left: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remaining_connections: Option<usize>,
+    /// Last local socket left the channel. Don't derive this from a count read.
+    #[serde(default)]
+    pub vacated_locally: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member: Option<PresenceMember>,
 }
@@ -101,11 +105,13 @@ impl ChannelManager {
     fn create_leave_response(
         left: bool,
         remaining_connections: usize,
+        vacated_locally: bool,
         member: Option<PresenceMember>,
     ) -> LeaveResponse {
         LeaveResponse {
             left,
             remaining_connections: Some(remaining_connections),
+            vacated_locally,
             member,
         }
     }
@@ -144,11 +150,10 @@ impl ChannelManager {
         // of the subscribe hot path; callers that need them can query after the
         // client acknowledgement has been sent.
         let t_before_lock = t_start.elapsed().as_micros();
-        let (newly_subscribed, local_connections) = connection_manager
+        let (newly_subscribed, activated_locally, local_connections) = connection_manager
             .add_to_channel_and_count_local(app_id, channel_name, &socket_id_owned)
             .await?;
         let is_already_in_channel = !newly_subscribed;
-        let activated_locally = newly_subscribed && local_connections == 1;
         let t_after_lock = t_start.elapsed().as_micros();
 
         if is_already_in_channel {
@@ -245,10 +250,12 @@ impl ChannelManager {
             None
         };
 
-        let (socket_removed, local_remaining) = connection_manager
+        let (socket_removed, vacated, local_remaining) = connection_manager
             .remove_from_channel_and_count_local(app_id, channel_name, &socket_id_owned)
             .await?;
 
+        // Clears the channel's filter index and prunes the empty namespace, which
+        // remove_from_channel does not do.
         if local_remaining == 0 {
             connection_manager
                 .remove_channel(app_id, channel_name)
@@ -258,6 +265,7 @@ impl ChannelManager {
         Ok(Self::create_leave_response(
             socket_removed,
             local_remaining,
+            vacated,
             member,
         ))
     }
@@ -292,8 +300,8 @@ impl ChannelManager {
         };
 
         // Remove socket and handle cleanup atomically
-        let (socket_removed, remaining_connections) = {
-            let socket_removed = connection_manager
+        let (socket_removed, vacated, remaining_connections) = {
+            let (socket_removed, vacated) = connection_manager
                 .remove_from_channel(app_id, channel_name, &socket_id_owned)
                 .await?;
 
@@ -308,12 +316,13 @@ impl ChannelManager {
                     .await;
             }
 
-            (socket_removed, remaining)
+            (socket_removed, vacated, remaining)
         };
 
         Ok(Self::create_leave_response(
             socket_removed,
             remaining_connections,
+            vacated,
             member,
         ))
     }
@@ -555,7 +564,7 @@ impl ChannelManager {
                 .remove_from_channel(app_id, channel_name, &socket_id_owned)
                 .await
             {
-                Ok(was_removed) => {
+                Ok((was_removed, local_vacated)) => {
                     let local_remaining = connection_manager
                         .get_local_channel_socket_count(app_id, channel_name)
                         .await;
@@ -563,6 +572,7 @@ impl ChannelManager {
                         channel_name: channel_name.clone(),
                         app_id: app_id.clone(),
                         was_removed,
+                        local_vacated,
                         local_remaining,
                     }));
                 }
@@ -619,6 +629,7 @@ impl ChannelManager {
                     channel_name,
                     app_id,
                     was_removed,
+                    local_vacated,
                     local_remaining,
                 }) => {
                     let remote = remote_counts
@@ -629,7 +640,6 @@ impl ChannelManager {
                     if total == 0 {
                         channels_to_cleanup.push((app_id, channel_name.clone()));
                     }
-                    let local_vacated = was_removed && local_remaining == 0;
                     results.push((channel_name, Ok((was_removed, total, local_vacated))));
                 }
                 Err((channel_name, e)) => {

--- a/crates/sockudo-adapter/src/connection_manager.rs
+++ b/crates/sockudo-adapter/src/connection_manager.rs
@@ -156,32 +156,32 @@ pub trait ConnectionManager: Send + Sync {
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Result<bool>;
+    ) -> Result<(bool, bool)>;
     async fn add_to_channel_and_count_local(
         &self,
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Result<(bool, usize)> {
-        let added = self.add_to_channel(app_id, channel, socket_id).await?;
+    ) -> Result<(bool, bool, usize)> {
+        let (newly_inserted, activated) = self.add_to_channel(app_id, channel, socket_id).await?;
         let count = self.get_local_channel_socket_count(app_id, channel).await;
-        Ok((added, count))
+        Ok((newly_inserted, activated, count))
     }
     async fn remove_from_channel(
         &self,
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Result<bool>;
+    ) -> Result<(bool, bool)>;
     async fn remove_from_channel_and_count_local(
         &self,
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Result<(bool, usize)> {
-        let removed = self.remove_from_channel(app_id, channel, socket_id).await?;
+    ) -> Result<(bool, bool, usize)> {
+        let (was_removed, vacated) = self.remove_from_channel(app_id, channel, socket_id).await?;
         let count = self.get_local_channel_socket_count(app_id, channel).await;
-        Ok((removed, count))
+        Ok((was_removed, vacated, count))
     }
     async fn get_presence_member(
         &self,

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -92,12 +92,9 @@ impl ConnectionHandler {
                 metrics.mark_channel_unsubscription(&app_config.id, channel_type_str);
             }
 
-            // Per-pod gauge: deactivate when the channel empties on this node, not cluster-wide.
-            let local_sub_count = self
-                .connection_manager
-                .get_local_channel_socket_count(&app_config.id, &channel_name)
-                .await;
-            if leave_response.left && local_sub_count == 0 {
+            // Per-pod gauge: deactivate on the transition from unsubscribe_local,
+            // not a separate count read.
+            if leave_response.vacated_locally {
                 metrics.mark_channel_deactivated(&app_config.id, channel_type_str);
             }
         }

--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -49,7 +49,7 @@ use sockudo_ws::Message;
 use sockudo_ws::axum_integration::{WebSocket, WebSocketReader, WebSocketWriter};
 use sonic_rs::Value;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, AtomicUsize};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
 use tokio::sync::Semaphore;
 use tracing::{debug, error, warn};
 
@@ -92,6 +92,9 @@ pub struct ConnectionHandler {
     #[cfg(feature = "recovery")]
     /// Replay buffer for connection recovery (enabled via config)
     pub(crate) replay_buffer: Option<Arc<crate::replay_buffer::ReplayBuffer>>,
+    /// Shared with the server runtime. Flipped to false on shutdown so the handler
+    /// stops accepting new connections and `/up` reports draining.
+    running: Arc<AtomicBool>,
 }
 
 /// Builder for constructing a `ConnectionHandler` without feature-gated function parameters.
@@ -110,6 +113,7 @@ pub struct ConnectionHandlerBuilder {
     cleanup_queue: Option<crate::cleanup::CleanupSender>,
     #[cfg(feature = "delta")]
     delta_compression: Option<Arc<sockudo_delta::DeltaCompressionManager>>,
+    running: Option<Arc<AtomicBool>>,
 }
 
 impl ConnectionHandlerBuilder {
@@ -134,6 +138,7 @@ impl ConnectionHandlerBuilder {
             cleanup_queue: None,
             #[cfg(feature = "delta")]
             delta_compression: None,
+            running: None,
         }
     }
 
@@ -180,6 +185,11 @@ impl ConnectionHandlerBuilder {
 
     pub fn cleanup_queue(mut self, queue: crate::cleanup::CleanupSender) -> Self {
         self.cleanup_queue = Some(queue);
+        self
+    }
+
+    pub fn running(mut self, running: Arc<AtomicBool>) -> Self {
+        self.running = Some(running);
         self
     }
 
@@ -279,6 +289,9 @@ impl ConnectionHandlerBuilder {
             presence_manager: Arc::new(PresenceManager::new()),
             #[cfg(feature = "recovery")]
             replay_buffer,
+            running: self
+                .running
+                .unwrap_or_else(|| Arc::new(AtomicBool::new(true))),
         };
 
         #[cfg(feature = "ai-transport")]
@@ -385,6 +398,12 @@ impl ConnectionHandler {
             cache_manager,
             server_options,
         )
+    }
+
+    /// Whether the server is still accepting new connections. Returns false once
+    /// shutdown has flipped the shared running flag, signalling drain.
+    pub fn is_accepting(&self) -> bool {
+        self.running.load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Get a reference to the presence manager
@@ -550,62 +569,63 @@ impl ConnectionHandler {
         )
         .await?;
 
-        // Setup rate limiting if needed
-        self.setup_rate_limiting(&socket_id, &app_config).await?;
-        self.setup_message_rate_limiting(&socket_id, &app_config)
-            .await?;
+        // Wrapped in an async block so any early return still reaches cleanup_socket below.
+        let result = async {
+            // Setup rate limiting if needed
+            self.setup_rate_limiting(&socket_id, &app_config).await?;
+            self.setup_message_rate_limiting(&socket_id, &app_config)
+                .await?;
 
-        if let Some(token) = initial_token.as_deref() {
-            let auth_result = async {
-                if protocol_version != ProtocolVersion::V2 {
-                    return Err(Error::Auth(
-                        "capability tokens require protocol V2".to_string(),
-                    ));
+            if let Some(token) = initial_token.as_deref() {
+                let auth_result = async {
+                    if protocol_version != ProtocolVersion::V2 {
+                        return Err(Error::Auth(
+                            "capability tokens require protocol V2".to_string(),
+                        ));
+                    }
+                    let context = self.validate_connection_token(&app_config, token).await?;
+                    self.apply_connection_token(&socket_id, &app_config, context, false)
+                        .await
                 }
-                let context = self.validate_connection_token(&app_config, token).await?;
-                self.apply_connection_token(&socket_id, &app_config, context, false)
-                    .await
-            }
-            .await;
+                .await;
 
-            if let Err(error) = auth_result {
-                let _ = self
-                    .send_error(&app_config.id, &socket_id, &error, None)
-                    .await;
-                let _ = self
-                    .close_connection(
-                        &socket_id,
-                        &app_config,
-                        error.close_code(),
-                        &error.to_string(),
-                    )
-                    .await;
-                self.cleanup_socket(&socket_id, &app_config).await;
-                return Err(error);
+                if let Err(error) = auth_result {
+                    let _ = self
+                        .send_error(&app_config.id, &socket_id, &error, None)
+                        .await;
+                    let _ = self
+                        .close_connection(
+                            &socket_id,
+                            &app_config,
+                            error.close_code(),
+                            &error.to_string(),
+                        )
+                        .await;
+                    return Err(error);
+                }
             }
+
+            // Get the cancellation token so the reader loop can be cancelled
+            // when the connection is cleaned up (e.g., ghost connection timeout)
+            let shutdown_token = self
+                .connection_manager
+                .get_connection(&socket_id, &app_config.id)
+                .await
+                .map(|conn| conn.cancellation_token());
+
+            // Send connection established
+            self.send_connection_established(&app_config.id, &socket_id)
+                .await?;
+
+            // Setup timeouts
+            self.setup_initial_timeouts(&socket_id, &app_config).await?;
+
+            // Main message loop
+            self.run_message_loop(socket_rx, &socket_id, &app_config, shutdown_token)
+                .await
         }
+        .await;
 
-        // Get the cancellation token so the reader loop can be cancelled
-        // when the connection is cleaned up (e.g., ghost connection timeout)
-        let shutdown_token = self
-            .connection_manager
-            .get_connection(&socket_id, &app_config.id)
-            .await
-            .map(|conn| conn.cancellation_token());
-
-        // Send connection established
-        self.send_connection_established(&app_config.id, &socket_id)
-            .await?;
-
-        // Setup timeouts
-        self.setup_initial_timeouts(&socket_id, &app_config).await?;
-
-        // Main message loop
-        let result = self
-            .run_message_loop(socket_rx, &socket_id, &app_config, shutdown_token)
-            .await;
-
-        // Cleanup
         self.cleanup_socket(&socket_id, &app_config).await;
 
         result
@@ -642,7 +662,9 @@ impl ConnectionHandler {
                 }
             }
 
-            // Remove any existing connection with the same socket_id (should be rare)
+            // Remove any existing connection with the same socket_id (should be rare).
+            // Balance the unconditional mark_new_connection below for the replaced
+            // socket, otherwise the gauge leaks.
             if let Some(conn) = self
                 .connection_manager
                 .get_connection(&socket_id, &app_config.id)
@@ -651,6 +673,9 @@ impl ConnectionHandler {
                 self.connection_manager
                     .cleanup_connection(&app_config.id, conn)
                     .await;
+                if let Some(ref metrics) = self.metrics {
+                    metrics.mark_disconnection(&app_config.id, &socket_id);
+                }
             }
 
             // Add the new socket - this must be in the same critical section as quota check

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -104,7 +104,7 @@ impl ConnectionHandler {
                 }
 
                 match fast_result {
-                    Some((channel_connections, newly_subscribed)) => {
+                    Some((channel_connections, _newly_subscribed, activated_locally)) => {
                         let t_after_fast = t_start.elapsed().as_micros();
                         tracing::debug!(
                             "PERF[FAST_PATH] socket_id={} channel={} total={}μs channel_type={}μs",
@@ -116,8 +116,7 @@ impl ConnectionHandler {
                         JoinResponse {
                             success: true,
                             channel_connections: Some(channel_connections),
-                            // Fast path is local-only, so this is the local count.
-                            activated_locally: newly_subscribed && channel_connections == 1,
+                            activated_locally,
                             member: None,
                             auth_error: None,
                             error_message: None,

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
@@ -547,7 +547,7 @@ where
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Result<bool> {
+    ) -> Result<(bool, bool)> {
         // Fast path: direct local adapter access without locking horizontal
         self.local_adapter
             .add_to_channel(app_id, channel, socket_id)
@@ -559,7 +559,7 @@ where
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Result<bool> {
+    ) -> Result<(bool, bool)> {
         // Fast path: direct local adapter access without locking horizontal
         self.local_adapter
             .remove_from_channel(app_id, channel, socket_id)

--- a/crates/sockudo-adapter/src/local_adapter/broadcast.rs
+++ b/crates/sockudo-adapter/src/local_adapter/broadcast.rs
@@ -1152,14 +1152,14 @@ impl LocalAdapter {
     /// Returns Some(connection_count) if successful, None if socket not found or already in channel
     /// Fast-path channel join for the local adapter.
     ///
-    /// Returns `(socket_count, newly_subscribed)`, where `newly_subscribed` is
-    /// `false` when the socket was already in the channel.
+    /// `activated` reports the first socket joining the channel. Do not re-derive
+    /// it from `socket_count`.
     pub fn join_channel_fast(
         &self,
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Option<(usize, bool)> {
+    ) -> Option<(usize, bool, bool)> {
         let t_start = std::time::Instant::now();
 
         // Get namespace (read-only operation on DashMap)
@@ -1195,16 +1195,16 @@ impl LocalAdapter {
                 t_before_count - t_before_chan_check,
                 t_after_count - t_before_count
             );
-            return Some((count, false));
+            return Some((count, false, false));
         }
         let t_after_chan_check = t_start.elapsed().as_nanos();
 
         // Atomically add socket to channel
         let t_before_add = t_start.elapsed().as_nanos();
-        let newly_subscribed = namespace.add_channel_to_socket(channel, socket_id);
+        let (newly_subscribed, activated) = namespace.add_channel_to_socket(channel, socket_id);
         let t_after_add = t_start.elapsed().as_nanos();
 
-        // Return the new connection count
+        // Connection count is a separate read for the ack, not the gauge.
         let t_before_count = t_start.elapsed().as_nanos();
         let count = namespace.get_channel_socket_count(channel);
         let t_after_count = t_start.elapsed().as_nanos();
@@ -1221,6 +1221,6 @@ impl LocalAdapter {
             t_after_count - t_before_count
         );
 
-        Some((count, newly_subscribed))
+        Some((count, newly_subscribed, activated))
     }
 }

--- a/crates/sockudo-adapter/src/local_adapter/connection_manager.rs
+++ b/crates/sockudo-adapter/src/local_adapter/connection_manager.rs
@@ -447,7 +447,7 @@ impl ConnectionManager for LocalAdapter {
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Result<bool> {
+    ) -> Result<(bool, bool)> {
         let t_start = std::time::Instant::now();
         let t_before_ns = t_start.elapsed().as_micros();
         let namespace = self.get_or_create_namespace(app_id).await;
@@ -474,7 +474,7 @@ impl ConnectionManager for LocalAdapter {
         app_id: &str,
         channel: &str,
         socket_id: &SocketId,
-    ) -> Result<bool> {
+    ) -> Result<(bool, bool)> {
         let namespace = self.get_or_create_namespace(app_id).await;
 
         // Clean up the filter index even if the socket was already removed

--- a/crates/sockudo-adapter/src/presence.rs
+++ b/crates/sockudo-adapter/src/presence.rs
@@ -1227,16 +1227,16 @@ mod tests {
             _app_id: &str,
             _channel: &str,
             _socket_id: &SocketId,
-        ) -> Result<bool> {
-            Ok(false)
+        ) -> Result<(bool, bool)> {
+            Ok((false, false))
         }
         async fn remove_from_channel(
             &self,
             _app_id: &str,
             _channel: &str,
             _socket_id: &SocketId,
-        ) -> Result<bool> {
-            Ok(false)
+        ) -> Result<(bool, bool)> {
+            Ok((false, false))
         }
         async fn get_presence_member(
             &self,

--- a/crates/sockudo-adapter/tests/adapter/active_channels_gauge_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/active_channels_gauge_tests.rs
@@ -79,21 +79,21 @@ async fn join_channel_fast_reports_transition_only_on_first_join() {
     let first = adapter.join_channel_fast(APP_ID, channel, &socket_id);
     assert_eq!(
         first,
-        Some((1, true)),
+        Some((1, true, true)),
         "first join is a genuine 0->1 transition"
     );
 
     let second = adapter.join_channel_fast(APP_ID, channel, &socket_id);
     assert_eq!(
         second,
-        Some((1, false)),
+        Some((1, false, false)),
         "re-subscribe must not report a new transition"
     );
 
     let third = adapter.join_channel_fast(APP_ID, channel, &socket_id);
     assert_eq!(
         third,
-        Some((1, false)),
+        Some((1, false, false)),
         "repeated re-subscribes stay non-transitional"
     );
 }

--- a/crates/sockudo-adapter/tests/adapter/connected_gauge_regression_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/connected_gauge_regression_tests.rs
@@ -1,0 +1,598 @@
+// Regression tests for the `sockudo_connected` gauge: every mark_new_connection
+// must be balanced by a mark_disconnection, and a draining node must stop
+// accepting connections. handle_socket and initialize_socket_with_quota_check
+// are private/need a live socket, so most tests drive the same public calls the
+// fixed paths use and assert on CountingMetrics.
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use ahash::AHashMap;
+use async_trait::async_trait;
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::connection_manager::{ChannelSocketCount, HorizontalAdapterInterface};
+use sockudo_adapter::handler::ConnectionHandler;
+use sockudo_adapter::local_adapter::LocalAdapter;
+use sockudo_app::memory_app_manager::MemoryAppManager;
+use sockudo_core::app::{App, AppLimitsPolicy, AppManager, AppPolicy};
+use sockudo_core::cache::CacheManager;
+use sockudo_core::channel::PresenceMemberInfo;
+use sockudo_core::error::{Error, Result};
+use sockudo_core::metrics::MetricsInterface;
+use sockudo_core::namespace::Namespace;
+use sockudo_core::options::ServerOptions;
+use sockudo_core::websocket::{SocketId, WebSocketBufferConfig, WebSocketRef};
+use sockudo_protocol::messages::PusherMessage;
+use sockudo_protocol::{ProtocolVersion, WireFormat};
+use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, Stream as WsStream, WebSocketStream};
+use sonic_rs::Value;
+use std::any::Any;
+use std::time::Duration;
+use tokio::net::{TcpListener, TcpStream};
+
+// Counts only the two calls that move the `sockudo_connected` gauge.
+struct CountingMetrics {
+    new_connections: AtomicUsize,
+    disconnections: AtomicUsize,
+}
+
+impl CountingMetrics {
+    fn new() -> Self {
+        Self {
+            new_connections: AtomicUsize::new(0),
+            disconnections: AtomicUsize::new(0),
+        }
+    }
+
+    fn new_connections(&self) -> usize {
+        self.new_connections.load(Ordering::SeqCst)
+    }
+
+    fn disconnections(&self) -> usize {
+        self.disconnections.load(Ordering::SeqCst)
+    }
+
+    fn net(&self) -> i64 {
+        self.new_connections.load(Ordering::SeqCst) as i64
+            - self.disconnections.load(Ordering::SeqCst) as i64
+    }
+}
+
+#[async_trait]
+impl MetricsInterface for CountingMetrics {
+    async fn init(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn mark_new_connection(&self, _app_id: &str, _socket_id: &SocketId) {
+        self.new_connections.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn mark_disconnection(&self, _app_id: &str, _socket_id: &SocketId) {
+        self.disconnections.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn mark_connection_error(&self, _: &str, _: &str) {}
+    fn mark_rate_limit_check(&self, _: &str, _: &str) {}
+    fn mark_rate_limit_check_with_context(&self, _: &str, _: &str, _: &str) {}
+    fn mark_rate_limit_triggered(&self, _: &str, _: &str) {}
+    fn mark_rate_limit_triggered_with_context(&self, _: &str, _: &str, _: &str) {}
+    fn mark_channel_subscription(&self, _: &str, _: &str) {}
+    fn mark_channel_unsubscription(&self, _: &str, _: &str) {}
+    fn mark_api_message(&self, _: &str, _: usize, _: usize) {}
+    fn mark_ws_message_sent(&self, _: &str, _: usize) {}
+    fn mark_ws_messages_sent_batch(&self, _: &str, _: usize, _: usize) {}
+    fn mark_ws_message_received(&self, _: &str, _: usize) {}
+    fn track_horizontal_adapter_resolve_time(&self, _: &str, _: f64) {}
+    fn track_horizontal_adapter_resolved_promises(&self, _: &str, _: bool) {}
+    fn mark_horizontal_adapter_request_sent(&self, _: &str) {}
+    fn mark_horizontal_adapter_request_received(&self, _: &str) {}
+    fn mark_horizontal_adapter_response_received(&self, _: &str) {}
+    fn track_broadcast_latency(&self, _: &str, _: &str, _: usize, _: f64) {}
+    fn track_horizontal_delta_compression(&self, _: &str, _: &str, _: bool) {}
+    fn track_delta_compression_bandwidth(&self, _: &str, _: &str, _: usize, _: usize) {}
+    fn track_delta_compression_full_message(&self, _: &str, _: &str) {}
+    fn track_delta_compression_delta_message(&self, _: &str, _: &str) {}
+
+    async fn get_metrics_as_plaintext(&self) -> String {
+        String::new()
+    }
+
+    async fn get_metrics_as_json(&self) -> Value {
+        sonic_rs::json!({})
+    }
+
+    async fn clear(&self) {}
+}
+
+// Reports a fixed socket count so the quota check rejects before mark_new_connection.
+#[derive(Clone)]
+struct FullCapacityAdapter {
+    reported_count: usize,
+}
+
+impl FullCapacityAdapter {
+    fn with_count(n: usize) -> Self {
+        Self { reported_count: n }
+    }
+}
+
+#[async_trait]
+impl ConnectionManager for FullCapacityAdapter {
+    async fn init(&self) {}
+    async fn get_namespace(&self, _: &str) -> Option<Arc<Namespace>> {
+        None
+    }
+    async fn add_socket(
+        &self,
+        _: SocketId,
+        _: WebSocketWriter,
+        _: &str,
+        _: Arc<dyn AppManager + Send + Sync>,
+        _: WebSocketBufferConfig,
+        _: ProtocolVersion,
+        _: WireFormat,
+        _: bool,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn get_connection(&self, _: &SocketId, _: &str) -> Option<WebSocketRef> {
+        None
+    }
+    async fn remove_connection(&self, _: &SocketId, _: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn send_message(&self, _: &str, _: &SocketId, _: PusherMessage) -> Result<()> {
+        Ok(())
+    }
+    async fn send(
+        &self,
+        _: &str,
+        _: PusherMessage,
+        _: Option<&SocketId>,
+        _: &str,
+        _: Option<f64>,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn get_channel_members(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<AHashMap<String, PresenceMemberInfo>> {
+        Ok(AHashMap::new())
+    }
+    async fn get_channel_sockets(&self, _: &str, _: &str) -> Result<Vec<SocketId>> {
+        Ok(Vec::new())
+    }
+    async fn remove_channel(&self, _: &str, _: &str) {}
+    async fn is_in_channel(&self, _: &str, _: &str, _: &SocketId) -> Result<bool> {
+        Ok(false)
+    }
+    async fn get_user_sockets(&self, _: &str, _: &str) -> Result<Vec<WebSocketRef>> {
+        Ok(Vec::new())
+    }
+    async fn cleanup_connection(&self, _: &str, _: WebSocketRef) {}
+    async fn terminate_connection(&self, _: &str, _: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn add_channel_to_sockets(&self, _: &str, _: &str, _: &SocketId) {}
+    async fn get_channel_socket_count_info(&self, _: &str, _: &str) -> ChannelSocketCount {
+        ChannelSocketCount {
+            count: 0,
+            complete: true,
+        }
+    }
+    async fn get_channel_socket_count(&self, _: &str, _: &str) -> usize {
+        0
+    }
+    async fn add_to_channel(&self, _: &str, _: &str, _: &SocketId) -> Result<(bool, bool)> {
+        Ok((false, false))
+    }
+    async fn remove_from_channel(&self, _: &str, _: &str, _: &SocketId) -> Result<(bool, bool)> {
+        Ok((false, false))
+    }
+    async fn get_presence_member(
+        &self,
+        _: &str,
+        _: &str,
+        _: &SocketId,
+    ) -> Option<PresenceMemberInfo> {
+        None
+    }
+    async fn terminate_user_connections(&self, _: &str, _: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn add_user(&self, _: WebSocketRef) -> Result<()> {
+        Ok(())
+    }
+    async fn remove_user(&self, _: WebSocketRef) -> Result<()> {
+        Ok(())
+    }
+    async fn get_channels_with_socket_count(&self, _: &str) -> Result<AHashMap<String, usize>> {
+        Ok(AHashMap::new())
+    }
+    async fn get_sockets_count(&self, _: &str) -> Result<usize> {
+        Ok(self.reported_count)
+    }
+    async fn get_namespaces(&self) -> Result<Vec<(String, Arc<Namespace>)>> {
+        Ok(Vec::new())
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    async fn remove_user_socket(&self, _: &str, _: &SocketId, _: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn count_user_connections_in_channel(
+        &self,
+        _: &str,
+        _: &str,
+        _: &str,
+        _: Option<&SocketId>,
+    ) -> Result<usize> {
+        Ok(0)
+    }
+    async fn check_health(&self) -> Result<()> {
+        Ok(())
+    }
+    fn get_node_id(&self) -> String {
+        "test-node".to_string()
+    }
+    fn as_horizontal_adapter(&self) -> Option<&dyn HorizontalAdapterInterface> {
+        None
+    }
+}
+
+struct NullCacheManager;
+
+#[async_trait]
+impl CacheManager for NullCacheManager {
+    async fn has(&self, _: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn get(&self, _: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+    async fn set(&self, _: &str, _: &str, _: u64) -> Result<()> {
+        Ok(())
+    }
+    async fn remove(&self, _: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn disconnect(&self) -> Result<()> {
+        Ok(())
+    }
+    async fn ttl(&self, _: &str) -> Result<Option<Duration>> {
+        Ok(None)
+    }
+    async fn check_health(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+const APP_ID: &str = "gauge-test-app";
+const APP_KEY: &str = "gauge-test-key";
+
+fn make_app(max_connections: u32) -> App {
+    App::from_policy(
+        APP_ID.to_string(),
+        APP_KEY.to_string(),
+        "secret".to_string(),
+        true,
+        AppPolicy {
+            limits: AppLimitsPolicy {
+                max_connections,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+}
+
+async fn make_ws_pair() -> (WebSocketWriter, WebSocketStream<WsStream<Http1>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server_task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (client_ws, _): (WebSocketStream<WsStream<Http1>>, _) = client
+        .connect(client_stream, &addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    let server_writer = server_task.await.unwrap();
+    (server_writer, client_ws)
+}
+
+async fn make_full_ws_pair() -> (WebSocket, WebSocketStream<WsStream<Http1>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server_task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        WebSocket::from_tcp(stream, WsConfig::default())
+    });
+
+    let client_stream = TcpStream::connect(addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (client_ws, _): (WebSocketStream<WsStream<Http1>>, _) = client
+        .connect(client_stream, &addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    let server_ws = server_task.await.unwrap();
+    (server_ws, client_ws)
+}
+
+async fn build_handler_with_local(
+    app: App,
+    metrics: Arc<CountingMetrics>,
+) -> (ConnectionHandler, Arc<LocalAdapter>, Arc<MemoryAppManager>) {
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager.create_app(app).await.unwrap();
+
+    let adapter = Arc::new(LocalAdapter::new());
+    adapter.init().await;
+
+    let handler = ConnectionHandler::builder(
+        app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+        adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(NullCacheManager),
+        ServerOptions::default(),
+    )
+    .local_adapter(adapter.clone())
+    .metrics(metrics)
+    .build();
+
+    (handler, adapter, app_manager)
+}
+
+// Once registered, cleanup_socket (-> handle_disconnect) must decrement,
+// even when a post-registration setup step fails.
+#[tokio::test]
+async fn connected_gauge_setup_failure_decrements_on_cleanup() {
+    let metrics = Arc::new(CountingMetrics::new());
+    let (handler, adapter, app_manager) =
+        build_handler_with_local(make_app(0), metrics.clone()).await;
+
+    let socket_id = SocketId::new();
+    let (writer, _client) = make_ws_pair().await;
+    adapter
+        .add_socket(
+            socket_id,
+            writer,
+            APP_ID,
+            app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+        )
+        .await
+        .unwrap();
+
+    metrics.mark_new_connection(APP_ID, &socket_id);
+    assert_eq!(
+        metrics.new_connections(),
+        1,
+        "pre-condition: one socket registered"
+    );
+
+    handler.handle_disconnect(APP_ID, &socket_id).await.unwrap();
+
+    assert_eq!(
+        metrics.new_connections(),
+        1,
+        "mark_new_connection was called exactly once"
+    );
+    assert_eq!(
+        metrics.disconnections(),
+        1,
+        "mark_disconnection was called exactly once by handle_disconnect"
+    );
+    assert_eq!(metrics.net(), 0, "gauge must be balanced after cleanup");
+}
+
+// Two handle_disconnect calls (Close frame, then cleanup_socket) must decrement
+// once: the `disconnecting` flag guards the second.
+#[tokio::test]
+async fn connected_gauge_no_double_decrement_on_close_and_cleanup() {
+    let metrics = Arc::new(CountingMetrics::new());
+    let (handler, adapter, app_manager) =
+        build_handler_with_local(make_app(0), metrics.clone()).await;
+
+    let socket_id = SocketId::new();
+    let (writer, _client) = make_ws_pair().await;
+    adapter
+        .add_socket(
+            socket_id,
+            writer,
+            APP_ID,
+            app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+        )
+        .await
+        .unwrap();
+
+    metrics.mark_new_connection(APP_ID, &socket_id);
+
+    handler.handle_disconnect(APP_ID, &socket_id).await.unwrap();
+    handler.handle_disconnect(APP_ID, &socket_id).await.unwrap();
+
+    assert_eq!(
+        metrics.disconnections(),
+        1,
+        "disconnecting flag must prevent the second handle_disconnect from decrementing"
+    );
+    assert_eq!(metrics.net(), 0, "gauge must remain balanced");
+}
+
+// Replacing a socket id decrements the evicted socket before the new one is
+// counted, so the gauge nets one live connection.
+#[tokio::test]
+async fn connected_gauge_socket_replacement_nets_zero() {
+    let metrics = Arc::new(CountingMetrics::new());
+    let (_, adapter, app_manager) = build_handler_with_local(make_app(0), metrics.clone()).await;
+
+    let socket_id = SocketId::new();
+    let (writer1, _client1) = make_ws_pair().await;
+    adapter
+        .add_socket(
+            socket_id,
+            writer1,
+            APP_ID,
+            app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+        )
+        .await
+        .unwrap();
+
+    metrics.mark_new_connection(APP_ID, &socket_id);
+    assert_eq!(metrics.new_connections(), 1, "one connection registered");
+
+    let old_conn = adapter
+        .get_connection(&socket_id, APP_ID)
+        .await
+        .expect("old socket must be present before replacement");
+    adapter.cleanup_connection(APP_ID, old_conn).await;
+    metrics.mark_disconnection(APP_ID, &socket_id);
+
+    assert_eq!(metrics.disconnections(), 1, "old socket decremented");
+
+    let (writer2, _client2) = make_ws_pair().await;
+    adapter
+        .add_socket(
+            socket_id,
+            writer2,
+            APP_ID,
+            app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+        )
+        .await
+        .unwrap();
+    metrics.mark_new_connection(APP_ID, &socket_id);
+
+    assert_eq!(metrics.new_connections(), 2, "total increments: old + new");
+    assert_eq!(
+        metrics.disconnections(),
+        1,
+        "only the evicted socket was decremented"
+    );
+    assert_eq!(
+        metrics.net(),
+        1,
+        "exactly one live connection remains after replacement"
+    );
+}
+
+// A quota rejection happens before registration, so neither counter moves.
+#[tokio::test]
+async fn connected_gauge_over_quota_never_increments() {
+    let app = make_app(1);
+
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager.create_app(app).await.unwrap();
+
+    let metrics = Arc::new(CountingMetrics::new());
+
+    let handler = ConnectionHandler::builder(
+        app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+        Arc::new(FullCapacityAdapter::with_count(1)) as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(NullCacheManager),
+        ServerOptions::default(),
+    )
+    .metrics(metrics.clone())
+    .build();
+
+    let (server_ws, _client) = make_full_ws_pair().await;
+
+    let result = handler
+        .handle_socket(
+            server_ws,
+            APP_KEY.to_string(),
+            None,
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+            None,
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(Error::OverConnectionQuota)),
+        "expected OverConnectionQuota, got {result:?}"
+    );
+    assert_eq!(
+        metrics.new_connections(),
+        0,
+        "mark_new_connection must NOT be called on quota rejection"
+    );
+    assert_eq!(
+        metrics.disconnections(),
+        0,
+        "mark_disconnection must NOT be called on quota rejection"
+    );
+    assert_eq!(metrics.net(), 0, "gauge must remain untouched");
+}
+
+// While draining (running=false), is_accepting() is false, which is what /up and
+// the WS upgrade gate on to return 503 and stop the gauge climbing on a dying pod.
+#[test]
+fn drain_guard_is_accepting_false_when_running_false() {
+    let handler = ConnectionHandler::builder(
+        Arc::new(MemoryAppManager::new()) as Arc<dyn AppManager + Send + Sync>,
+        Arc::new(FullCapacityAdapter::with_count(0)) as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(NullCacheManager),
+        ServerOptions::default(),
+    )
+    .running(Arc::new(AtomicBool::new(false)))
+    .build();
+
+    assert!(
+        !handler.is_accepting(),
+        "is_accepting() must be false while draining so the /up and WS guards return 503"
+    );
+}
+
+// Without an injected running flag the handler must still accept connections,
+// otherwise a builder missing .running() would silently reject all traffic.
+#[test]
+fn is_accepting_defaults_to_true() {
+    let app_manager = Arc::new(MemoryAppManager::new());
+    let handler = ConnectionHandler::builder(
+        app_manager as Arc<dyn AppManager + Send + Sync>,
+        Arc::new(FullCapacityAdapter::with_count(0)) as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(NullCacheManager),
+        ServerOptions::default(),
+    )
+    .build();
+
+    assert!(
+        handler.is_accepting(),
+        "default handler must accept connections"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/local_adapter_fallback_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/local_adapter_fallback_tests.rs
@@ -22,7 +22,7 @@ async fn test_local_adapter_cluster_health_disabled() {
     let socket_id = SocketId::from_string("socket-123").unwrap();
 
     // Add to channel should work
-    let added = adapter
+    let (added, _activated) = adapter
         .add_to_channel(app_id, channel, &socket_id)
         .await
         .unwrap();
@@ -39,7 +39,7 @@ async fn test_local_adapter_cluster_health_disabled() {
     assert!(exists, "Socket should exist in channel");
 
     // Remove from channel
-    let removed = adapter
+    let (removed, _vacated) = adapter
         .remove_from_channel(app_id, channel, &socket_id)
         .await
         .unwrap();
@@ -391,7 +391,7 @@ async fn test_local_adapter_error_handling() {
     let socket_id = SocketId::from_string("error-socket").unwrap();
 
     // Try to remove from non-existent channel
-    let removed = adapter
+    let (removed, _vacated) = adapter
         .remove_from_channel(app_id, channel, &socket_id)
         .await
         .unwrap();

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -84,3 +84,6 @@ mod presence_concurrency_tests;
 
 #[cfg(test)]
 mod presence_lock_scope_tests;
+
+#[cfg(test)]
+mod connected_gauge_regression_tests;

--- a/crates/sockudo-adapter/tests/adapter/presence_concurrency_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_concurrency_tests.rs
@@ -138,8 +138,8 @@ impl ConnectionManager for ScriptedCM {
         _app_id: &str,
         _channel: &str,
         _socket_id: &SocketId,
-    ) -> Result<bool> {
-        Ok(false)
+    ) -> Result<(bool, bool)> {
+        Ok((false, false))
     }
 
     async fn remove_from_channel(
@@ -147,8 +147,8 @@ impl ConnectionManager for ScriptedCM {
         _app_id: &str,
         _channel: &str,
         _socket_id: &SocketId,
-    ) -> Result<bool> {
-        Ok(false)
+    ) -> Result<(bool, bool)> {
+        Ok((false, false))
     }
 
     async fn get_presence_member(

--- a/crates/sockudo-adapter/tests/adapter/presence_lock_scope_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_lock_scope_tests.rs
@@ -166,8 +166,8 @@ impl ConnectionManager for ScriptedCM {
         _app_id: &str,
         _channel: &str,
         _socket_id: &SocketId,
-    ) -> Result<bool> {
-        Ok(false)
+    ) -> Result<(bool, bool)> {
+        Ok((false, false))
     }
 
     async fn remove_from_channel(
@@ -175,8 +175,8 @@ impl ConnectionManager for ScriptedCM {
         _app_id: &str,
         _channel: &str,
         _socket_id: &SocketId,
-    ) -> Result<bool> {
-        Ok(false)
+    ) -> Result<(bool, bool)> {
+        Ok((false, false))
     }
 
     async fn get_presence_member(

--- a/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
+++ b/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
@@ -124,16 +124,16 @@ impl ConnectionManager for MockAdapter {
         _app_id: &str,
         _channel: &str,
         _socket_id: &SocketId,
-    ) -> Result<bool> {
-        Ok(false)
+    ) -> Result<(bool, bool)> {
+        Ok((false, false))
     }
     async fn remove_from_channel(
         &self,
         _app_id: &str,
         _channel: &str,
         _socket_id: &SocketId,
-    ) -> Result<bool> {
-        Ok(false)
+    ) -> Result<(bool, bool)> {
+        Ok((false, false))
     }
     async fn get_presence_member(
         &self,

--- a/crates/sockudo-core/src/namespace.rs
+++ b/crates/sockudo-core/src/namespace.rs
@@ -5,6 +5,7 @@ use crate::utils::wildcard_pattern_matches;
 use crate::websocket::{SocketId, WebSocket, WebSocketBufferConfig, WebSocketRef};
 use ahash::AHashMap as HashMap;
 use ahash::AHashSet;
+use dashmap::mapref::entry::Entry;
 use dashmap::{DashMap, DashSet};
 use futures_util::future::join_all;
 use sockudo_ws::axum_integration::WebSocketWriter;
@@ -467,15 +468,20 @@ impl Namespace {
         Ok(())
     }
 
-    pub fn add_channel_to_socket(&self, channel: &str, socket_id: &SocketId) -> bool {
+    /// `activated` reports the first socket joining the channel, computed under
+    /// the shard write lock so it is safe against concurrent add/remove.
+    pub fn add_channel_to_socket(&self, channel: &str, socket_id: &SocketId) -> (bool, bool) {
         let t_start = std::time::Instant::now();
 
         let t_before_entry = t_start.elapsed().as_nanos();
-        let result = self
-            .channels
-            .entry(channel.to_string())
-            .or_default()
-            .insert(*socket_id);
+        let (newly_inserted, activated) = match self.channels.entry(channel.to_string()) {
+            Entry::Occupied(entry) => (entry.get().insert(*socket_id), false),
+            Entry::Vacant(entry) => {
+                let set_ref = entry.insert(DashSet::new());
+                set_ref.insert(*socket_id);
+                (true, true)
+            }
+        };
         let t_after_entry = t_start.elapsed().as_nanos();
 
         self.socket_channels
@@ -492,13 +498,16 @@ impl Namespace {
             channel,
             socket_id,
             t_after_entry - t_before_entry,
-            result
+            newly_inserted
         );
 
-        result
+        (newly_inserted, activated)
     }
 
-    pub fn remove_channel_from_socket(&self, channel: &str, socket_id: &SocketId) -> bool {
+    /// `vacated` reports the last socket leaving: `remove_if` saw an empty set and
+    /// deleted the entry under the shard write lock. Exactly one concurrent remover
+    /// wins, so it pairs with `add`'s `activated`.
+    pub fn remove_channel_from_socket(&self, channel: &str, socket_id: &SocketId) -> (bool, bool) {
         if let Some(socket_channels_ref) = self.socket_channels.get(socket_id) {
             socket_channels_ref.remove(channel);
         }
@@ -507,19 +516,19 @@ impl Namespace {
             let removed = channel_sockets_ref.remove(socket_id);
             drop(channel_sockets_ref);
 
-            if self
+            let vacated = self
                 .channels
                 .remove_if(channel, |_, set| set.is_empty())
-                .is_some()
-            {
+                .is_some();
+            if vacated {
                 if channel.contains('*') {
                     self.wildcard_channels.remove(channel);
                 }
                 debug!("Removed empty channel entry: {}", channel);
             }
-            return removed.is_some();
+            return (removed.is_some(), vacated);
         }
-        false
+        (false, false)
     }
 
     pub fn remove_connection(&self, socket_id: &SocketId) {
@@ -874,5 +883,100 @@ mod tests {
         assert!(!namespace.is_in_channel("room-1", &socket_id));
         assert!(!namespace.is_in_channel("room-2", &socket_id));
         assert!(!namespace.is_in_channel("presence-x", &socket_id));
+    }
+
+    #[test]
+    fn add_reports_activation_only_on_first_socket() {
+        let namespace = Namespace::new("app".to_string());
+        let s1 = SocketId::new();
+        let s2 = SocketId::new();
+
+        let (newly1, activated1) = namespace.add_channel_to_socket("presence-room", &s1);
+        assert!(newly1);
+        assert!(activated1, "first socket must activate the channel");
+
+        let (newly2, activated2) = namespace.add_channel_to_socket("presence-room", &s2);
+        assert!(newly2);
+        assert!(!activated2, "second socket must not re-activate");
+
+        let (newly1_again, activated1_again) =
+            namespace.add_channel_to_socket("presence-room", &s1);
+        assert!(!newly1_again, "re-subscribe is not a new insertion");
+        assert!(!activated1_again, "re-subscribe must not activate");
+    }
+
+    #[test]
+    fn remove_reports_vacation_only_on_last_socket() {
+        let namespace = Namespace::new("app".to_string());
+        let s1 = SocketId::new();
+        let s2 = SocketId::new();
+        namespace.add_channel_to_socket("presence-room", &s1);
+        namespace.add_channel_to_socket("presence-room", &s2);
+
+        let (removed1, vacated1) = namespace.remove_channel_from_socket("presence-room", &s1);
+        assert!(removed1);
+        assert!(!vacated1, "channel still has a socket, must not vacate");
+
+        let (removed2, vacated2) = namespace.remove_channel_from_socket("presence-room", &s2);
+        assert!(removed2);
+        assert!(vacated2, "last socket leaving must vacate the channel");
+
+        let (removed_absent, vacated_absent) =
+            namespace.remove_channel_from_socket("presence-room", &s1);
+        assert!(!removed_absent, "socket already gone");
+        assert!(!vacated_absent, "absent channel must not report vacation");
+    }
+
+    // Under concurrent churn on a shared channel, activations and vacations must
+    // stay balanced: each entry is created once and deleted once, so the gauge
+    // never goes negative.
+    #[test]
+    fn concurrent_churn_keeps_activation_and_vacation_balanced() {
+        use std::sync::atomic::{AtomicI64, Ordering};
+
+        let namespace = Arc::new(Namespace::new("app".to_string()));
+        let channel = "presence-shared";
+        let activations = Arc::new(AtomicI64::new(0));
+        let vacations = Arc::new(AtomicI64::new(0));
+
+        let threads = 16;
+        let iterations = 2_000;
+
+        let handles: Vec<_> = (0..threads)
+            .map(|_| {
+                let namespace = Arc::clone(&namespace);
+                let activations = Arc::clone(&activations);
+                let vacations = Arc::clone(&vacations);
+                std::thread::spawn(move || {
+                    for _ in 0..iterations {
+                        let socket_id = SocketId::new();
+                        let (_, activated) = namespace.add_channel_to_socket(channel, &socket_id);
+                        if activated {
+                            activations.fetch_add(1, Ordering::Relaxed);
+                        }
+                        let (_, vacated) =
+                            namespace.remove_channel_from_socket(channel, &socket_id);
+                        if vacated {
+                            vacations.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(
+            activations.load(Ordering::Relaxed),
+            vacations.load(Ordering::Relaxed),
+            "every activation must pair with exactly one vacation (gauge returns to zero)"
+        );
+        assert_eq!(
+            namespace.get_channel_socket_count(channel),
+            0,
+            "channel must be empty after all sockets leave"
+        );
     }
 }

--- a/crates/sockudo-server/src/bootstrap/mod.rs
+++ b/crates/sockudo-server/src/bootstrap/mod.rs
@@ -54,7 +54,7 @@ struct ServerState {
     queue_manager: Option<Arc<QueueManager>>,
     webhooks_integration: Arc<WebhookIntegration>,
     metrics: Option<Arc<dyn MetricsInterface + Send + Sync>>,
-    running: AtomicBool,
+    running: Arc<AtomicBool>,
     http_api_rate_limiter: Option<Arc<dyn RateLimiter + Send + Sync>>,
     websocket_rate_limiter: Option<Arc<dyn RateLimiter + Send + Sync>>,
     #[cfg(feature = "push")]

--- a/crates/sockudo-server/src/bootstrap/server.rs
+++ b/crates/sockudo-server/src/bootstrap/server.rs
@@ -694,7 +694,7 @@ impl SockudoServer {
             queue_manager: queue_manager_opt,
             webhooks_integration: webhook_integration.clone(),
             metrics: metrics.clone(),
-            running: AtomicBool::new(true),
+            running: Arc::new(AtomicBool::new(true)),
             http_api_rate_limiter: Some(http_api_rate_limiter_instance.clone()),
             websocket_rate_limiter: Some(websocket_rate_limiter_instance.clone()),
             #[cfg(feature = "push")]
@@ -862,6 +862,7 @@ impl SockudoServer {
             builder = builder.delta_compression(delta_compression_manager.clone());
         }
 
+        builder = builder.running(Arc::clone(&state.running));
         let handler = Arc::new(builder.build());
 
         // Start dead node cleanup event processing loop (only runs if cluster health is enabled)

--- a/crates/sockudo-server/src/http_handler/system.rs
+++ b/crates/sockudo-server/src/http_handler/system.rs
@@ -336,6 +336,16 @@ pub async fn up(
     app_id: Option<Path<String>>,
     State(handler): State<Arc<ConnectionHandler>>,
 ) -> Result<impl IntoResponse, AppError> {
+    // Once shutdown begins, fail readiness so the orchestrator removes this pod
+    // from its load-balancer endpoints and routes no new connections here while
+    // existing ones drain.
+    if !handler.is_accepting() {
+        return Ok(axum::http::Response::builder()
+            .status(StatusCode::SERVICE_UNAVAILABLE)
+            .header("X-Health-Check", "DRAINING")
+            .body("DRAINING".to_string())?);
+    }
+
     let timeout_duration = Duration::from_millis(handler.server_options().health_check_timeout_ms);
 
     let (health_status, app_id_str) = if let Some(Path(app_id)) = app_id {

--- a/crates/sockudo-server/src/ws_handler.rs
+++ b/crates/sockudo-server/src/ws_handler.rs
@@ -35,6 +35,12 @@ pub async fn handle_ws_upgrade(
     ws: WebSocketUpgrade,
     State(handler): State<Arc<ConnectionHandler>>,
 ) -> impl IntoResponse {
+    // Reject new connections once draining so a terminating pod stops taking work
+    // and its sockudo_connected gauge can decay to zero instead of spiking.
+    if !handler.is_accepting() {
+        return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+    }
+
     // Extract Origin header if present
     let origin = headers
         .get(axum::http::header::ORIGIN)


### PR DESCRIPTION
The per-pod active_channels gauge could drift below zero because the decrement was decided by a socket-count read taken separately from the removal that triggered it. Under concurrent unsubscribes on a shared channel — common on presence channels with multi-connection users — two leaves could each observe the channel as empty and both decrement, so the gauge counted more deactivations than activations.

Decide the channel activation/deactivation transition inside the same critical section that mutates channel membership, so every activation pairs with exactly one deactivation:

- add_channel_to_socket reports activation only when the channel entry is created (first local subscriber).
- remove_channel_from_socket reports deactivation only when this call deletes the channel entry (last local subscriber leaves).
- The connection-manager channel add/remove methods and the local and horizontal adapters forward these transition flags.
- The subscribe, unsubscribe, batch-unsubscribe, and fast-path join routes drive the gauge off the transition flags. Channel cleanup (filter index and empty namespace) still runs on the post-removal count, as before.

This also keeps the gauge work on the hot path lighter, since the extra count read per subscribe/unsubscribe is gone.

Also fixes the health check endpoint so a draining node stops accepting new connections and reports unhealthy during shutdown, instead of continuing to take work while terminating.

Add regression tests covering first-join activation, last-leave deactivation, and high-concurrency churn that asserts activations and deactivations stay balanced and the gauge never goes negative.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
