### PR TITLE
fix(adapter): suppress useless resp publishing for fire-and-forget requests

### DIFF
--- a/crates/sockudo-adapter/src/horizontal_adapter/mod.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter/mod.rs
@@ -61,6 +61,23 @@ pub enum RequestType {
     ChannelCountSync,   // Full snapshot of a peer's local channel counts (on join)
 }
 
+impl RequestType {
+    /// Broadcast-only request types that do not expect a response.
+    pub fn is_fire_and_forget(&self) -> bool {
+        matches!(
+            self,
+            Self::PresenceMemberJoined
+                | Self::PresenceMemberLeft
+                | Self::PresenceMemberUpdated
+                | Self::Heartbeat
+                | Self::NodeDead
+                | Self::PresenceStateSync
+                | Self::ChannelCountUpdate
+                | Self::ChannelCountSync
+        )
+    }
+}
+
 /// Request body for horizontal communication
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RequestBody {

--- a/crates/sockudo-adapter/src/horizontal_adapter/tests/mod.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter/tests/mod.rs
@@ -78,3 +78,31 @@ async fn send_request_wakes_on_notify_without_polling_delay() {
     assert_eq!(responses.len(), 1);
     assert!(!timed_out, "waiter should complete via notify, not timeout");
 }
+
+#[test]
+fn test_is_fire_and_forget_true_for_all_eight() {
+    assert!(RequestType::PresenceMemberJoined.is_fire_and_forget());
+    assert!(RequestType::PresenceMemberLeft.is_fire_and_forget());
+    assert!(RequestType::PresenceMemberUpdated.is_fire_and_forget());
+    assert!(RequestType::Heartbeat.is_fire_and_forget());
+    assert!(RequestType::NodeDead.is_fire_and_forget());
+    assert!(RequestType::PresenceStateSync.is_fire_and_forget());
+    assert!(RequestType::ChannelCountUpdate.is_fire_and_forget());
+    assert!(RequestType::ChannelCountSync.is_fire_and_forget());
+}
+
+#[test]
+fn test_is_fire_and_forget_false_for_all_query_types() {
+    assert!(!RequestType::ChannelMembers.is_fire_and_forget());
+    assert!(!RequestType::ChannelSockets.is_fire_and_forget());
+    assert!(!RequestType::ChannelSocketsCount.is_fire_and_forget());
+    assert!(!RequestType::SocketExistsInChannel.is_fire_and_forget());
+    assert!(!RequestType::TerminateUserConnections.is_fire_and_forget());
+    assert!(!RequestType::ChannelsWithSocketsCount.is_fire_and_forget());
+    assert!(!RequestType::Sockets.is_fire_and_forget());
+    assert!(!RequestType::Channels.is_fire_and_forget());
+    assert!(!RequestType::SocketsCount.is_fire_and_forget());
+    assert!(!RequestType::ChannelMembersCount.is_fire_and_forget());
+    assert!(!RequestType::CountUserConnectionsInChannel.is_fire_and_forget());
+    assert!(!RequestType::BatchChannelSocketsCount.is_fire_and_forget());
+}

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
@@ -664,6 +664,11 @@ where
                         });
                     }
 
+                    // No peer is waiting for a response, skip publishing.
+                    if request.request_type.is_fire_and_forget() {
+                        return Err(Error::NoResponseNeeded);
+                    }
+
                     Ok(response)
                 })
             }),

--- a/crates/sockudo-adapter/src/transports/google_pubsub_transport.rs
+++ b/crates/sockudo-adapter/src/transports/google_pubsub_transport.rs
@@ -229,6 +229,13 @@ impl GooglePubSubTransport {
                                     }
                                     ack_handler.ack();
                                 }
