### PR TITLE
fix mysql index charset limits

### DIFF
--- a/crates/sockudo-app/src/mysql_app_manager.rs
+++ b/crates/sockudo-app/src/mysql_app_manager.rs
@@ -130,8 +130,8 @@ impl MySQLAppManager {
     async fn ensure_table_exists(&self) -> Result<()> {
         const CREATE_TABLE_QUERY: &str = r#"
             CREATE TABLE IF NOT EXISTS `applications` (
-                id VARCHAR(255) PRIMARY KEY,
-                `key` VARCHAR(255) UNIQUE NOT NULL,
+                id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci PRIMARY KEY,
+                `key` VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci UNIQUE NOT NULL,
                 secret VARCHAR(255) NOT NULL,
                 max_connections INT UNSIGNED NOT NULL,
                 enable_client_messages BOOLEAN NOT NULL DEFAULT FALSE,

--- a/crates/sockudo-push/src/sql/common_traits.rs
+++ b/crates/sockudo-push/src/sql/common_traits.rs
@@ -1,5 +1,8 @@
 use super::helpers::*;
-use super::stores::{MySqlPushStore, PostgresPushStore};
+#[cfg(feature = "mysql")]
+use super::stores::MySqlPushStore;
+#[cfg(feature = "postgres")]
+use super::stores::PostgresPushStore;
 use crate::domain::{
     DeleteDeviceOutcome, DeliveryEvent, NotificationTemplate, ProviderCredential, PublishLogEvent,
     PublishStatus, PushCursor, PushCursorKind, ShardJob,

--- a/crates/sockudo-push/src/sql/mod.rs
+++ b/crates/sockudo-push/src/sql/mod.rs
@@ -3,7 +3,10 @@ mod device;
 mod helpers;
 mod stores;
 
-pub use stores::{MySqlPushStore, PostgresPushStore};
+#[cfg(feature = "mysql")]
+pub use stores::MySqlPushStore;
+#[cfg(feature = "postgres")]
+pub use stores::PostgresPushStore;
 
 #[cfg(test)]
 mod tests;

--- a/crates/sockudo-push/src/storage.rs
+++ b/crates/sockudo-push/src/storage.rs
@@ -494,6 +494,18 @@ mod migration_smoke_tests {
     }
 
     #[test]
+    fn mysql_push_schema_limits_indexed_identifiers_to_ascii() {
+        for required in [
+            "app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL",
+            "device_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL",
+            "client_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NULL",
+            "channel VARCHAR(512) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL",
+        ] {
+            assert!(MYSQL_PUSH_SCHEMA.contains(required), "mysql: {required}");
+        }
+    }
+
+    #[test]
     fn hyperscale_backend_schema_contracts_cover_denormalized_indexes() {
         for required in [
             "devices_by_id",

--- a/crates/sockudo-server/src/history/mysql/mod.rs
+++ b/crates/sockudo-server/src/history/mysql/mod.rs
@@ -9,12 +9,15 @@ use sockudo_core::history::{
 };
 use sockudo_core::metrics::MetricsInterface;
 use sockudo_core::options::{DatabaseConnection, DatabasePooling, HistoryConfig};
+#[cfg(feature = "versioned-messages")]
 use sockudo_core::versioned_messages::MAX_VERSIONED_SERIAL_LENGTH;
 use sonic_rs::JsonValueTrait;
 use sqlx::{MySqlPool, Row, mysql::MySqlPoolOptions};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::{error, info};
+
+const MYSQL_ASCII_IDENTIFIER_CHARSET: &str = "CHARACTER SET ascii COLLATE ascii_general_ci";
 
 #[derive(Clone)]
 struct HistoryTables {
@@ -254,7 +257,9 @@ mod writes;
 
 mod store_impl;
 
+#[cfg(feature = "versioned-messages")]
 mod version_store;
+#[cfg(feature = "versioned-messages")]
 pub(super) use version_store::create_mysql_version_store;
 
 #[cfg(test)]

--- a/crates/sockudo-server/src/history/mysql/schema.rs
+++ b/crates/sockudo-server/src/history/mysql/schema.rs
@@ -1,7 +1,7 @@
 use sockudo_core::error::{Error, Result};
 use sockudo_core::versioned_messages::MAX_VERSIONED_SERIAL_LENGTH;
 
-use super::MySqlHistoryStore;
+use super::{MYSQL_ASCII_IDENTIFIER_CHARSET, MySqlHistoryStore};
 
 impl MySqlHistoryStore {
     async fn add_column_if_not_exists(
@@ -46,9 +46,9 @@ impl MySqlHistoryStore {
         let create_streams = format!(
             r#"
             CREATE TABLE IF NOT EXISTS {} (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
-                stream_id VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                stream_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 next_serial BIGINT NOT NULL,
                 durable_state VARCHAR(32) NOT NULL DEFAULT 'healthy',
                 durable_state_reason TEXT NULL,
@@ -69,9 +69,9 @@ impl MySqlHistoryStore {
         let create_entries = format!(
             r#"
             CREATE TABLE IF NOT EXISTS {} (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
-                stream_id VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                stream_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 serial BIGINT NOT NULL,
                 published_at_ms BIGINT NOT NULL,
                 message_id VARCHAR(255) NULL,
@@ -90,8 +90,8 @@ impl MySqlHistoryStore {
         let create_version_streams = format!(
             r#"
             CREATE TABLE IF NOT EXISTS {} (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 next_delivery_serial BIGINT NOT NULL,
                 oldest_available_delivery_serial BIGINT NULL,
                 newest_available_delivery_serial BIGINT NULL,
@@ -106,8 +106,8 @@ impl MySqlHistoryStore {
         let create_version_messages = format!(
             r#"
             CREATE TABLE IF NOT EXISTS {} (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 message_serial VARCHAR({}) NOT NULL,
                 history_serial BIGINT NOT NULL,
                 original_client_id VARCHAR(255) NULL,
@@ -125,8 +125,8 @@ impl MySqlHistoryStore {
         let create_version_entries = format!(
             r#"
             CREATE TABLE IF NOT EXISTS {} (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 message_serial VARCHAR({}) NOT NULL,
                 version_serial VARCHAR({}) NOT NULL,
                 delivery_serial BIGINT NOT NULL,
@@ -149,11 +149,11 @@ impl MySqlHistoryStore {
         let create_annotation_events = format!(
             r#"
             CREATE TABLE IF NOT EXISTS {} (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 message_serial VARCHAR({}) NOT NULL,
                 annotation_serial VARCHAR({}) NOT NULL,
-                annotation_type VARCHAR(256) NOT NULL,
+                annotation_type VARCHAR(256) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 name VARCHAR(255) NULL,
                 client_id VARCHAR(255) NULL,
                 count_value BIGINT NULL,
@@ -172,10 +172,10 @@ impl MySqlHistoryStore {
         let create_annotation_projections = format!(
             r#"
             CREATE TABLE IF NOT EXISTS {} (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 message_serial VARCHAR({}) NOT NULL,
-                annotation_type VARCHAR(256) NOT NULL,
+                annotation_type VARCHAR(256) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 summary_json JSON NOT NULL,
                 last_annotation_serial VARCHAR({}) NULL,
                 updated_at_ms BIGINT NOT NULL,
@@ -299,5 +299,23 @@ impl MySqlHistoryStore {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const MYSQL_FRESH_SCHEMA: &str =
+        include_str!("../../../../../ops/migrations/mysql/001_fresh_schema.sql");
+
+    #[test]
+    fn mysql_fresh_schema_limits_indexed_identifiers_to_ascii() {
+        for required in [
+            "app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL",
+            "channel VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL",
+            "stream_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL",
+            "annotation_type VARCHAR(256) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL",
+        ] {
+            assert!(MYSQL_FRESH_SCHEMA.contains(required), "{required}");
+        }
     }
 }

--- a/crates/sockudo-server/src/history/mysql/version_store/mod.rs
+++ b/crates/sockudo-server/src/history/mysql/version_store/mod.rs
@@ -76,8 +76,8 @@ impl MysqlVersionStore {
     async fn ensure_version_tables(&self) -> Result<()> {
         let create_version_streams = format!(
             r#"CREATE TABLE IF NOT EXISTS `{}` (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 next_delivery_serial BIGINT NOT NULL,
                 oldest_available_delivery_serial BIGINT NULL,
                 newest_available_delivery_serial BIGINT NULL,
@@ -90,8 +90,8 @@ impl MysqlVersionStore {
         );
         let create_version_messages = format!(
             r#"CREATE TABLE IF NOT EXISTS `{}` (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 message_serial VARCHAR({}) NOT NULL,
                 history_serial BIGINT NOT NULL,
                 original_client_id VARCHAR(255) NULL,
@@ -110,8 +110,8 @@ impl MysqlVersionStore {
         );
         let create_version_entries = format!(
             r#"CREATE TABLE IF NOT EXISTS `{}` (
-                app_id VARCHAR(255) NOT NULL,
-                channel VARCHAR(255) NOT NULL,
+                app_id VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
+                channel VARCHAR(255) {MYSQL_ASCII_IDENTIFIER_CHARSET} NOT NULL,
                 message_serial VARCHAR({}) NOT NULL,
                 version_serial VARCHAR({}) NOT NULL,
                 delivery_serial BIGINT NOT NULL,

--- a/ops/migrations/mysql/001_fresh_schema.sql
+++ b/ops/migrations/mysql/001_fresh_schema.sql
@@ -19,8 +19,8 @@
 -- stores until release-4.4-aware annotation events are published.
 
 CREATE TABLE IF NOT EXISTS `applications` (
-    id VARCHAR(255) PRIMARY KEY,
-    `key` VARCHAR(255) UNIQUE NOT NULL,
+    id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci PRIMARY KEY,
+    `key` VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci UNIQUE NOT NULL,
     secret VARCHAR(255) NOT NULL,
     max_connections INT UNSIGNED NOT NULL,
     enable_client_messages BOOLEAN NOT NULL DEFAULT FALSE,
@@ -52,9 +52,9 @@ CREATE INDEX idx_applications_enabled ON `applications` (enabled);
 CREATE INDEX idx_applications_created_at ON `applications` (created_at);
 
 CREATE TABLE IF NOT EXISTS `sockudo_history_streams` (
-    app_id VARCHAR(255) NOT NULL,
-    channel VARCHAR(255) NOT NULL,
-    stream_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    channel VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    stream_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     next_serial BIGINT NOT NULL,
     durable_state VARCHAR(32) NOT NULL DEFAULT 'healthy',
     durable_state_reason TEXT NULL,
@@ -71,9 +71,9 @@ CREATE TABLE IF NOT EXISTS `sockudo_history_streams` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `sockudo_history_entries` (
-    app_id VARCHAR(255) NOT NULL,
-    channel VARCHAR(255) NOT NULL,
-    stream_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    channel VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    stream_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     serial BIGINT NOT NULL,
     published_at_ms BIGINT NOT NULL,
     message_id VARCHAR(255) NULL,
@@ -94,8 +94,8 @@ CREATE INDEX sockudo_history_entries_app_channel_time_idx
 ON `sockudo_history_entries` (app_id, channel, published_at_ms DESC, serial DESC);
 
 CREATE TABLE IF NOT EXISTS `sockudo_history_version_streams` (
-    app_id VARCHAR(255) NOT NULL,
-    channel VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    channel VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     next_delivery_serial BIGINT NOT NULL,
     oldest_available_delivery_serial BIGINT NULL,
     newest_available_delivery_serial BIGINT NULL,
@@ -106,8 +106,8 @@ CREATE TABLE IF NOT EXISTS `sockudo_history_version_streams` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `sockudo_history_version_messages` (
-    app_id VARCHAR(255) NOT NULL,
-    channel VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    channel VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     message_serial VARCHAR(128) NOT NULL,
     history_serial BIGINT NOT NULL,
     original_client_id VARCHAR(255) NULL,
@@ -124,8 +124,8 @@ CREATE INDEX sockudo_history_version_messages_latest_version_idx
 ON `sockudo_history_version_messages` (app_id, channel, latest_version_serial);
 
 CREATE TABLE IF NOT EXISTS `sockudo_history_version_entries` (
-    app_id VARCHAR(255) NOT NULL,
-    channel VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    channel VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     message_serial VARCHAR(128) NOT NULL,
     version_serial VARCHAR(128) NOT NULL,
     delivery_serial BIGINT NOT NULL,
@@ -153,11 +153,11 @@ CREATE INDEX sockudo_history_version_entries_history_version_idx
 ON `sockudo_history_version_entries` (app_id, channel, history_serial, version_serial DESC);
 
 CREATE TABLE IF NOT EXISTS `sockudo_history_annotation_events` (
-    app_id VARCHAR(255) NOT NULL,
-    channel VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    channel VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     message_serial VARCHAR(128) NOT NULL,
     annotation_serial VARCHAR(128) NOT NULL,
-    annotation_type VARCHAR(256) NOT NULL,
+    annotation_type VARCHAR(256) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     name VARCHAR(255) NULL,
     client_id VARCHAR(255) NULL,
     count_value BIGINT NULL,
@@ -184,10 +184,10 @@ CREATE INDEX sockudo_history_annotation_events_created_at_idx
 ON `sockudo_history_annotation_events` (created_at_ms);
 
 CREATE TABLE IF NOT EXISTS `sockudo_history_annotation_projections` (
-    app_id VARCHAR(255) NOT NULL,
-    channel VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    channel VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     message_serial VARCHAR(128) NOT NULL,
-    annotation_type VARCHAR(256) NOT NULL,
+    annotation_type VARCHAR(256) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     summary_json JSON NOT NULL,
     last_annotation_serial VARCHAR(128) NULL,
     updated_at_ms BIGINT NOT NULL,

--- a/ops/migrations/mysql/003_push_schema.sql
+++ b/ops/migrations/mysql/003_push_schema.sql
@@ -25,9 +25,9 @@
 --   jobs, then retiring the old version.
 
 CREATE TABLE IF NOT EXISTS `push_devices` (
-    app_id VARCHAR(255) NOT NULL,
-    device_id VARCHAR(255) NOT NULL,
-    client_id VARCHAR(255) NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    device_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    client_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NULL,
     form_factor VARCHAR(32) NOT NULL,
     platform VARCHAR(32) NOT NULL,
     metadata JSON NOT NULL,
@@ -52,10 +52,10 @@ CREATE TABLE IF NOT EXISTS `push_devices` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_channel_subscribers` (
-    app_id VARCHAR(255) NOT NULL,
-    channel VARCHAR(512) NOT NULL,
-    device_id VARCHAR(255) NOT NULL,
-    client_id VARCHAR(255) NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    channel VARCHAR(512) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    device_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+    client_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NULL,
     provider VARCHAR(32) NOT NULL,
     token_hash VARCHAR(128) NOT NULL,
     credential_version BIGINT UNSIGNED NULL,
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS `push_channel_subscribers` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_provider_credentials` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     credential_id VARCHAR(255) NOT NULL,
     provider VARCHAR(32) NOT NULL,
     version BIGINT UNSIGNED NOT NULL,
@@ -83,7 +83,7 @@ CREATE TABLE IF NOT EXISTS `push_provider_credentials` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_notification_templates` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     template_id VARCHAR(255) NOT NULL,
     default_locale VARCHAR(64) NOT NULL,
     locales_json JSON NOT NULL,
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS `push_notification_templates` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_scheduled_jobs` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     publish_id VARCHAR(255) NOT NULL,
     due_minute_ms BIGINT UNSIGNED NOT NULL,
     due_at_ms BIGINT UNSIGNED NOT NULL,
@@ -107,7 +107,7 @@ CREATE TABLE IF NOT EXISTS `push_scheduled_jobs` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_scheduler_locks` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     publish_id VARCHAR(255) NOT NULL,
     owner_id VARCHAR(255) NOT NULL,
     expires_at_ms BIGINT UNSIGNED NOT NULL,
@@ -117,7 +117,7 @@ CREATE TABLE IF NOT EXISTS `push_scheduler_locks` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_publish_status` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     publish_id VARCHAR(255) NOT NULL,
     state VARCHAR(32) NOT NULL,
     counters_json JSON NOT NULL,
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS `push_publish_status` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_publish_log` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     publish_id VARCHAR(255) NOT NULL,
     occurred_at_ms BIGINT UNSIGNED NOT NULL,
     event_id VARCHAR(255) NOT NULL,
@@ -139,7 +139,7 @@ CREATE TABLE IF NOT EXISTS `push_publish_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_fanout_shards` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     publish_id VARCHAR(255) NOT NULL,
     shard_id VARCHAR(255) NOT NULL,
     shard_json JSON NOT NULL,
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS `push_fanout_shards` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_delivery_events` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     publish_id VARCHAR(255) NOT NULL,
     occurred_at_ms BIGINT UNSIGNED NOT NULL,
     event_id VARCHAR(255) NOT NULL,
@@ -160,7 +160,7 @@ CREATE TABLE IF NOT EXISTS `push_delivery_events` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_dead_letters` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     publish_id VARCHAR(255) NOT NULL,
     dead_letter_id VARCHAR(255) NOT NULL,
     occurred_at_ms BIGINT UNSIGNED NOT NULL,
@@ -172,7 +172,7 @@ CREATE TABLE IF NOT EXISTS `push_dead_letters` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_idempotency` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     idempotency_key VARCHAR(255) NOT NULL,
     publish_id VARCHAR(255) NOT NULL,
     expires_at_ms BIGINT UNSIGNED NOT NULL,
@@ -182,7 +182,7 @@ CREATE TABLE IF NOT EXISTS `push_idempotency` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `push_operator_invalidations` (
-    app_id VARCHAR(255) NOT NULL,
+    app_id VARCHAR(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
     occurred_at_ms BIGINT UNSIGNED NOT NULL,
     event_id VARCHAR(255) NOT NULL,
     subject VARCHAR(1024) NOT NULL,


### PR DESCRIPTION
## Summary

Fixes #289.

MySQL fresh provisioning used the table-level `utf8mb4` charset for every text column, so composite keys over app IDs, channels, stream IDs, annotation types, and push device/client identifiers could exceed InnoDB's 3072-byte index key limit. This updates the MySQL fresh schema and runtime provisioning DDL so indexed ASCII identifiers use `CHARACTER SET ascii COLLATE ascii_general_ci` while payload/user-facing text remains `utf8mb4`.

Also fixes adjacent feature-gating leaks that blocked MySQL-only validation:

- gate the MySQL version-store module/export behind `versioned-messages`
- gate push SQL store imports/exports independently for `mysql` and `postgres`

## Validation

- `cargo fmt --all`
- `cargo test -p sockudo-app --features mysql`
- `cargo test -p sockudo --features mysql`
- `cargo test -p sockudo --features "mysql,versioned-messages"`
- `cargo test -p sockudo-push`
- `cargo test -p sockudo-push --features mysql`
- `cargo test -p sockudo-push --features postgres`
- `cargo test -p sockudo-push --features "mysql,postgres"`
- static MySQL migration key-size check: max calculated key is 2303 bytes, under the 3072-byte limit
