### PR TITLE
Fix V1 delivery for versioned creates

### DIFF
--- a/crates/sockudo-adapter/src/local_adapter/broadcast.rs
+++ b/crates/sockudo-adapter/src/local_adapter/broadcast.rs
@@ -6,7 +6,7 @@ use sockudo_core::error::{Error, Result};
 use sockudo_core::namespace::Namespace;
 use sockudo_core::websocket::{SocketId, WebSocketRef};
 use sockudo_protocol::messages::PusherMessage;
-use sockudo_protocol::versioned_messages::extract_runtime_action;
+use sockudo_protocol::versioned_messages::{MessageAction, extract_runtime_action};
 #[cfg(feature = "delta")]
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -1000,11 +1000,16 @@ impl LocalAdapter {
     }
 
     pub(super) fn v1_compatible_message(message: &PusherMessage) -> Option<PusherMessage> {
-        if extract_runtime_action(message).is_some() {
-            return None;
+        let runtime_action = extract_runtime_action(message);
+        match runtime_action {
+            Some(MessageAction::Create) | None => {}
+            Some(_) => return None,
         }
 
         let mut v1_message = message.clone();
+        if runtime_action == Some(MessageAction::Create) {
+            v1_message.rewrite_prefix(sockudo_protocol::ProtocolVersion::V1);
+        }
         v1_message.serial = None;
         v1_message.message_id = None;
         v1_message.stream_id = None;

--- a/crates/sockudo-adapter/src/local_adapter/tests/mod.rs
+++ b/crates/sockudo-adapter/src/local_adapter/tests/mod.rs
@@ -1,6 +1,9 @@
 use super::LocalAdapter;
 use crate::ConnectionManager;
 use sockudo_protocol::messages::{ExtrasValue, MessageData, MessageExtras, PusherMessage};
+use sockudo_protocol::versioned_messages::{
+    MessageAction, MessageVersionMetadata, apply_runtime_metadata,
+};
 use std::collections::HashMap;
 
 #[test]
@@ -39,6 +42,73 @@ fn v1_compatible_message_strips_v2_only_fields_for_plain_messages() {
     assert!(v1.message_id.is_none());
     assert!(v1.stream_id.is_none());
     assert!(v1.idempotency_key.is_none());
+    assert!(v1.extras.is_none());
+}
+
+#[test]
+fn v1_compatible_message_delivers_versioned_creates_as_plain_events() {
+    let mut message =
+        PusherMessage::channel_event("chat.message", "room", sonic_rs::json!({"text": "hello"}));
+    message.message_id = Some("mid-1".to_string());
+    message.serial = Some(11);
+    message.stream_id = Some("stream-1".to_string());
+    message.extras = Some(MessageExtras {
+        headers: Some(HashMap::from([(
+            "tenant".to_string(),
+            ExtrasValue::String("alpha".to_string()),
+        )])),
+        idempotency_key: Some("extra-idem".to_string()),
+        ..Default::default()
+    });
+
+    apply_runtime_metadata(
+        &mut message,
+        MessageAction::Create,
+        "msg:1",
+        &MessageVersionMetadata {
+            serial: "ver:1".to_string(),
+            client_id: Some("client-1".to_string()),
+            timestamp_ms: 2,
+            description: None,
+            metadata: None,
+        },
+        Some(10),
+    );
+
+    let v1 = LocalAdapter::v1_compatible_message(&message).unwrap();
+    assert_eq!(v1.event.as_deref(), Some("chat.message"));
+    assert_eq!(v1.channel.as_deref(), Some("room"));
+    assert_eq!(v1.data, message.data);
+    assert!(v1.serial.is_none());
+    assert!(v1.message_id.is_none());
+    assert!(v1.stream_id.is_none());
+    assert!(v1.idempotency_key.is_none());
+    assert!(v1.extras.is_none());
+}
+
+#[test]
+fn v1_compatible_message_rewrites_versioned_create_protocol_prefix_to_v1() {
+    let mut message = PusherMessage::channel_event(
+        "sockudo:cache_miss",
+        "cache-room",
+        sonic_rs::json!({"miss": true}),
+    );
+    apply_runtime_metadata(
+        &mut message,
+        MessageAction::Create,
+        "msg:2",
+        &MessageVersionMetadata {
+            serial: "ver:2".to_string(),
+            client_id: None,
+            timestamp_ms: 3,
+            description: None,
+            metadata: None,
+        },
+        Some(12),
+    );
+
+    let v1 = LocalAdapter::v1_compatible_message(&message).unwrap();
+    assert_eq!(v1.event.as_deref(), Some("pusher:cache_miss"));
     assert!(v1.extras.is_none());
 }
 


### PR DESCRIPTION
## Summary

- Allow automatic versioned `message.create` publishes to be projected back to plain V1/Pusher events.
- Keep non-create versioned mutation frames V2-only for V1 clients.
- Add regression coverage for versioned create delivery and V1 prefix rewriting.

## Root Cause

When versioned messages were enabled, ordinary HTTP publishes gained runtime metadata in `extras.headers` with `sockudo_action=message.create`. The V1 compatibility projection dropped any message with a runtime action, so those otherwise ordinary events were skipped for V1 subscribers before serialization.

## Validation

- `cargo fmt --all`
- `cargo test -p sockudo-adapter v1_compatible_message`
- `cargo test -p sockudo-adapter local_adapter::tests`
- `cargo test -p sockudo-adapter --lib`

Fixes #290