### PR TITLE
Fix PHP SDK PHPUnit config warnings

### DIFF
--- a/server-sdks/sockudo-http-php/phpunit.xml.dist
+++ b/server-sdks/sockudo-http-php/phpunit.xml.dist
@@ -1,24 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          bootstrap="tests/bootstrap.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          failOnWarning="true"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         verbose="true"
 >
     <testsuites>
-        <testsuite name="all">
-            <directory>./tests/</directory>
-        </testsuite>
-
         <testsuite name="unit">
             <directory>./tests/unit/</directory>
         </testsuite>


### PR DESCRIPTION
## Summary

- Remove the overlapping PHP `all` PHPUnit suite so `vendor/bin/phpunit` no longer discovers unit and acceptance tests twice.
- Remove PHPUnit root attributes that are rejected by the PHPUnit 13.2 schema.
- Keep targeted `unit` and `acceptance` suites available; the default run still executes both.

## Root Cause

The PHP SDK config defined `all` as `./tests/` and also defined nested `unit` and `acceptance` suites. PHPUnit 13 reports each file as already added when the nested suites are processed, and `failOnWarning=true` turns that otherwise passing suite red. The same XML also used deprecated/removed root attributes, causing a PHPUnit configuration deprecation.

## Validation

- `vendor/bin/phpunit --validate-configuration`
- `vendor/bin/phpunit --list-suites`
- `vendor/bin/phpunit`

Fixes #297