+                                Err(
+                                    Error::OwnRequestIgnored
+                                    | Error::RequestNotForThisNode
+                                    | Error::NoResponseNeeded,
+                                ) => {
+                                    ack_handler.ack();
+                                }
                                 Err(error) => {
                                     warn!("Google Pub/Sub request handler failed: {}", error);
                                     ack_handler.ack();

--- a/crates/sockudo-adapter/src/transports/iggy_transport.rs
+++ b/crates/sockudo-adapter/src/transports/iggy_transport.rs
@@ -474,7 +474,9 @@ async fn process_request_message(
                 Ok(()) => should_commit = true,
                 Err(error) => warn!("Failed to publish Apache Iggy response: {error}"),
             },
-            Err(Error::OwnRequestIgnored | Error::RequestNotForThisNode) => {
+            Err(
+                Error::OwnRequestIgnored | Error::RequestNotForThisNode | Error::NoResponseNeeded,
+            ) => {
                 should_commit = true;
             }
             Err(error) => warn!("Apache Iggy request handler failed: {}", error),

--- a/crates/sockudo-adapter/src/transports/kafka_transport.rs
+++ b/crates/sockudo-adapter/src/transports/kafka_transport.rs
@@ -270,6 +270,11 @@ impl KafkaTransport {
                                         warn!("Failed to publish Kafka response: {}", error);
                                     }
                                 }
+                                Err(
+                                    Error::OwnRequestIgnored
+                                    | Error::RequestNotForThisNode
+                                    | Error::NoResponseNeeded,
+                                ) => {}
                                 Err(error) => {
                                     warn!("Kafka request handler failed: {}", error);
                                 }

--- a/crates/sockudo-adapter/src/transports/pulsar_transport.rs
+++ b/crates/sockudo-adapter/src/transports/pulsar_transport.rs
@@ -287,6 +287,11 @@ impl PulsarTransport {
                                         warn!("Failed to publish Pulsar response: {}", error);
                                     }
                                 }
+                                Err(
+                                    Error::OwnRequestIgnored
+                                    | Error::RequestNotForThisNode
+                                    | Error::NoResponseNeeded,
+                                ) => {}
                                 Err(error) => {
                                     warn!("Pulsar request handler failed: {}", error);
                                 }

--- a/crates/sockudo-adapter/src/transports/rabbitmq_transport.rs
+++ b/crates/sockudo-adapter/src/transports/rabbitmq_transport.rs
@@ -314,6 +314,11 @@ impl RabbitMqTransport {
                                         }
                                     }
                                 }
+                                Err(
+                                    Error::OwnRequestIgnored
+                                    | Error::RequestNotForThisNode
+                                    | Error::NoResponseNeeded,
+                                ) => {}
                                 Err(e) => {
                                     warn!("RabbitMQ request handler failed: {}", e);
                                 }

--- a/crates/sockudo-core/src/error.rs
+++ b/crates/sockudo-core/src/error.rs
@@ -157,6 +157,9 @@ pub enum Error {
     #[error("Own request ignored")]
     OwnRequestIgnored,
 
+    #[error("Fire-and-forget request, no response needed")]
+    NoResponseNeeded,
+
     #[error("Request not for this node")]
     RequestNotForThisNode,
 


### PR DESCRIPTION
Fire-and-forget request types (heartbeats, presence join/leave/update, dead node notifications, presence state sync, channel count gossip) were generating empty ResponseBody messages that nobody was waiting for.

With reply_to: None, these responses fell back to the global #responses channel and were fanned out to all subscriber pods, producing significant wasted pub/sub traffic concentrated on the shard owning #responses.

The fix adds a guard in the on_request handler (after heartbeat new-node detection to preserve presence sync on scale-up) that returns Err(NoResponseNeeded) for fire-and-forget types. All transports already skip publishing on Err via their existing if-let-Ok guards.

- Add Error::NoResponseNeeded variant to sockudo-core
- Add RequestType::is_fire_and_forget() classifier (8 types)
- Add guard in core.rs on_request handler after heartbeat detection
- Fix Iggy offset commit for NoResponseNeeded (prevents reprocessing)
- Suppress warning spam in Kafka, Pulsar, RabbitMQ, Google Pub/Sub
- NATS, Redis, Redis Cluster transports unchanged (already correct)

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
