### PR TITLE
fix(sockudo-swift): replace ObjC++ delta dep with vendored xdelta3, fix reconnect races

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "929fca62a9a0ffec8ddb96070325cf7f9cce4dadc22be69a2faa38a477f924e1",
+  "originHash" : "810e3dce6d47e43de603ea97f2fceef4e5e42e5c72379d8db909ff518d5d94d8",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "590dd92231b0428f2b6910f856845d1895c58af9",
         "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "delta-codec-cocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ably/delta-codec-cocoa.git",
-      "state" : {
-        "revision" : "d53eec08f9443c6160d941327a6f9d8bbb93cea2",
-        "version" : "1.3.5"
       }
     },
     {
@@ -67,9 +58,10 @@
     {
       "identity" : "tweetnacl-swiftwrap",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/bitmark-inc/tweetnacl-swiftwrap",
+      "location" : "https://github.com/pusher/tweetnacl-swiftwrap",
       "state" : {
-        "revision" : "f8fd111642bf2336b11ef9ea828510693106e954"
+        "revision" : "92375f83c3af1b8af011d3c0af1001929844b936",
+        "version" : "1.2.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -27,22 +27,31 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/jedisct1/swift-sodium.git", from: "0.9.1"),
-    .package(url: "https://github.com/ably/delta-codec-cocoa.git", from: "1.0.0"),
     .package(url: "https://github.com/danielrbrowne/APIota", .upToNextMajor(from: "0.2.0")),
     .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.4.0")),
     .package(url: "https://github.com/apple/swift-crypto", .upToNextMajor(from: "1.1.6")),
-    .package(
-      url: "https://github.com/bitmark-inc/tweetnacl-swiftwrap",
-      revision: "f8fd111642bf2336b11ef9ea828510693106e954"
-    ),
+    .package(url: "https://github.com/pusher/tweetnacl-swiftwrap", from: "1.1.0"),
     .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.12.0"),
   ],
   targets: [
     .target(
+      name: "CXDelta3",
+      path: "client-sdks/sockudo-swift/Vendor/xdelta3",
+      sources: ["xdelta3.c"],
+      publicHeadersPath: "include",
+      cSettings: [
+        .headerSearchPath("."),
+        .define("SIZEOF_SIZE_T", to: "8"),
+        .define("SIZEOF_UNSIGNED_INT", to: "4"),
+        .define("SIZEOF_UNSIGNED_LONG", to: "8"),
+        .define("SIZEOF_UNSIGNED_LONG_LONG", to: "8"),
+      ]
+    ),
+    .target(
       name: "SockudoSwift",
       dependencies: [
         .product(name: "Sodium", package: "swift-sodium"),
-        .product(name: "AblyDeltaCodec", package: "delta-codec-cocoa"),
+        "CXDelta3",
       ],
       path: "client-sdks/sockudo-swift/Sources/SockudoSwift",
       swiftSettings: [
@@ -81,6 +90,7 @@ let package = Package(
       name: "SockudoSwiftTests",
       dependencies: [
         "SockudoSwift",
+        "CXDelta3",
         .product(name: "Testing", package: "swift-testing"),
       ],
       path: "client-sdks/sockudo-swift/Tests/SockudoSwiftTests",

--- a/client-sdks/sockudo-swift/Package.resolved
+++ b/client-sdks/sockudo-swift/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "df463ac19ad22ca6490f0041eca803600200682ddc4c948fe2fe0ed70c30c108",
+  "originHash" : "3b1f30fea9473cde9e41d71521753e2846bb2df553c40b051564643dcd822b1a",
   "pins" : [
-    {
-      "identity" : "delta-codec-cocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ably/delta-codec-cocoa.git",
-      "state" : {
-        "revision" : "d53eec08f9443c6160d941327a6f9d8bbb93cea2",
-        "version" : "1.3.5"
-      }
-    },
     {
       "identity" : "swift-sodium",
       "kind" : "remoteSourceControl",

--- a/client-sdks/sockudo-swift/Package.swift
+++ b/client-sdks/sockudo-swift/Package.swift
@@ -19,15 +19,27 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/jedisct1/swift-sodium.git", from: "0.9.1"),
-    .package(url: "https://github.com/ably/delta-codec-cocoa.git", from: "1.0.0"),
     .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.12.0"),
   ],
   targets: [
     .target(
+      name: "CXDelta3",
+      path: "Vendor/xdelta3",
+      sources: ["xdelta3.c"],
+      publicHeadersPath: "include",
+      cSettings: [
+        .headerSearchPath("."),
+        .define("SIZEOF_SIZE_T", to: "8"),
+        .define("SIZEOF_UNSIGNED_INT", to: "4"),
+        .define("SIZEOF_UNSIGNED_LONG", to: "8"),
+        .define("SIZEOF_UNSIGNED_LONG_LONG", to: "8"),
+      ]
+    ),
+    .target(
       name: "SockudoSwift",
       dependencies: [
         .product(name: "Sodium", package: "swift-sodium"),
-        .product(name: "AblyDeltaCodec", package: "delta-codec-cocoa"),
+        "CXDelta3",
       ],
       swiftSettings: [
         .unsafeFlags(["-Xfrontend", "-strict-concurrency=minimal"])

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/DeltaCompression.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/DeltaCompression.swift
@@ -1,4 +1,4 @@
-import AblyDeltaCodec
+import CXDelta3
 import Foundation
 
 private struct CachedMessage {
@@ -162,8 +162,7 @@ final class DeltaCompressionManager {
           decoding: FossilDelta.apply(base: Data(baseMessage.utf8), delta: deltaData),
           as: UTF8.self)
       case .xdelta3:
-        let output = try ARTDeltaCodec.applyDelta(
-          deltaData, previous: Data(baseMessage.utf8))
+        let output = try XDelta3.decode(delta: deltaData, base: Data(baseMessage.utf8))
         reconstructed = String(decoding: output, as: UTF8.self)
       }
 

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
@@ -341,7 +341,6 @@ public final class SockudoClient: @unchecked Sendable {
     updateState(.connecting)
     openWebSocketAfterInitialAuth(using: transports[0])
     setUnavailableTimer()
-    reachability.start()
   }
 
   public func disconnect() {
@@ -580,6 +579,7 @@ public final class SockudoClient: @unchecked Sendable {
           min(config.activityTimeout * 1000, negotiatedTimeout) / 1000
         clearUnavailableTimer()
         updateState(.connected, metadata: ["socket_id": socketID])
+        reachability.start()
         subscribeAll()
         if config.connectionRecovery, channelPositions.isEmpty == false {
           let positionsPayload: [String: Any] = [

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
@@ -143,6 +143,7 @@ public final class SockudoClient: @unchecked Sendable {
   private var currentTransport: Transport?
   private var attemptedFallback = false
   private var manuallyDisconnected = false
+  private var terminalEventHandled = false
   private var tokenRequestInFlight = false
 
   public init(_ key: String, options: Options, urlSession: URLSession? = nil) throws {
@@ -335,6 +336,7 @@ public final class SockudoClient: @unchecked Sendable {
       return
     }
     manuallyDisconnected = false
+    terminalEventHandled = false
     attemptedFallback = false
     updateState(.connecting)
     openWebSocketAfterInitialAuth(using: transports[0])
@@ -344,6 +346,7 @@ public final class SockudoClient: @unchecked Sendable {
 
   public func disconnect() {
     manuallyDisconnected = true
+    terminalEventHandled = true
     invalidateTimers()
     webSocketTask?.cancel(with: .normalClosure, reason: nil)
     webSocketTask = nil
@@ -467,7 +470,9 @@ public final class SockudoClient: @unchecked Sendable {
         self?.readNextMessage()
       }
       webSocketDelegate.didClose = { [weak self] code, reason in
-        self?.handleSocketClosed(code: code, reason: reason)
+        Task { @MainActor in
+          self?.handleSocketClosed(code: code, reason: reason)
+        }
       }
       webSocketTask = task
       task.resume()
@@ -751,6 +756,8 @@ public final class SockudoClient: @unchecked Sendable {
   }
 
   private func handleSocketClosed(code: URLSessionWebSocketTask.CloseCode, reason: String?) {
+    guard !terminalEventHandled else { return }
+    terminalEventHandled = true
     invalidateActivityTimer()
     clearUnavailableTimer()
     webSocketTask = nil
@@ -909,6 +916,7 @@ public final class SockudoClient: @unchecked Sendable {
       [weak self] _ in
       Task { @MainActor in
         guard let self else { return }
+        self.terminalEventHandled = false
         self.webSocketTask?.cancel(with: .goingAway, reason: nil)
         self.webSocketTask = nil
         self.updateState(.connecting)

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/XDelta3.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/XDelta3.swift
@@ -1,0 +1,34 @@
+import Foundation
+import CXDelta3
+
+enum XDelta3 {
+  static func decode(delta: Data, base: Data) throws -> Data {
+    try delta.withUnsafeBytes { deltaPtr in
+      try base.withUnsafeBytes { basePtr in
+        let maxOutput = 32 * 1024 * 1024
+        var output = Data(count: maxOutput)
+        var outputSize = UInt64(maxOutput)
+
+        let result = output.withUnsafeMutableBytes { outPtr in
+          xd3_decode_memory(
+            deltaPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+            UInt64(delta.count),
+            basePtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+            UInt64(base.count),
+            outPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+            &outputSize,
+            UInt64(maxOutput),
+            0
+          )
+        }
+
+        guard result == 0 else {
+          throw SockudoError.deltaFailure("xd3_decode_memory failed with code \(result)")
+        }
+
+        output.count = Int(outputSize)
+        return output
+      }
+    }
+  }
+}

--- a/client-sdks/sockudo-swift/Tests/SockudoSwiftTests/SockudoSwiftTests.swift
+++ b/client-sdks/sockudo-swift/Tests/SockudoSwiftTests/SockudoSwiftTests.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import CXDelta3
 import Foundation
 import Testing
 
@@ -1421,5 +1422,48 @@ func liveV1HeartbeatStillUsesProtocolPing() async throws {
     _ = try await receiveMessage(from: task, timeout: 1.5)
   } catch ReceiveTimeoutError.timedOut {
     // Connection remained open without immediate timeout close, which is what we want.
+  }
+}
+
+@Test func xdelta3RoundTripDecodeProducesCorrectOutput() throws {
+  let source = Data("hello world".utf8)
+  let target = Data("hello xdelta3 world".utf8)
+
+  let delta = try source.withUnsafeBytes { srcPtr in
+    try target.withUnsafeBytes { tgtPtr in
+      var deltaSize = UInt64(target.count * 2 + 1024)
+      var delta = Data(count: Int(deltaSize))
+      let deltaCap = UInt64(delta.count)
+      let result = delta.withUnsafeMutableBytes { deltaPtr in
+        xd3_encode_memory(
+          tgtPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+          UInt64(target.count),
+          srcPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+          UInt64(source.count),
+          deltaPtr.baseAddress?.assumingMemoryBound(to: UInt8.self),
+          &deltaSize,
+          deltaCap,
+          0
+        )
+      }
+      guard result == 0 else {
+        throw SockudoError.deltaFailure("encode failed: \(result)")
+      }
+      delta.count = Int(deltaSize)
+      return delta
+    }
+  }
+
+  let reconstructed = try XDelta3.decode(delta: delta, base: source)
+
+  #expect(reconstructed == target)
+  #expect(String(decoding: reconstructed, as: UTF8.self) == "hello xdelta3 world")
+}
+
+@Test func xdelta3InvalidInputThrows() {
+  let garbage = Data([0xFF, 0xFE, 0x00, 0x01, 0x02])
+  let base = Data("some base".utf8)
+  #expect(throws: (any Error).self) {
+    try XDelta3.decode(delta: garbage, base: base)
   }
 }

--- a/client-sdks/sockudo-swift/VENDORED.md
+++ b/client-sdks/sockudo-swift/VENDORED.md
@@ -1,0 +1,12 @@
+# Vendored Dependencies
+
+## xdelta3
+
+| Field    | Value                                                |
+|----------|------------------------------------------------------|
+| What     | xdelta3 (VCDIFF delta codec)                         |
+| Source   | https://github.com/jmacd/xdelta                      |
+| Tag      | v3.2.0                                               |
+| License  | Apache 2.0 (Copyright 2016 Joshua MacDonald)         |
+| Location | client-sdks/sockudo-swift/Vendor/xdelta3/            |
+

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/LICENSE
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/LICENSE
@@ -1,0 +1,176 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/include/CXDelta3.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/include/CXDelta3.h
@@ -1,0 +1,20 @@
+// Shim header exposing xdelta3 to Swift via CXDelta3 module.
+// Vendored from https://github.com/jmacd/xdelta (Apache 2.0)
+//
+// Forward-declare xd3_decode_memory with concrete uint64_t sizes rather than
+// the usize_t typedef, which depends on SIZEOF_* platform macros that Clang's
+// Swift-module pass may not see.  The ABI is identical on all Apple 64-bit
+// targets (uint64_t == unsigned long == 8 bytes).  The full xdelta3.h is still
+// picked up by xdelta3.c via the headerSearchPath cSetting, so the
+// implementation compiles correctly against the original signature.
+#include <stdint.h>
+
+int xd3_decode_memory(const uint8_t *input, uint64_t input_size,
+                      const uint8_t *source, uint64_t source_size,
+                      uint8_t *output, uint64_t *output_size,
+                      uint64_t avail_output, int flags);
+
+int xd3_encode_memory(const uint8_t *input, uint64_t input_size,
+                      const uint8_t *source, uint64_t source_size,
+                      uint8_t *output, uint64_t *output_size,
+                      uint64_t avail_output, int flags);

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-blkcache.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-blkcache.h
@@ -1,0 +1,492 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "xdelta3-internal.h"
+
+typedef struct _main_blklru main_blklru;
+typedef struct _main_blklru_list main_blklru_list;
+
+#define XD3_INVALID_OFFSET XOFF_T_MAX
+
+struct _main_blklru_list {
+  main_blklru_list *next;
+  main_blklru_list *prev;
+};
+
+struct _main_blklru {
+  uint8_t *blk;
+  xoff_t blkno;
+  usize_t size;
+  main_blklru_list link;
+};
+
+XD3_MAKELIST(main_blklru_list, main_blklru, link);
+
+static usize_t lru_size = 0;
+static main_blklru *lru = NULL; /* array of lru_size elts */
+static main_blklru_list lru_list;
+static int do_src_fifo = 0; /* set to avoid lru */
+
+static int lru_hits = 0;
+static int lru_misses = 0;
+static int lru_filled = 0;
+
+static void main_lru_reset(void) {
+  lru_size = 0;
+  lru = NULL;
+  do_src_fifo = 0;
+  lru_hits = 0;
+  lru_misses = 0;
+  lru_filled = 0;
+}
+
+static void main_lru_cleanup(void) {
+  if (lru != NULL) {
+    main_buffree(lru[0].blk);
+  }
+
+  main_free(lru);
+  lru = NULL;
+
+  lru_hits = 0;
+  lru_misses = 0;
+  lru_filled = 0;
+}
+
+/* This is called at different times for encoding and decoding.  The
+ * encoder calls it immediately, the decoder delays until the
+ * application header is received.  */
+static int main_set_source(xd3_stream *stream, xd3_cmd cmd, main_file *sfile,
+                           xd3_source *source) {
+  int ret = 0;
+  usize_t i;
+  xoff_t source_size = 0;
+  usize_t blksize;
+
+  XD3_ASSERT(lru == NULL);
+  XD3_ASSERT(stream->src == NULL);
+  XD3_ASSERT(option_srcwinsz >= XD3_MINSRCWINSZ);
+
+  /* TODO: this code needs refactoring into FIFO, LRU, FAKE.  Yuck!
+   * This is simplified from 3.0z which had issues with sizing the
+   * source buffer memory allocation and the source blocksize. */
+
+  /* LRU-specific */
+  main_blklru_list_init(&lru_list);
+
+  if (allow_fake_source) {
+    /* TODO: refactor
+     * TOOLS/recode-specific: Check "allow_fake_source" mode looks
+     * broken now. */
+    sfile->mode = XO_READ;
+    sfile->realname = sfile->filename;
+    sfile->nread = 0;
+  } else {
+    /* Either a regular file (possibly compressed) or a FIFO
+     * (possibly compressed). */
+    if ((ret = main_file_open(sfile, sfile->filename, XO_READ))) {
+      return ret;
+    }
+
+    /* If the file is regular we know it's size.  If the file turns
+     * out to be externally compressed, size_known may change. */
+    sfile->size_known = (main_file_stat(sfile, &source_size) == 0);
+  }
+
+  /* Clamp the source window to the known source size.  A large -B on a small
+   * source would otherwise reserve the full (rounded-up) window up front --
+   * e.g. an 8 GiB buffer for a 100 KB file -- wasting memory and risking
+   * out-of-memory failures.  Only shrink, never below XD3_MINSRCWINSZ, and only
+   * when the size is known; non-seekable sources keep the full window because
+   * they need it.  For an externally compressed source the known size is the
+   * compressed length, so the window is bounded by that length; this stays
+   * correct because the logical content is read through the block cache. */
+  if (sfile->size_known && source_size < option_srcwinsz) {
+    option_srcwinsz = xd3_max((xoff_t)XD3_MINSRCWINSZ, source_size);
+  }
+
+  /* Note: The API requires a power-of-two blocksize and srcwinsz
+   * (-B).  The logic here will use a single block if the entire file
+   * is known to fit into srcwinsz. */
+  option_srcwinsz = xd3_xoff_roundup(option_srcwinsz);
+
+  /* Though called "lru", it is not LRU-specific.  We always allocate
+   * a maximum number of source block buffers.  If the entire file
+   * fits into srcwinsz, this buffer will stay as the only
+   * (lru_size==1) source block.  Otherwise, we know that at least
+   * option_srcwinsz bytes are available.  Split the source window
+   * into buffers. */
+  if ((lru = (main_blklru *)main_malloc(MAX_LRU_SIZE * sizeof(main_blklru))) ==
+      NULL) {
+    ret = ENOMEM;
+    return ret;
+  }
+
+  memset(lru, 0, sizeof(lru[0]) * MAX_LRU_SIZE);
+
+  /* Allocate the entire buffer. */
+  if ((lru[0].blk = (uint8_t *)main_bufalloc(option_srcwinsz)) == NULL) {
+    ret = ENOMEM;
+    return ret;
+  }
+
+  /* Main calls main_getblk_func() once before xd3_set_source().  This
+   * is the point at which external decompression may begin.  Set the
+   * system for a single block. */
+  lru_size = 1;
+  lru[0].blkno = XD3_INVALID_OFFSET;
+  blksize = option_srcwinsz;
+  main_blklru_list_push_back(&lru_list, &lru[0]);
+  XD3_ASSERT(blksize != 0);
+
+  /* Initialize xd3_source. */
+  source->blksize = blksize;
+  source->name = sfile->filename;
+  source->ioh = sfile;
+  source->curblkno = XD3_INVALID_OFFSET;
+  source->curblk = NULL;
+  source->max_winsize = option_srcwinsz;
+
+  if ((ret = main_getblk_func(stream, source, 0)) != 0) {
+    XPR(NT "error reading source: %s: %s\n", sfile->filename,
+        xd3_mainerror(ret));
+    return ret;
+  }
+
+  source->onblk = lru[0].size; /* xd3 sets onblk */
+
+  /* If the file is smaller than a block, size is known. */
+  if (!sfile->size_known && source->onblk < blksize) {
+    source_size = source->onblk;
+    source->onlastblk = source_size;
+    sfile->size_known = 1;
+  }
+
+  /* If the size is not known or is greater than the buffer size, we
+   * split the buffer across MAX_LRU_SIZE blocks (already allocated in
+   * "lru"). */
+  if (!sfile->size_known || source_size > option_srcwinsz) {
+    /* Modify block 0, change blocksize. */
+    blksize = option_srcwinsz / MAX_LRU_SIZE;
+    source->blksize = blksize;
+    source->onblk = blksize;
+    source->onlastblk = blksize;
+    source->max_blkno = MAX_LRU_SIZE - 1;
+
+    lru[0].size = blksize;
+    lru_size = MAX_LRU_SIZE;
+
+    /* Setup rest of blocks. */
+    for (i = 1; i < lru_size; i += 1) {
+      lru[i].blk = lru[0].blk + (blksize * i);
+      lru[i].blkno = i;
+      lru[i].size = blksize;
+      main_blklru_list_push_back(&lru_list, &lru[i]);
+    }
+  }
+
+  if (!sfile->size_known) {
+    /* If the size is not know, we must use FIFO discipline. */
+    do_src_fifo = 1;
+  }
+
+  /* Call the appropriate set_source method, handle errors, print
+   * verbose message, etc. */
+  if (sfile->size_known) {
+    ret = xd3_set_source_and_size(stream, source, source_size);
+  } else {
+    ret = xd3_set_source(stream, source);
+  }
+
+  if (ret) {
+    XPR(NT XD3_LIB_ERRMSG(stream, ret));
+    return ret;
+  }
+
+  XD3_ASSERT(stream->src == source);
+  XD3_ASSERT(source->blksize == blksize);
+
+  if (option_verbose) {
+    static shortbuf srcszbuf;
+    static shortbuf srccntbuf;
+    static shortbuf winszbuf;
+    static shortbuf blkszbuf;
+    static shortbuf nbufs;
+
+    if (sfile->size_known) {
+      short_sprintf(srcszbuf, "source size %s [%" XD3_Q "u]",
+                    main_format_bcnt(source_size, &srccntbuf), source_size);
+    } else {
+      short_sprintf(srcszbuf, "%s", "source size unknown");
+    }
+
+    nbufs.buf[0] = 0;
+
+    if (option_verbose > 1) {
+      short_sprintf(nbufs, " #bufs %" XD3_W "u", lru_size);
+    }
+
+    XPR(NT "source %s %s blksize %s window %s%s%s\n", sfile->filename,
+        srcszbuf.buf, main_format_bcnt(blksize, &blkszbuf),
+        main_format_bcnt(option_srcwinsz, &winszbuf), nbufs.buf,
+        do_src_fifo ? " (FIFO)" : "");
+  }
+
+  return 0;
+}
+
+static int main_getblk_lru(xd3_source *source, xoff_t blkno,
+                           main_blklru **blrup, int *is_new) {
+  main_blklru *blru = NULL;
+  usize_t i;
+
+  (*is_new) = 0;
+
+  if (do_src_fifo) {
+    /* Direct lookup assumes sequential scan w/o skipping blocks. */
+    int idx = (int)(blkno % lru_size);
+    blru = &lru[idx];
+    if (blru->blkno == blkno) {
+      (*blrup) = blru;
+      return 0;
+    }
+    /* No going backwards in a sequential scan. */
+    if (blru->blkno != XD3_INVALID_OFFSET && blru->blkno > blkno) {
+      return XD3_TOOFARBACK;
+    }
+  } else {
+    /* Sequential search through LRU. */
+    for (i = 0; i < lru_size; i += 1) {
+      blru = &lru[i];
+      if (blru->blkno == blkno) {
+        main_blklru_list_remove(blru);
+        main_blklru_list_push_back(&lru_list, blru);
+        (*blrup) = blru;
+        IF_DEBUG1(DP(RINT "[getblk_lru] HIT blkno = %" XD3_Q
+                          "u lru_size=%" XD3_W "u\n",
+                     blkno, lru_size));
+        return 0;
+      }
+    }
+    IF_DEBUG1(DP(RINT "[getblk_lru] MISS blkno = %" XD3_Q "u lru_size=%" XD3_W
+                      "u\n",
+                 blkno, lru_size));
+  }
+
+  if (do_src_fifo) {
+    int idx = (int)(blkno % lru_size);
+    blru = &lru[idx];
+  } else {
+    XD3_ASSERT(!main_blklru_list_empty(&lru_list));
+    blru = main_blklru_list_pop_front(&lru_list);
+    main_blklru_list_push_back(&lru_list, blru);
+  }
+
+  lru_filled += 1;
+  (*is_new) = 1;
+  (*blrup) = blru;
+  blru->blkno = XD3_INVALID_OFFSET;
+  return 0;
+}
+
+static int main_read_seek_source(xd3_stream *stream, xd3_source *source,
+                                 xoff_t blkno) {
+  xoff_t pos = blkno * source->blksize;
+  main_file *sfile = (main_file *)source->ioh;
+  main_blklru *blru;
+  int is_new;
+  size_t nread = 0;
+  int ret = 0;
+
+  if (!sfile->seek_failed) {
+    ret = main_file_seek(sfile, pos);
+
+    if (ret == 0) {
+      sfile->source_position = pos;
+    }
+  }
+
+  if (sfile->seek_failed || ret != 0) {
+    /* For an unseekable file (or other seek error, does it
+     * matter?) */
+    if (sfile->source_position > pos) {
+      /* Could assert !IS_ENCODE(), this shouldn't happen
+       * because of do_src_fifo during encode. */
+      if (!option_quiet) {
+        XPR(NT "source can't seek backwards; requested block offset "
+               "%" XD3_Q "u source position is %" XD3_Q "u\n",
+            pos, sfile->source_position);
+      }
+
+      sfile->seek_failed = 1;
+      stream->msg = "non-seekable source: "
+                    "copy is too far back (try raising -B)";
+      return XD3_TOOFARBACK;
+    }
+
+    /* There's a chance here, that an genuine lseek error will cause
+     * xdelta3 to shift into non-seekable mode, entering a degraded
+     * condition.  */
+    if (!sfile->seek_failed && option_verbose) {
+      XPR(NT "source can't seek, will use FIFO for %s\n", sfile->filename);
+
+      if (option_verbose > 1) {
+        XPR(NT "seek error at offset %" XD3_Q "u: %s\n", pos,
+            xd3_mainerror(ret));
+      }
+    }
+
+    sfile->seek_failed = 1;
+
+    if (option_verbose > 1 && pos != sfile->source_position) {
+      XPR(NT "non-seekable source skipping %" XD3_Q "u bytes @ %" XD3_Q "u\n",
+          pos - sfile->source_position, sfile->source_position);
+    }
+
+    while (sfile->source_position < pos) {
+      xoff_t skip_blkno;
+      usize_t skip_offset;
+
+      xd3_blksize_div(sfile->source_position, source, &skip_blkno,
+                      &skip_offset);
+
+      /* Read past unused data */
+      XD3_ASSERT(pos - sfile->source_position >= source->blksize);
+      XD3_ASSERT(skip_offset == 0);
+
+      if ((ret = main_getblk_lru(source, skip_blkno, &blru, &is_new))) {
+        return ret;
+      }
+
+      XD3_ASSERT(is_new);
+      blru->blkno = skip_blkno;
+
+      if ((ret = main_read_primary_input(sfile, (uint8_t *)blru->blk,
+                                         source->blksize, &nread))) {
+        return ret;
+      }
+
+      if (nread != source->blksize) {
+        IF_DEBUG1(
+            DP(RINT "[getblk] short skip block nread = %" XD3_Z "u\n", nread));
+        stream->msg = "non-seekable input is short";
+        return XD3_INVALID_INPUT;
+      }
+
+      sfile->source_position += nread;
+      blru->size = nread;
+
+      IF_DEBUG1(DP(RINT "[getblk] skip blkno %" XD3_Q "u size %" XD3_W "u\n",
+                   skip_blkno, blru->size));
+
+      XD3_ASSERT(sfile->source_position <= pos);
+    }
+  }
+
+  return 0;
+}
+
+/* This is the callback for reading a block of source.  This function
+ * is blocking and it implements a small LRU.
+ *
+ * Note that it is possible for main_input() to handle getblk requests
+ * in a non-blocking manner.  If the callback is NULL then the caller
+ * of xd3_*_input() must handle the XD3_GETSRCBLK return value and
+ * fill the source in the same way.  See xd3_getblk for details.  To
+ * see an example of non-blocking getblk, see xdelta-test.h. */
+static int main_getblk_func(xd3_stream *stream, xd3_source *source,
+                            xoff_t blkno) {
+  int ret = 0;
+  xoff_t pos = blkno * source->blksize;
+  main_file *sfile = (main_file *)source->ioh;
+  main_blklru *blru;
+  int is_new;
+  size_t nread = 0;
+
+  if (allow_fake_source) {
+    source->curblkno = blkno;
+    source->onblk = 0;
+    source->curblk = lru[0].blk;
+    lru[0].size = 0;
+    return 0;
+  }
+
+  if ((ret = main_getblk_lru(source, blkno, &blru, &is_new))) {
+    return ret;
+  }
+
+  if (!is_new) {
+    source->curblkno = blkno;
+    source->onblk = blru->size;
+    source->curblk = blru->blk;
+    lru_hits++;
+    return 0;
+  }
+
+  lru_misses += 1;
+
+  if (pos != sfile->source_position) {
+    /* Only try to seek when the position is wrong.  This means the
+     * decoder will fail when the source buffer is too small, but
+     * only when the input is non-seekable. */
+    if ((ret = main_read_seek_source(stream, source, blkno))) {
+      return ret;
+    }
+  }
+
+  XD3_ASSERT(sfile->source_position == pos);
+
+  if ((ret = main_read_primary_input(sfile, (uint8_t *)blru->blk,
+                                     source->blksize, &nread))) {
+    return ret;
+  }
+
+  /* Save the last block read, used to handle non-seekable files. */
+  sfile->source_position = pos + nread;
+
+  if (option_verbose > 3) {
+    if (blru->blkno != XD3_INVALID_OFFSET) {
+      if (blru->blkno != blkno) {
+        XPR(NT "source block %" XD3_Q "u read %" XD3_Z "u ejects %" XD3_Q
+               "u (lru_hits=%u, "
+               "lru_misses=%u, lru_filled=%u)\n",
+            blkno, nread, blru->blkno, lru_hits, lru_misses, lru_filled);
+      } else {
+        XPR(NT "source block %" XD3_Q "u read %" XD3_Z "u (lru_hits=%u, "
+               "lru_misses=%u, lru_filled=%u)\n",
+            blkno, nread, lru_hits, lru_misses, lru_filled);
+      }
+    } else {
+      XPR(NT "source block %" XD3_Q "u read %" XD3_Z
+             "u (lru_hits=%u, lru_misses=%u, "
+             "lru_filled=%u)\n",
+          blkno, nread, lru_hits, lru_misses, lru_filled);
+    }
+  }
+
+  source->curblk = blru->blk;
+  source->curblkno = blkno;
+  source->onblk = nread;
+  blru->size = nread;
+  blru->blkno = blkno;
+
+  IF_DEBUG1(DP(RINT "[main_getblk] blkno %" XD3_Q "u onblk %" XD3_Z
+                    "u pos %" XD3_Q "u "
+                    "srcpos %" XD3_Q "u\n",
+               blkno, nread, pos, sfile->source_position));
+
+  return 0;
+}

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-cfgs.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-cfgs.h
@@ -1,0 +1,171 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/******************************************************************
+ SOFT string matcher
+ ******************************************************************/
+
+#if XD3_BUILD_SOFT
+
+#define TEMPLATE soft
+#define LLOOK stream->smatcher.large_look
+#define LSTEP stream->smatcher.large_step
+#define SLOOK stream->smatcher.small_look
+#define SCHAIN stream->smatcher.small_chain
+#define SLCHAIN stream->smatcher.small_lchain
+#define MAXLAZY stream->smatcher.max_lazy
+#define LONGENOUGH stream->smatcher.long_enough
+
+#define SOFTCFG 1
+#include "xdelta3.c"
+#undef SOFTCFG
+
+#undef TEMPLATE
+#undef LLOOK
+#undef SLOOK
+#undef LSTEP
+#undef SCHAIN
+#undef SLCHAIN
+#undef MAXLAZY
+#undef LONGENOUGH
+#endif
+
+#define SOFTCFG 0
+
+/************************************************************
+ FASTEST string matcher
+ **********************************************************/
+#if XD3_BUILD_FASTEST
+#define TEMPLATE fastest
+#define LLOOK 9
+#define LSTEP 26
+#define SLOOK 4U
+#define SCHAIN 1
+#define SLCHAIN 1
+#define MAXLAZY 6
+#define LONGENOUGH 6
+
+#include "xdelta3.c"
+
+#undef TEMPLATE
+#undef LLOOK
+#undef SLOOK
+#undef LSTEP
+#undef SCHAIN
+#undef SLCHAIN
+#undef MAXLAZY
+#undef LONGENOUGH
+#endif
+
+/************************************************************
+ FASTER string matcher
+ **********************************************************/
+#if XD3_BUILD_FASTER
+#define TEMPLATE faster
+#define LLOOK 9
+#define LSTEP 15
+#define SLOOK 4U
+#define SCHAIN 1
+#define SLCHAIN 1
+#define MAXLAZY 18
+#define LONGENOUGH 18
+
+#include "xdelta3.c"
+
+#undef TEMPLATE
+#undef LLOOK
+#undef SLOOK
+#undef LSTEP
+#undef SCHAIN
+#undef SLCHAIN
+#undef MAXLAZY
+#undef LONGENOUGH
+#endif
+
+/******************************************************
+ FAST string matcher
+ ********************************************************/
+#if XD3_BUILD_FAST
+#define TEMPLATE fast
+#define LLOOK 9
+#define LSTEP 8
+#define SLOOK 4U
+#define SCHAIN 4
+#define SLCHAIN 1
+#define MAXLAZY 18
+#define LONGENOUGH 35
+
+#include "xdelta3.c"
+
+#undef TEMPLATE
+#undef LLOOK
+#undef SLOOK
+#undef LSTEP
+#undef SCHAIN
+#undef SLCHAIN
+#undef MAXLAZY
+#undef LONGENOUGH
+#endif
+
+/**************************************************
+ SLOW string matcher
+ **************************************************************/
+#if XD3_BUILD_SLOW
+#define TEMPLATE slow
+#define LLOOK 9
+#define LSTEP 2
+#define SLOOK 4U
+#define SCHAIN 44
+#define SLCHAIN 13
+#define MAXLAZY 90
+#define LONGENOUGH 70
+
+#include "xdelta3.c"
+
+#undef TEMPLATE
+#undef LLOOK
+#undef SLOOK
+#undef LSTEP
+#undef SCHAIN
+#undef SLCHAIN
+#undef MAXLAZY
+#undef LONGENOUGH
+#endif
+
+/********************************************************
+ DEFAULT string matcher
+ ************************************************************/
+#if XD3_BUILD_DEFAULT
+#define TEMPLATE default
+#define LLOOK 9
+#define LSTEP 3
+#define SLOOK 4U
+#define SCHAIN 8
+#define SLCHAIN 2
+#define MAXLAZY 36
+#define LONGENOUGH 70
+
+#include "xdelta3.c"
+
+#undef TEMPLATE
+#undef LLOOK
+#undef SLOOK
+#undef LSTEP
+#undef SCHAIN
+#undef SLCHAIN
+#undef MAXLAZY
+#undef LONGENOUGH
+#endif

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-decode.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-decode.h
@@ -1,0 +1,1073 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef _XDELTA3_DECODE_H_
+#define _XDELTA3_DECODE_H_
+
+#include "xdelta3-internal.h"
+
+#define SRCORTGT(x)                                                            \
+  ((((x) & VCD_SRCORTGT) == VCD_SOURCE)                                        \
+       ? VCD_SOURCE                                                            \
+       : ((((x) & VCD_SRCORTGT) == VCD_TARGET) ? VCD_TARGET : 0))
+
+static inline int xd3_decode_byte(xd3_stream *stream, usize_t *val) {
+  if (stream->avail_in == 0) {
+    stream->msg = "further input required";
+    return XD3_INPUT;
+  }
+
+  (*val) = stream->next_in[0];
+
+  DECODE_INPUT(1);
+  return 0;
+}
+
+static inline int xd3_decode_bytes(xd3_stream *stream, uint8_t *buf,
+                                   usize_t *pos, usize_t size) {
+  usize_t want;
+  usize_t take;
+
+  /* Note: The case where (*pos == size) happens when a zero-length
+   * appheader or code table is transmitted, but there is nothing in
+   * the standard against that. */
+  while (*pos < size) {
+    if (stream->avail_in == 0) {
+      stream->msg = "further input required";
+      return XD3_INPUT;
+    }
+
+    want = size - *pos;
+    take = xd3_min(want, stream->avail_in);
+
+    memcpy(buf + *pos, stream->next_in, (size_t)take);
+
+    DECODE_INPUT(take);
+    (*pos) += take;
+  }
+
+  return 0;
+}
+
+/* Initialize the decoder for a new window.  The dec_tgtlen value is
+ * preserved across successive window decodings, and the update to
+ * dec_winstart is delayed until a new window actually starts.  This
+ * is to avoid throwing an error due to overflow until the last
+ * possible moment.  This makes it possible to encode exactly 4GB
+ * through a 32-bit encoder. */
+static int xd3_decode_init_window(xd3_stream *stream) {
+  stream->dec_cpylen = 0;
+  stream->dec_cpyoff = 0;
+  stream->dec_cksumbytes = 0;
+
+  xd3_init_cache(&stream->acache);
+
+  return 0;
+}
+
+/* Allocates buffer space for the target window and possibly the
+ * VCD_TARGET copy-window.  Also sets the base of the two copy
+ * segments. */
+static int xd3_decode_setup_buffers(xd3_stream *stream) {
+  /* If VCD_TARGET is set then the previous buffer may be reused. */
+  if (stream->dec_win_ind & VCD_TARGET) {
+    /* Note: this implementation is untested, since Xdelta3 itself
+     * does not implement an encoder for VCD_TARGET mode. Thus, mark
+     * unimplemented until needed. */
+    if (1) {
+      stream->msg = "VCD_TARGET not implemented";
+      return XD3_UNIMPLEMENTED;
+    }
+
+    /* But this implementation only supports copying from the last
+     * target window.  If the offset is outside that range, it can't
+     * be done. */
+    if (stream->dec_cpyoff < stream->dec_laststart) {
+      stream->msg = "unsupported VCD_TARGET offset";
+      return XD3_INVALID_INPUT;
+    }
+
+    /* See if the two windows are the same.  This indicates the
+     * first time VCD_TARGET is used.  This causes a second buffer
+     * to be allocated, after that the two are swapped in the
+     * DEC_FINISH case. */
+    if (stream->dec_lastwin == stream->next_out) {
+      stream->next_out = NULL;
+      stream->space_out = 0;
+    }
+
+    /* TODO: (See note above, this looks incorrect) */
+    stream->dec_cpyaddrbase =
+        stream->dec_lastwin +
+        (usize_t)(stream->dec_cpyoff - stream->dec_laststart);
+  }
+
+  /* See if the current output window is large enough. */
+  if (stream->space_out < stream->dec_tgtlen) {
+    xd3_free(stream, stream->dec_buffer);
+
+    stream->space_out = xd3_round_blksize(stream->dec_tgtlen, XD3_ALLOCSIZE);
+
+    if ((stream->dec_buffer =
+             (uint8_t *)xd3_alloc(stream, stream->space_out, 1)) == NULL) {
+      return ENOMEM;
+    }
+
+    stream->next_out = stream->dec_buffer;
+  }
+
+  /* dec_tgtaddrbase refers to an invalid base address, but it is
+   * always used with a sufficiently large instruction offset (i.e.,
+   * beyond the copy window).  This condition is enforced by
+   * xd3_decode_output_halfinst. */
+  stream->dec_tgtaddrbase = stream->next_out - stream->dec_cpylen;
+
+  return 0;
+}
+
+static int xd3_decode_allocate(xd3_stream *stream, usize_t size,
+                               uint8_t **buf_ptr, usize_t *buf_alloc) {
+  IF_DEBUG2(DP(RINT "[xd3_decode_allocate] size %" XD3_W "u alloc %" XD3_W
+                    "u\n",
+               size, *buf_alloc));
+
+  if (*buf_ptr != NULL && *buf_alloc < size) {
+    xd3_free(stream, *buf_ptr);
+    *buf_ptr = NULL;
+  }
+
+  if (*buf_ptr == NULL) {
+    *buf_alloc = xd3_round_blksize(size, XD3_ALLOCSIZE);
+
+    if ((*buf_ptr = (uint8_t *)xd3_alloc(stream, *buf_alloc, 1)) == NULL) {
+      return ENOMEM;
+    }
+  }
+
+  return 0;
+}
+
+static int xd3_decode_section(xd3_stream *stream, xd3_desect *section,
+                              xd3_decode_state nstate, int copy) {
+  XD3_ASSERT(section->pos <= section->size);
+  XD3_ASSERT(stream->dec_state != nstate);
+
+  if (section->pos < section->size) {
+    usize_t sect_take;
+
+    if (stream->avail_in == 0) {
+      return XD3_INPUT;
+    }
+
+    if ((copy == 0) && (section->pos == 0)) {
+      /* No allocation/copy needed */
+      section->buf = stream->next_in;
+      sect_take = section->size;
+      IF_DEBUG1(DP(RINT "[xd3_decode_section] zerocopy %" XD3_W "u @ %" XD3_W
+                        "u avail %" XD3_W "u\n",
+                   sect_take, section->pos, stream->avail_in));
+    } else {
+      usize_t sect_need = section->size - section->pos;
+
+      /* Allocate and copy */
+      sect_take = xd3_min(sect_need, stream->avail_in);
+
+      if (section->pos == 0) {
+        int ret;
+
+        if ((ret = xd3_decode_allocate(stream, section->size, &section->copied1,
+                                       &section->alloc1))) {
+          return ret;
+        }
+
+        section->buf = section->copied1;
+      }
+
+      IF_DEBUG2(DP(RINT "[xd3_decode_section] take %" XD3_W "u @ %" XD3_W
+                        "u [need %" XD3_W "u] avail %" XD3_W "u\n",
+                   sect_take, section->pos, sect_need, stream->avail_in));
+      XD3_ASSERT(section->pos + sect_take <= section->alloc1);
+
+      memcpy(section->copied1 + section->pos, stream->next_in, sect_take);
+    }
+
+    section->pos += sect_take;
+
+    stream->dec_winbytes += sect_take;
+
+    DECODE_INPUT(sect_take);
+  }
+
+  if (section->pos < section->size) {
+    IF_DEBUG1(DP(RINT "[xd3_decode_section] further input required %" XD3_W
+                      "u\n",
+                 section->size - section->pos));
+    stream->msg = "further input required";
+    return XD3_INPUT;
+  }
+
+  XD3_ASSERT(section->pos == section->size);
+
+  stream->dec_state = nstate;
+  section->buf_max = section->buf + section->size;
+  section->pos = 0;
+  return 0;
+}
+
+/* Decode the size and address for half of an instruction (i.e., a
+ * single opcode).  This updates the stream->dec_position, which are
+ * bytes already output prior to processing this instruction.  Perform
+ * bounds checking for sizes and copy addresses, which uses the
+ * dec_position (which is why these checks are done here). */
+static int xd3_decode_parse_halfinst(xd3_stream *stream, xd3_hinst *inst) {
+  int ret;
+
+  /* If the size from the instruction table is zero then read a size value. */
+  if ((inst->size == 0) &&
+      (ret = xd3_read_size(stream, &stream->inst_sect.buf,
+                           stream->inst_sect.buf_max, &inst->size))) {
+    return XD3_INVALID_INPUT;
+  }
+
+  /* For copy instructions, read address. */
+  if (inst->type >= XD3_CPY) {
+    IF_DEBUG2({
+      static int cnt = 0;
+      XPR(NT "DECODE:%u: COPY at %" XD3_Q "u (winoffset %" XD3_W "u) "
+             "size %" XD3_W "u winaddr %" XD3_W "u\n",
+          cnt++,
+          stream->total_out + (stream->dec_position - stream->dec_cpylen),
+          (stream->dec_position - stream->dec_cpylen), inst->size, inst->addr);
+    });
+
+    if ((ret = xd3_decode_address(stream, stream->dec_position,
+                                  inst->type - XD3_CPY, &stream->addr_sect.buf,
+                                  stream->addr_sect.buf_max, &inst->addr))) {
+      return ret;
+    }
+
+    /* Cannot copy an address before it is filled-in. */
+    if (inst->addr >= stream->dec_position) {
+      stream->msg = "address too large";
+      return XD3_INVALID_INPUT;
+    }
+
+    /* Check: a VCD_TARGET or VCD_SOURCE copy cannot exceed the remaining
+     * buffer space in its own segment. */
+    if (inst->addr < stream->dec_cpylen &&
+        inst->addr + inst->size > stream->dec_cpylen) {
+      stream->msg = "size too large";
+      return XD3_INVALID_INPUT;
+    }
+  } else {
+    IF_DEBUG2({
+      if (inst->type == XD3_ADD) {
+        static int cnt;
+        XPR(NT "DECODE:%d: ADD at %" XD3_Q "u (winoffset %" XD3_W
+               "u) size %" XD3_W "u\n",
+            cnt++,
+            (stream->total_out + stream->dec_position - stream->dec_cpylen),
+            stream->dec_position - stream->dec_cpylen, inst->size);
+      } else {
+        static int cnt;
+        XD3_ASSERT(inst->type == XD3_RUN);
+        XPR(NT "DECODE:%d: RUN at %" XD3_Q "u (winoffset %" XD3_W
+               "u) size %" XD3_W "u\n",
+            cnt++,
+            stream->total_out + stream->dec_position - stream->dec_cpylen,
+            stream->dec_position - stream->dec_cpylen, inst->size);
+      }
+    });
+  }
+
+  /* Check: The instruction will not overflow the output buffer. */
+  if (stream->dec_position + inst->size > stream->dec_maxpos) {
+    stream->msg = "size too large";
+    return XD3_INVALID_INPUT;
+  }
+
+  stream->dec_position += inst->size;
+  return 0;
+}
+
+/* Decode a single opcode and then decode the two half-instructions. */
+static int xd3_decode_instruction(xd3_stream *stream) {
+  int ret;
+  const xd3_dinst *inst;
+
+  if (stream->inst_sect.buf == stream->inst_sect.buf_max) {
+    stream->msg = "instruction underflow";
+    return XD3_INVALID_INPUT;
+  }
+
+  inst = &stream->code_table[*stream->inst_sect.buf++];
+
+  stream->dec_current1.type = inst->type1;
+  stream->dec_current2.type = inst->type2;
+  stream->dec_current1.size = inst->size1;
+  stream->dec_current2.size = inst->size2;
+
+  /* For each instruction with a real operation, decode the
+   * corresponding size and addresses if necessary.  Assume a
+   * code-table may have NOOP in either position, although this is
+   * unlikely. */
+  if (inst->type1 != XD3_NOOP &&
+      (ret = xd3_decode_parse_halfinst(stream, &stream->dec_current1))) {
+    return ret;
+  }
+  if (inst->type2 != XD3_NOOP &&
+      (ret = xd3_decode_parse_halfinst(stream, &stream->dec_current2))) {
+    return ret;
+  }
+  return 0;
+}
+
+/* Output the result of a single half-instruction. OPT: This the
+   decoder hotspot.  Modifies "hinst", see below.  */
+static int xd3_decode_output_halfinst(xd3_stream *stream, xd3_hinst *inst) {
+  /* This method is reentrant for copy instructions which may return
+   * XD3_GETSRCBLK to the caller.  Each time through a copy takes the
+   * minimum of inst->size and the available space on whichever block
+   * supplies the data */
+  usize_t take = inst->size;
+
+  if (USIZE_T_OVERFLOW(stream->avail_out, take) ||
+      stream->avail_out + take > stream->space_out) {
+    stream->msg = "overflow while decoding";
+    return XD3_INVALID_INPUT;
+  }
+
+  XD3_ASSERT(inst->type != XD3_NOOP);
+
+  switch (inst->type) {
+  case XD3_RUN: {
+    /* Only require a single data byte. */
+    if (stream->data_sect.buf == stream->data_sect.buf_max) {
+      stream->msg = "data underflow";
+      return XD3_INVALID_INPUT;
+    }
+
+    memset(stream->next_out + stream->avail_out, stream->data_sect.buf[0],
+           take);
+
+    stream->data_sect.buf += 1;
+    stream->avail_out += take;
+    inst->type = XD3_NOOP;
+    break;
+  }
+  case XD3_ADD: {
+    /* Require at least TAKE data bytes. */
+    if (stream->data_sect.buf + take > stream->data_sect.buf_max) {
+      stream->msg = "data underflow";
+      return XD3_INVALID_INPUT;
+    }
+
+    memcpy(stream->next_out + stream->avail_out, stream->data_sect.buf, take);
+
+    stream->data_sect.buf += take;
+    stream->avail_out += take;
+    inst->type = XD3_NOOP;
+    break;
+  }
+  default: {
+    usize_t i;
+    const uint8_t *src;
+    uint8_t *dst;
+    int overlap;
+
+    /* See if it copies from the VCD_TARGET/VCD_SOURCE window or
+     * the target window.  Out-of-bounds checks for the addresses
+     * and sizes are performed in xd3_decode_parse_halfinst.  This
+     * if/else must set "overlap", "src", and "dst". */
+    if (inst->addr < stream->dec_cpylen) {
+      /* In both branches we are copying from outside the
+       * current decoder window, the first (VCD_TARGET) is
+       * unimplemented. */
+      overlap = 0;
+
+      /* This branch sets "src".  As a side-effect, we modify
+       * "inst" so that if we reenter this method after a
+       * XD3_GETSRCBLK response the state is correct.  So if the
+       * instruction can be fulfilled by a contiguous block of
+       * memory then we will set:
+       *
+       *  inst->type = XD3_NOOP;
+       *  inst->size = 0;
+       */
+      if (stream->dec_win_ind & VCD_TARGET) {
+        /* TODO: Users have requested long-distance copies of
+         * similar material within a target (e.g., for dup
+         * supression in backups). This code path is probably
+         * dead due to XD3_UNIMPLEMENTED in xd3_decode_setup_buffers */
+        inst->size = 0;
+        inst->type = XD3_NOOP;
+        stream->msg = "VCD_TARGET not implemented";
+        return XD3_UNIMPLEMENTED;
+      } else {
+        /* In this case we have to read a source block, which
+         * could return control to the caller.  We need to
+         * know the first block number needed for this
+         * copy. */
+        xd3_source *source = stream->src;
+        xoff_t block = source->cpyoff_blocks;
+        usize_t blkoff = source->cpyoff_blkoff;
+        const usize_t blksize = source->blksize;
+        int ret;
+
+        xd3_blksize_add(&block, &blkoff, source, inst->addr);
+        XD3_ASSERT(blkoff < blksize);
+
+        if ((ret = xd3_getblk(stream, block))) {
+          /* could be a XD3_GETSRCBLK failure. */
+          if (ret == XD3_TOOFARBACK) {
+            stream->msg = "non-seekable source in decode";
+            ret = XD3_INTERNAL;
+          }
+          return ret;
+        }
+
+        src = source->curblk + blkoff;
+
+        /* This block is either full, or a partial block that
+         * must contain enough bytes. */
+        if ((source->onblk != blksize) && (blkoff + take > source->onblk)) {
+          IF_DEBUG1(XPR(NT "[srcfile] short at blkno %" XD3_Q "u onblk "
+                           "%" XD3_W "u blksize %" XD3_W "u blkoff %" XD3_W
+                           "u take %" XD3_W "u\n",
+                        block, source->onblk, blksize, blkoff, take));
+          stream->msg = "source file too short";
+          return XD3_INVALID_INPUT;
+        }
+
+        XD3_ASSERT(blkoff != blksize);
+
+        /* Check if we have enough data on this block to
+         * finish the instruction. */
+        if (blkoff + take <= blksize) {
+          inst->type = XD3_NOOP;
+          inst->size = 0;
+        } else {
+          take = blksize - blkoff;
+          inst->size -= take;
+          inst->addr += take;
+
+          /* because (blkoff + take > blksize), above */
+          XD3_ASSERT(inst->size != 0);
+        }
+      }
+    } else {
+      /* TODO: the memcpy/overlap optimization, etc.  Overlap
+       * here could be more specific, it's whether (inst->addr -
+       * srclen) + inst->size > input_pos ?  And is the system
+       * memcpy really any good? */
+      overlap = 1;
+
+      /* For a target-window copy, we know the entire range is
+       * in-memory.  The dec_tgtaddrbase is negatively offset by
+       * dec_cpylen because the addresses start beyond that
+       * point. */
+      src = stream->dec_tgtaddrbase + inst->addr;
+      inst->type = XD3_NOOP;
+      inst->size = 0;
+    }
+
+    dst = stream->next_out + stream->avail_out;
+
+    stream->avail_out += take;
+
+    if (overlap) {
+      /* Can't just memcpy here due to possible overlap. */
+      for (i = take; i != 0; i -= 1) {
+        *dst++ = *src++;
+      }
+    } else {
+      memcpy(dst, src, take);
+    }
+  }
+  }
+
+  return 0;
+}
+
+static int xd3_decode_finish_window(xd3_stream *stream) {
+  stream->dec_winbytes = 0;
+  stream->dec_state = DEC_FINISH;
+
+  stream->data_sect.pos = 0;
+  stream->inst_sect.pos = 0;
+  stream->addr_sect.pos = 0;
+
+  return XD3_OUTPUT;
+}
+
+static int xd3_decode_secondary_sections(xd3_stream *secondary_stream) {
+#if SECONDARY_ANY
+  int ret;
+#define DECODE_SECONDARY_SECTION(UPPER, LOWER)                                 \
+  ((secondary_stream->dec_del_ind & VCD_##UPPER##COMP) &&                      \
+   (ret = xd3_decode_secondary(secondary_stream,                               \
+                               &secondary_stream->LOWER##_sect,                \
+                               &xd3_sec_##LOWER(secondary_stream))))
+
+  if (DECODE_SECONDARY_SECTION(DATA, data) ||
+      DECODE_SECONDARY_SECTION(INST, inst) ||
+      DECODE_SECONDARY_SECTION(ADDR, addr)) {
+    return ret;
+  }
+#undef DECODE_SECONDARY_SECTION
+#endif
+  return 0;
+}
+
+static int xd3_decode_sections(xd3_stream *stream) {
+  usize_t need, more, take;
+  int copy, ret;
+
+  if ((stream->flags & XD3_JUST_HDR) != 0) {
+    /* Nothing left to do. */
+    return xd3_decode_finish_window(stream);
+  }
+
+  /* To avoid extra copying, allocate three sections at once (but
+   * check for overflow). */
+  need = stream->inst_sect.size;
+
+  if (USIZE_T_OVERFLOW(need, stream->addr_sect.size)) {
+    stream->msg = "decoder section size overflow";
+    return XD3_INTERNAL;
+  }
+  need += stream->addr_sect.size;
+
+  if (USIZE_T_OVERFLOW(need, stream->data_sect.size)) {
+    stream->msg = "decoder section size overflow";
+    return XD3_INTERNAL;
+  }
+  need += stream->data_sect.size;
+
+  /* The window may be entirely processed. */
+  XD3_ASSERT(stream->dec_winbytes <= need);
+
+  /* Compute how much more input is needed. */
+  more = (need - stream->dec_winbytes);
+
+  /* How much to consume. */
+  take = xd3_min(more, stream->avail_in);
+
+  /* See if the input is completely available, to avoid copy. */
+  copy = (take != more);
+
+  /* If the window is skipped... */
+  if ((stream->flags & XD3_SKIP_WINDOW) != 0) {
+    /* Skip the available input. */
+    DECODE_INPUT(take);
+
+    stream->dec_winbytes += take;
+
+    if (copy) {
+      stream->msg = "further input required";
+      return XD3_INPUT;
+    }
+
+    return xd3_decode_finish_window(stream);
+  }
+
+  /* Process all but the DATA section. */
+  switch (stream->dec_state) {
+  default:
+    stream->msg = "internal error";
+    return XD3_INVALID_INPUT;
+
+  case DEC_DATA:
+    if ((ret =
+             xd3_decode_section(stream, &stream->data_sect, DEC_INST, copy))) {
+      return ret;
+    }
+  case DEC_INST:
+    if ((ret =
+             xd3_decode_section(stream, &stream->inst_sect, DEC_ADDR, copy))) {
+      return ret;
+    }
+  case DEC_ADDR:
+    if ((ret =
+             xd3_decode_section(stream, &stream->addr_sect, DEC_EMIT, copy))) {
+      return ret;
+    }
+  }
+
+  XD3_ASSERT(stream->dec_winbytes == need);
+
+  if ((ret = xd3_decode_secondary_sections(stream))) {
+    return ret;
+  }
+
+  if (stream->flags & XD3_SKIP_EMIT) {
+    return xd3_decode_finish_window(stream);
+  }
+
+  /* OPT: A possible optimization is to avoid allocating memory in
+   * decode_setup_buffers and to avoid a large memcpy when the window
+   * consists of a single VCD_SOURCE copy instruction. */
+  if ((ret = xd3_decode_setup_buffers(stream))) {
+    return ret;
+  }
+
+  return 0;
+}
+
+static int xd3_decode_emit(xd3_stream *stream) {
+  int ret;
+
+  /* Produce output: originally structured to allow reentrant code
+   * that fills as much of the output buffer as possible, but VCDIFF
+   * semantics allows to copy from anywhere from the target window, so
+   * instead allocate a sufficiently sized buffer after the target
+   * window length is decoded.
+   *
+   * This code still needs to be reentrant to allow XD3_GETSRCBLK to
+   * return control.  This is handled by setting the
+   * stream->dec_currentN instruction types to XD3_NOOP after they
+   * have been processed. */
+  XD3_ASSERT(!(stream->flags & XD3_SKIP_EMIT));
+  XD3_ASSERT(stream->dec_tgtlen <= stream->space_out);
+
+  while (stream->inst_sect.buf != stream->inst_sect.buf_max ||
+         stream->dec_current1.type != XD3_NOOP ||
+         stream->dec_current2.type != XD3_NOOP) {
+    /* Decode next instruction pair. */
+    if ((stream->dec_current1.type == XD3_NOOP) &&
+        (stream->dec_current2.type == XD3_NOOP) &&
+        (ret = xd3_decode_instruction(stream))) {
+      return ret;
+    }
+
+    /* Output dec_current1 */
+    while ((stream->dec_current1.type != XD3_NOOP)) {
+      if ((ret = xd3_decode_output_halfinst(stream, &stream->dec_current1))) {
+        return ret;
+      }
+    }
+    /* Output dec_current2 */
+    while (stream->dec_current2.type != XD3_NOOP) {
+      if ((ret = xd3_decode_output_halfinst(stream, &stream->dec_current2))) {
+        return ret;
+      }
+    }
+  }
+
+  if (stream->avail_out != stream->dec_tgtlen) {
+    IF_DEBUG2(DP(RINT "AVAIL_OUT(%" XD3_W "u) != DEC_TGTLEN(%" XD3_W "u)\n",
+                 stream->avail_out, stream->dec_tgtlen));
+    stream->msg = "wrong window length";
+    return XD3_INVALID_INPUT;
+  }
+
+  if (stream->data_sect.buf != stream->data_sect.buf_max) {
+    stream->msg = "extra data section";
+    return XD3_INVALID_INPUT;
+  }
+
+  if (stream->addr_sect.buf != stream->addr_sect.buf_max) {
+    stream->msg = "extra address section";
+    return XD3_INVALID_INPUT;
+  }
+
+  /* OPT: Should cksum computation be combined with the above loop? */
+  if ((stream->dec_win_ind & VCD_ADLER32) != 0 &&
+      (stream->flags & XD3_ADLER32_NOVER) == 0) {
+    uint32_t a32 = adler32(1L, stream->next_out, stream->avail_out);
+
+    if (a32 != stream->dec_adler32) {
+      stream->msg = "target window checksum mismatch: the supplied "
+                    "source likely does not match the one used to create "
+                    "this patch";
+      return XD3_INVALID_INPUT;
+    }
+  }
+
+  /* Finished with a window. */
+  return xd3_decode_finish_window(stream);
+}
+
+int xd3_decode_input(xd3_stream *stream) {
+  int ret;
+
+  if (stream->enc_state != 0) {
+    stream->msg = "encoder/decoder transition";
+    return XD3_INVALID_INPUT;
+  }
+
+#define BYTE_CASE(expr, x, nstate)                                             \
+  do {                                                                         \
+    if ((expr) && ((ret = xd3_decode_byte(stream, &(x))) != 0)) {              \
+      return ret;                                                              \
+    }                                                                          \
+    stream->dec_state = (nstate);                                              \
+  } while (0)
+
+#define OFFSET_CASE(expr, x, nstate)                                           \
+  do {                                                                         \
+    if ((expr) && ((ret = xd3_decode_offset(stream, &(x))) != 0)) {            \
+      return ret;                                                              \
+    }                                                                          \
+    stream->dec_state = (nstate);                                              \
+  } while (0)
+
+#define SIZE_CASE(expr, x, nstate)                                             \
+  do {                                                                         \
+    if ((expr) && ((ret = xd3_decode_size(stream, &(x))) != 0)) {              \
+      return ret;                                                              \
+    }                                                                          \
+    stream->dec_state = (nstate);                                              \
+  } while (0)
+
+  switch (stream->dec_state) {
+  case DEC_VCHEAD: {
+    if ((ret = xd3_decode_bytes(stream, stream->dec_magic,
+                                &stream->dec_magicbytes, 4))) {
+      return ret;
+    }
+
+    if (stream->dec_magic[0] != VCDIFF_MAGIC1 ||
+        stream->dec_magic[1] != VCDIFF_MAGIC2 ||
+        stream->dec_magic[2] != VCDIFF_MAGIC3) {
+      stream->msg = "not a VCDIFF input";
+      return XD3_INVALID_INPUT;
+    }
+
+    if (stream->dec_magic[3] != 0) {
+      stream->msg = "VCDIFF input version > 0 is not supported";
+      return XD3_INVALID_INPUT;
+    }
+
+    stream->dec_state = DEC_HDRIND;
+  }
+  case DEC_HDRIND: {
+    if ((ret = xd3_decode_byte(stream, &stream->dec_hdr_ind))) {
+      return ret;
+    }
+
+    if ((stream->dec_hdr_ind & VCD_INVHDR) != 0) {
+      stream->msg = "unrecognized header indicator bits set";
+      return XD3_INVALID_INPUT;
+    }
+
+    stream->dec_state = DEC_SECONDID;
+  }
+
+  case DEC_SECONDID:
+    /* Secondary compressor ID: only if VCD_SECONDARY is set */
+    if ((stream->dec_hdr_ind & VCD_SECONDARY) != 0) {
+      BYTE_CASE(1, stream->dec_secondid, DEC_TABLEN);
+
+      switch (stream->dec_secondid) {
+      case VCD_FGK_ID:
+        FGK_CASE(stream);
+      case VCD_DJW_ID:
+        DJW_CASE(stream);
+      case VCD_LZMA_ID:
+        LZMA_CASE(stream);
+      default:
+        stream->msg = "unknown secondary compressor ID";
+        return XD3_INVALID_INPUT;
+      }
+    }
+
+  case DEC_TABLEN:
+    /* Length of code table data: only if VCD_CODETABLE is set */
+    SIZE_CASE((stream->dec_hdr_ind & VCD_CODETABLE) != 0, stream->dec_codetblsz,
+              DEC_NEAR);
+
+    /* The codetblsz counts the two NEAR/SAME bytes */
+    if ((stream->dec_hdr_ind & VCD_CODETABLE) != 0) {
+      if (stream->dec_codetblsz <= 2) {
+        stream->msg = "invalid code table size";
+        return ENOMEM;
+      }
+      stream->dec_codetblsz -= 2;
+    }
+  case DEC_NEAR:
+    /* Near modes: only if VCD_CODETABLE is set */
+    BYTE_CASE((stream->dec_hdr_ind & VCD_CODETABLE) != 0, stream->acache.s_near,
+              DEC_SAME);
+  case DEC_SAME:
+    /* Same modes: only if VCD_CODETABLE is set */
+    BYTE_CASE((stream->dec_hdr_ind & VCD_CODETABLE) != 0, stream->acache.s_same,
+              DEC_TABDAT);
+  case DEC_TABDAT:
+    /* Compressed code table data */
+
+    if ((stream->dec_hdr_ind & VCD_CODETABLE) != 0) {
+      stream->msg = "VCD_CODETABLE support was removed";
+      return XD3_UNIMPLEMENTED;
+    } else {
+      /* Use the default table. */
+      stream->acache.s_near = __rfc3284_code_table_desc.near_modes;
+      stream->acache.s_same = __rfc3284_code_table_desc.same_modes;
+      stream->code_table = xd3_rfc3284_code_table();
+    }
+
+    if ((ret = xd3_alloc_cache(stream))) {
+      return ret;
+    }
+
+    stream->dec_state = DEC_APPLEN;
+
+  case DEC_APPLEN:
+    /* Length of application data */
+    SIZE_CASE((stream->dec_hdr_ind & VCD_APPHEADER) != 0, stream->dec_appheadsz,
+              DEC_APPDAT);
+
+  case DEC_APPDAT:
+    /* Application data */
+    if (stream->dec_hdr_ind & VCD_APPHEADER) {
+      /* Note: we add an additional byte for padding, to allow
+         0-termination. Check for overflow: */
+      if (USIZE_T_OVERFLOW(stream->dec_appheadsz, 1)) {
+        stream->msg = "exceptional appheader size";
+        return XD3_INVALID_INPUT;
+      }
+
+      if ((stream->dec_appheader == NULL) &&
+          (stream->dec_appheader = (uint8_t *)xd3_alloc(
+               stream, stream->dec_appheadsz + 1, 1)) == NULL) {
+        return ENOMEM;
+      }
+
+      stream->dec_appheader[stream->dec_appheadsz] = 0;
+
+      if ((ret = xd3_decode_bytes(stream, stream->dec_appheader,
+                                  &stream->dec_appheadbytes,
+                                  stream->dec_appheadsz))) {
+        return ret;
+      }
+    }
+
+    /* xoff_t -> usize_t is safe because this is the first block. */
+    stream->dec_hdrsize = (usize_t)stream->total_in;
+    stream->dec_state = DEC_WININD;
+
+  case DEC_WININD: {
+    /* Start of a window: the window indicator */
+    if ((ret = xd3_decode_byte(stream, &stream->dec_win_ind))) {
+      return ret;
+    }
+
+    stream->current_window = stream->dec_window_count;
+
+    if (XOFF_T_OVERFLOW(stream->dec_winstart, stream->dec_tgtlen)) {
+      stream->msg = "decoder file offset overflow";
+      return XD3_INVALID_INPUT;
+    }
+
+    stream->dec_winstart += stream->dec_tgtlen;
+
+    if ((stream->dec_win_ind & VCD_INVWIN) != 0) {
+      stream->msg = "unrecognized window indicator bits set";
+      return XD3_INVALID_INPUT;
+    }
+
+    if ((ret = xd3_decode_init_window(stream))) {
+      return ret;
+    }
+
+    stream->dec_state = DEC_CPYLEN;
+
+    IF_DEBUG2(DP(RINT "--------- TARGET WINDOW %" XD3_Q "u -----------\n",
+                 stream->current_window));
+  }
+
+  case DEC_CPYLEN:
+    /* Copy window length: only if VCD_SOURCE or VCD_TARGET is set */
+    SIZE_CASE(SRCORTGT(stream->dec_win_ind), stream->dec_cpylen, DEC_CPYOFF);
+
+    /* Set the initial, logical decoder position (HERE address) in
+     * dec_position.  This is set to just after the source/copy
+     * window, as we are just about to output the first byte of
+     * target window. */
+    stream->dec_position = stream->dec_cpylen;
+
+  case DEC_CPYOFF:
+    /* Copy window offset: only if VCD_SOURCE or VCD_TARGET is set */
+    OFFSET_CASE(SRCORTGT(stream->dec_win_ind), stream->dec_cpyoff, DEC_ENCLEN);
+
+    /* Copy offset and copy length may not overflow. */
+    if (XOFF_T_OVERFLOW(stream->dec_cpyoff, stream->dec_cpylen)) {
+      stream->msg = "decoder copy window overflows a file offset";
+      return XD3_INVALID_INPUT;
+    }
+
+    /* Check copy window bounds: VCD_TARGET window may not exceed
+       current position. */
+    if ((stream->dec_win_ind & VCD_TARGET) &&
+        (stream->dec_cpyoff + stream->dec_cpylen > stream->dec_winstart)) {
+      stream->msg = "VCD_TARGET window out of bounds";
+      return XD3_INVALID_INPUT;
+    }
+
+  case DEC_ENCLEN:
+    /* Length of the delta encoding */
+    SIZE_CASE(1, stream->dec_enclen, DEC_TGTLEN);
+  case DEC_TGTLEN:
+    /* Length of target window */
+    SIZE_CASE(1, stream->dec_tgtlen, DEC_DELIND);
+
+    /* Set the maximum decoder position, beyond which we should not
+     * decode any data.  This is the maximum value for dec_position.
+     * This may not exceed the size of a usize_t. */
+    if (USIZE_T_OVERFLOW(stream->dec_cpylen, stream->dec_tgtlen)) {
+      stream->msg = "decoder target window overflows a usize_t";
+      return XD3_INVALID_INPUT;
+    }
+
+    /* Check for malicious files. */
+    if (stream->dec_tgtlen > XD3_HARDMAXWINSIZE) {
+      stream->msg = "hard window size exceeded";
+      return XD3_INVALID_INPUT;
+    }
+
+    stream->dec_maxpos = stream->dec_cpylen + stream->dec_tgtlen;
+
+  case DEC_DELIND:
+    /* Delta indicator */
+    BYTE_CASE(1, stream->dec_del_ind, DEC_DATALEN);
+
+    if ((stream->dec_del_ind & VCD_INVDEL) != 0) {
+      stream->msg = "unrecognized delta indicator bits set";
+      return XD3_INVALID_INPUT;
+    }
+
+    /* Delta indicator is only used with secondary compression. */
+    if ((stream->dec_del_ind != 0) && (stream->sec_type == NULL)) {
+      stream->msg = "invalid delta indicator bits set";
+      return XD3_INVALID_INPUT;
+    }
+
+    /* Section lengths */
+  case DEC_DATALEN:
+    SIZE_CASE(1, stream->data_sect.size, DEC_INSTLEN);
+  case DEC_INSTLEN:
+    SIZE_CASE(1, stream->inst_sect.size, DEC_ADDRLEN);
+  case DEC_ADDRLEN:
+    SIZE_CASE(1, stream->addr_sect.size, DEC_CKSUM);
+
+  case DEC_CKSUM:
+    /* Window checksum. */
+    if ((stream->dec_win_ind & VCD_ADLER32) != 0) {
+      int i;
+
+      if ((ret = xd3_decode_bytes(stream, stream->dec_cksum,
+                                  &stream->dec_cksumbytes, 4))) {
+        return ret;
+      }
+
+      for (i = 0; i < 4; i += 1) {
+        stream->dec_adler32 = (stream->dec_adler32 << 8) | stream->dec_cksum[i];
+      }
+    }
+
+    stream->dec_state = DEC_DATA;
+
+    /* Check dec_enclen for redundency, otherwise it is not really used. */
+    {
+      usize_t enclen_check = (1 +
+                              (xd3_sizeof_size(stream->dec_tgtlen) +
+                               xd3_sizeof_size(stream->data_sect.size) +
+                               xd3_sizeof_size(stream->inst_sect.size) +
+                               xd3_sizeof_size(stream->addr_sect.size)) +
+                              stream->data_sect.size + stream->inst_sect.size +
+                              stream->addr_sect.size +
+                              ((stream->dec_win_ind & VCD_ADLER32) ? 4 : 0));
+
+      if (stream->dec_enclen != enclen_check) {
+        stream->msg = "incorrect encoding length (redundent)";
+        return XD3_INVALID_INPUT;
+      }
+    }
+
+    /* Returning here gives the application a chance to inspect the
+     * header, skip the window, etc. */
+    if (stream->current_window == 0) {
+      return XD3_GOTHEADER;
+    } else {
+      return XD3_WINSTART;
+    }
+
+  case DEC_DATA:
+  case DEC_INST:
+  case DEC_ADDR:
+    /* Next read the three sections. */
+    if ((ret = xd3_decode_sections(stream))) {
+      return ret;
+    }
+
+  case DEC_EMIT:
+
+    /* To speed VCD_SOURCE block-address calculations, the source
+     * cpyoff_blocks and cpyoff_blkoff are pre-computed. */
+    if (stream->dec_win_ind & VCD_SOURCE) {
+      xd3_source *src = stream->src;
+
+      if (src == NULL) {
+        stream->msg = "source input required";
+        return XD3_INVALID_INPUT;
+      }
+
+      xd3_blksize_div(stream->dec_cpyoff, src, &src->cpyoff_blocks,
+                      &src->cpyoff_blkoff);
+
+      IF_DEBUG2(DP(RINT "[decode_cpyoff] %" XD3_Q "u "
+                        "cpyblkno %" XD3_Q "u "
+                        "cpyblkoff %" XD3_W "u "
+                        "blksize %" XD3_W "u\n",
+                   stream->dec_cpyoff, src->cpyoff_blocks, src->cpyoff_blkoff,
+                   src->blksize));
+    }
+
+    /* xd3_decode_emit returns XD3_OUTPUT on every success. */
+    if ((ret = xd3_decode_emit(stream)) == XD3_OUTPUT) {
+      stream->total_out += stream->avail_out;
+    }
+
+    return ret;
+
+  case DEC_FINISH: {
+    if (stream->dec_win_ind & VCD_TARGET) {
+      if (stream->dec_lastwin == NULL) {
+        stream->dec_lastwin = stream->next_out;
+        stream->dec_lastspace = stream->space_out;
+      } else {
+        xd3_swap_uint8p(&stream->dec_lastwin, &stream->next_out);
+        xd3_swap_usize_t(&stream->dec_lastspace, &stream->space_out);
+      }
+    }
+
+    stream->dec_lastlen = stream->dec_tgtlen;
+    stream->dec_laststart = stream->dec_winstart;
+    stream->dec_window_count += 1;
+
+    /* Note: the updates to dec_winstart & current_window are
+     * deferred until after the next DEC_WININD byte is read. */
+    stream->dec_state = DEC_WININD;
+    return XD3_WINFINISH;
+  }
+
+  default:
+    stream->msg = "invalid state";
+    return XD3_INVALID_INPUT;
+  }
+}
+
+#endif // _XDELTA3_DECODE_H_

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-djw.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-djw.h
@@ -1,0 +1,1682 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef _XDELTA3_DJW_H_
+#define _XDELTA3_DJW_H_
+
+/* The following people deserve much credit for the algorithms and
+ * techniques contained in this file:
+
+ Julian Seward
+ Bzip2 sources, implementation of the multi-table Huffman technique.
+
+ Jean-loup Gailly and Mark Adler and L. Peter Deutsch
+ Zlib source code, RFC 1951
+
+ Daniel S. Hirschberg and Debra A. LeLewer
+ "Efficient Decoding of Prefix Codes"
+ Communications of the ACM, April 1990 33(4).
+
+ David J. Wheeler
+ Program bred3.c, bexp3 and accompanying documents bred3.ps, huff.ps.
+ This contains the idea behind the multi-table Huffman and 1-2 coding
+ techniques.
+ ftp://ftp.cl.cam.ac.uk/users/djw3/
+
+*/
+
+/* OPT: during the multi-table iteration, pick the worst-overall
+ * performing table and replace it with exactly the frequencies of the
+ * worst-overall performing sector or N-worst performing sectors. */
+
+/* REF: See xdfs-0.222 and xdfs-0.226 for some old experiments with
+ * the Bzip prefix coding strategy.  xdfs-0.256 contains the last of
+ * the other-format tests, including RFC1950 and the RFC1950+MTF
+ * tests. */
+
+#define DJW_MAX_CODELEN 20U /* Maximum length of an alphabet code. */
+
+/* Code lengths are themselves code-length encoded, so the total number of
+ * codes is: [RUN_0, RUN_1, 1-DJW_MAX_CODELEN] */
+#define DJW_TOTAL_CODES (DJW_MAX_CODELEN + 2)
+
+#define RUN_0 0U /* Symbols used in MTF+1/2 coding. */
+#define RUN_1 1U
+
+/* Number of code lengths always encoded (djw_encode_basic array) */
+#define DJW_BASIC_CODES 5U
+#define DJW_RUN_CODES 2U /* Number of run codes */
+
+/* Offset of extra codes */
+#define DJW_EXTRA_12OFFSET (DJW_BASIC_CODES + DJW_RUN_CODES)
+
+/* Number of optionally encoded code lengths (djw_encode_extra array) */
+#define DJW_EXTRA_CODES 15U
+
+/* Number of bits to code [0-DJW_EXTRA_CODES] */
+#define DJW_EXTRA_CODE_BITS 4U
+
+#define DJW_MAX_GROUPS 8U /* Max number of group coding tables */
+#define DJW_GROUP_BITS 3U /* Number of bits to code [1-DJW_MAX_GROUPS] */
+
+#define DJW_SECTORSZ_MULT 5U /* Multiplier for encoded sectorsz */
+#define DJW_SECTORSZ_BITS 5U /* Number of bits to code group size */
+#define DJW_SECTORSZ_MAX ((1U << DJW_SECTORSZ_BITS) * DJW_SECTORSZ_MULT)
+
+/* Maximum number of iterations to find group tables. */
+#define DJW_MAX_ITER 6U
+/* Minimum number of bits an iteration must reduce coding by. */
+#define DJW_MIN_IMPROVEMENT 20U
+
+/* Maximum code length of a prefix code length */
+#define DJW_MAX_CLCLEN 15U
+
+/* Number of bits to code [0-DJW_MAX_CLCLEN] */
+#define DJW_CLCLEN_BITS 4U
+
+#define DJW_MAX_GBCLEN 7U /* Maximum code length of a group selector */
+
+/* Number of bits to code [0-DJW_MAX_GBCLEN]
+ * TODO: Actually, should never have zero code lengths here, or else a group
+ * went unused.  Write a test for this: if a group goes unused, eliminate
+ * it? */
+#define DJW_GBCLEN_BITS 3U
+
+/* It has to save at least this many bits... */
+#define EFFICIENCY_BITS 16U
+
+typedef struct _djw_stream djw_stream;
+typedef struct _djw_heapen djw_heapen;
+typedef struct _djw_prefix djw_prefix;
+typedef uint32_t djw_weight;
+
+struct _djw_heapen {
+  uint32_t depth;
+  uint32_t freq;
+  uint32_t parent;
+};
+
+struct _djw_prefix {
+  usize_t scount;
+  uint8_t *symbol;
+  usize_t mcount;
+  uint8_t *mtfsym;
+  uint8_t *repcnt;
+};
+
+struct _djw_stream {
+  int unused;
+};
+
+/* Each Huffman table consists of 256 "code length" (CLEN) codes,
+ * which are themselves Huffman coded after eliminating repeats and
+ * move-to-front coding.  The prefix consists of all the CLEN codes in
+ * djw_encode_basic plus a 4-bit value stating how many of the
+ * djw_encode_extra codes are actually coded (the rest are presumed
+ * zero, or unused CLEN codes).
+ *
+ * These values of these two arrays were arrived at by studying the
+ * distribution of min and max clen over a collection of DATA, INST,
+ * and ADDR inputs.  The goal is to specify the order of
+ * djw_extra_codes that is most likely to minimize the number of extra
+ * codes that must be encoded.
+ *
+ * Results: 158896 sections were counted by compressing files (window
+ * size 512K) listed with: `find / -type f ( -user jmacd -o -perm +444
+ * )`
+ *
+ * The distribution of CLEN codes for each efficient invocation of the
+ * secondary compressor (taking the best number of groups/sector size)
+ * was recorded.  Then we look at the distribution of min and max clen
+ * values, counting the number of times the value C_low is less than
+ * the min and C_high is greater than the max.  Values >= C_high and
+ * <= C_low will not have their lengths coded.  The results are sorted
+ * and the least likely 15 are placed into the djw_encode_extra[]
+ * array in order.  These values are used as the initial MTF ordering.
+
+ clow[1] = 155119
+ clow[2] = 140325
+ clow[3] = 84072
+ ---
+ clow[4] = 7225
+ clow[5] = 1093
+ clow[6] = 215
+ ---
+ chigh[4] = 1
+ chigh[5] = 30
+ chigh[6] = 218
+ chigh[7] = 2060
+ chigh[8] = 13271
+ ---
+ chigh[9] = 39463
+ chigh[10] = 77360
+ chigh[11] = 118298
+ chigh[12] = 141360
+ chigh[13] = 154086
+ chigh[14] = 157967
+ chigh[15] = 158603
+ chigh[16] = 158864
+ chigh[17] = 158893
+ chigh[18] = 158895
+ chigh[19] = 158896
+ chigh[20] = 158896
+
+*/
+
+static const uint8_t djw_encode_12extra[DJW_EXTRA_CODES] = {
+    9, 10, 3, 11, 2, 12, 13, 1, 14, 15, 16, 17, 18, 19, 20,
+};
+
+static const uint8_t djw_encode_12basic[DJW_BASIC_CODES] = {
+    4, 5, 6, 7, 8,
+};
+
+/*********************************************************************/
+/*                              DECLS                                */
+/*********************************************************************/
+
+static djw_stream *djw_alloc(xd3_stream *stream);
+static int djw_init(xd3_stream *stream, djw_stream *h, int is_encode);
+static void djw_destroy(xd3_stream *stream, djw_stream *h);
+
+#if XD3_ENCODER
+static int xd3_encode_huff(xd3_stream *stream, djw_stream *sec_stream,
+                           xd3_output *input, xd3_output *output,
+                           xd3_sec_cfg *cfg);
+#endif
+
+static int xd3_decode_huff(xd3_stream *stream, djw_stream *sec_stream,
+                           const uint8_t **input,
+                           const uint8_t *const input_end, uint8_t **output,
+                           const uint8_t *const output_end);
+
+/*********************************************************************/
+/*                             HUFFMAN                               */
+/*********************************************************************/
+
+static djw_stream *djw_alloc(xd3_stream *stream) {
+  return (djw_stream *)xd3_alloc(stream, sizeof(djw_stream), 1);
+}
+
+static int djw_init(xd3_stream *stream, djw_stream *h, int is_encode) {
+  /* Fields are initialized prior to use. */
+  return 0;
+}
+
+static void djw_destroy(xd3_stream *stream, djw_stream *h) {
+  xd3_free(stream, h);
+}
+
+/*********************************************************************/
+/*                               HEAP                                */
+/*********************************************************************/
+
+static inline int heap_less(const djw_heapen *a, const djw_heapen *b) {
+  return a->freq < b->freq || (a->freq == b->freq && a->depth < b->depth);
+}
+
+static inline void heap_insert(usize_t *heap, const djw_heapen *ents, usize_t p,
+                               const usize_t e) {
+  /* Insert ents[e] into next slot heap[p] */
+  usize_t pp = p / 2; /* P's parent */
+
+  while (heap_less(&ents[e], &ents[heap[pp]])) {
+    heap[p] = heap[pp];
+    p = pp;
+    pp = p / 2;
+  }
+
+  heap[p] = e;
+}
+
+static inline djw_heapen *heap_extract(usize_t *heap, const djw_heapen *ents,
+                                       usize_t heap_last) {
+  usize_t smallest = heap[1];
+  usize_t p, pc, t;
+
+  /* Caller decrements heap_last, so heap_last+1 is the replacement elt. */
+  heap[1] = heap[heap_last + 1];
+
+  /* Re-heapify */
+  for (p = 1;; p = pc) {
+    pc = p * 2;
+
+    /* Reached bottom of heap */
+    if (pc > heap_last) {
+      break;
+    }
+
+    /* See if second child is smaller. */
+    if (pc < heap_last && heap_less(&ents[heap[pc + 1]], &ents[heap[pc]])) {
+      pc += 1;
+    }
+
+    /* If pc is not smaller than p, heap property re-established. */
+    if (!heap_less(&ents[heap[pc]], &ents[heap[p]])) {
+      break;
+    }
+
+    t = heap[pc];
+    heap[pc] = heap[p];
+    heap[p] = t;
+  }
+
+  return (djw_heapen *)&ents[smallest];
+}
+
+#if XD3_DEBUG
+static void heap_check(usize_t *heap, djw_heapen *ents, usize_t heap_last) {
+  usize_t i;
+  for (i = 1; i <= heap_last; i += 1) {
+    /* Heap property: child not less than parent */
+    XD3_ASSERT(!heap_less(&ents[heap[i]], &ents[heap[i / 2]]));
+
+    IF_DEBUG2(DP(RINT "heap[%" XD3_W "u] = %u\n", i, ents[heap[i]].freq));
+  }
+}
+#endif
+
+/*********************************************************************/
+/*                             MTF, 1/2                              */
+/*********************************************************************/
+
+static inline usize_t djw_update_mtf(uint8_t *mtf, usize_t mtf_i) {
+  int k;
+  usize_t sym = mtf[mtf_i];
+
+  for (k = (int)mtf_i; k != 0; k -= 1) {
+    mtf[k] = mtf[k - 1];
+  }
+
+  mtf[0] = (uint8_t)sym;
+  return sym;
+}
+
+static inline void djw_update_1_2(int *mtf_run, usize_t *mtf_i, uint8_t *mtfsym,
+                                  djw_weight *freq) {
+  uint8_t code;
+
+  do {
+    /* Offset by 1, since any number of RUN_ symbols implies run>0... */
+    *mtf_run -= 1;
+
+    code = (*mtf_run & 1) ? RUN_1 : RUN_0;
+
+    mtfsym[(*mtf_i)++] = code;
+    freq[code] += 1;
+    *mtf_run >>= 1;
+  } while (*mtf_run >= 1);
+
+  *mtf_run = 0;
+}
+
+static void djw_init_clen_mtf_1_2(uint8_t *clmtf) {
+  usize_t i, cl_i = 0;
+
+  clmtf[cl_i++] = 0;
+  for (i = 0; i < DJW_BASIC_CODES; i += 1) {
+    clmtf[cl_i++] = djw_encode_12basic[i];
+  }
+  for (i = 0; i < DJW_EXTRA_CODES; i += 1) {
+    clmtf[cl_i++] = djw_encode_12extra[i];
+  }
+}
+
+/*********************************************************************/
+/*                           PREFIX CODES                            */
+/*********************************************************************/
+#if XD3_ENCODER
+static usize_t djw_build_prefix(const djw_weight *freq, uint8_t *clen,
+                                usize_t asize, usize_t maxlen) {
+  /* Heap with 0th entry unused, prefix tree with up to ALPHABET_SIZE-1
+   * internal nodes, never more than ALPHABET_SIZE entries actually in the
+   * heap (minimum weight subtrees during prefix construction).  First
+   * ALPHABET_SIZE entries are the actual symbols, next ALPHABET_SIZE-1 are
+   * internal nodes. */
+  djw_heapen ents[ALPHABET_SIZE * 2];
+  usize_t heap[ALPHABET_SIZE + 1];
+
+  usize_t heap_last; /* Index of the last _valid_ heap entry. */
+  usize_t ents_size; /* Number of entries, including 0th fake entry */
+  usize_t overflow;  /* Number of code lengths that overflow */
+  usize_t total_bits;
+  usize_t i;
+
+  IF_DEBUG(usize_t first_bits = 0);
+
+  /* Insert real symbol frequences. */
+  for (i = 0; i < asize; i += 1) {
+    ents[i + 1].freq = freq[i];
+    IF_DEBUG2(DP(RINT "ents[%" XD3_W "i] = freq[%" XD3_W "u] = %d\n", i + 1, i,
+                 freq[i]));
+  }
+
+again:
+
+  /* The loop is re-entered each time an overflow occurs.  Re-initialize... */
+  heap_last = 0;
+  ents_size = 1;
+  overflow = 0;
+  total_bits = 0;
+
+  /* 0th entry terminates the while loop in heap_insert (it's the parent of
+   * the smallest element, always less-than) */
+  heap[0] = 0;
+  ents[0].depth = 0;
+  ents[0].freq = 0;
+
+  /* Initial heap. */
+  for (i = 0; i < asize; i += 1, ents_size += 1) {
+    ents[ents_size].depth = 0;
+    ents[ents_size].parent = 0;
+
+    if (ents[ents_size].freq != 0) {
+      heap_insert(heap, ents, ++heap_last, ents_size);
+    }
+  }
+
+  IF_DEBUG(heap_check(heap, ents, heap_last));
+
+  /* Must be at least one symbol, or else we can't get here. */
+  XD3_ASSERT(heap_last != 0);
+
+  /* If there is only one symbol, fake a second to prevent zero-length
+   * codes. */
+  if (heap_last == 1) {
+    /* Pick either the first or last symbol. */
+    usize_t s = freq[0] ? asize - 1 : 0;
+    ents[s + 1].freq = 1;
+    goto again;
+  }
+
+  /* Build prefix tree. */
+  while (heap_last > 1) {
+    djw_heapen *h1 = heap_extract(heap, ents, --heap_last);
+    djw_heapen *h2 = heap_extract(heap, ents, --heap_last);
+
+    ents[ents_size].freq = h1->freq + h2->freq;
+    ents[ents_size].depth = 1 + xd3_max(h1->depth, h2->depth);
+    ents[ents_size].parent = 0;
+
+    h1->parent = h2->parent = (uint32_t)ents_size;
+
+    heap_insert(heap, ents, ++heap_last, ents_size++);
+  }
+
+  IF_DEBUG(heap_check(heap, ents, heap_last));
+
+  /* Now compute prefix code lengths, counting parents. */
+  for (i = 1; i < asize + 1; i += 1) {
+    usize_t b = 0;
+
+    if (ents[i].freq != 0) {
+      usize_t p = i;
+
+      while ((p = ents[p].parent) != 0) {
+        b += 1;
+      }
+
+      if (b > maxlen) {
+        overflow = 1;
+      }
+
+      total_bits += b * freq[i - 1];
+    }
+
+    /* clen is 0-origin, unlike ents. */
+    IF_DEBUG2(DP(RINT "clen[%" XD3_W "u] = %" XD3_W "u\n", i - 1, b));
+    clen[i - 1] = (uint8_t)b;
+  }
+
+  IF_DEBUG(if (first_bits == 0) first_bits = total_bits);
+
+  if (!overflow) {
+    IF_DEBUG2(if (first_bits != total_bits) {
+      DP(RINT "code length overflow changed %" XD3_W "u bits\n",
+         total_bits - first_bits);
+    });
+    return total_bits;
+  }
+
+  /* OPT: There is a non-looping way to fix overflow shown in zlib, but this
+   * is easier (for now), as done in bzip2. */
+  for (i = 1; i < asize + 1; i += 1) {
+    ents[i].freq = ents[i].freq / 2 + 1;
+  }
+
+  goto again;
+}
+
+static void djw_build_codes(usize_t *codes, const uint8_t *clen, usize_t asize,
+                            usize_t abs_max) {
+  usize_t i, l;
+  usize_t min_clen = DJW_MAX_CODELEN;
+  usize_t max_clen = 0;
+  usize_t code = 0;
+
+  /* Find the min and max code length */
+  for (i = 0; i < asize; i += 1) {
+    if (clen[i] > 0 && clen[i] < min_clen) {
+      min_clen = clen[i];
+    }
+
+    max_clen = xd3_max(max_clen, (usize_t)clen[i]);
+  }
+
+  XD3_ASSERT(max_clen <= abs_max);
+
+  /* Generate a code for each symbol with the appropriate length. */
+  for (l = min_clen; l <= max_clen; l += 1) {
+    for (i = 0; i < asize; i += 1) {
+      if (clen[i] == l) {
+        codes[i] = code++;
+      }
+    }
+
+    code <<= 1;
+  }
+
+  IF_DEBUG2({
+    for (i = 0; i < asize; i += 1) {
+      DP(RINT "code[%" XD3_W "u] = %" XD3_W "u\n", i, codes[i]);
+    }
+  });
+}
+
+/*********************************************************************/
+/*			      MOVE-TO-FRONT                          */
+/*********************************************************************/
+static void djw_compute_mtf_1_2(djw_prefix *prefix, uint8_t *mtf,
+                                djw_weight *freq_out, usize_t nsym) {
+  size_t i, j, k;
+  usize_t sym;
+  usize_t size = prefix->scount;
+  usize_t mtf_i = 0;
+  int mtf_run = 0;
+
+  /* This +2 is for the RUN_0, RUN_1 codes */
+  memset(freq_out, 0, sizeof(freq_out[0]) * (nsym + 2));
+
+  for (i = 0; i < size;) {
+    /* OPT: Bzip optimizes this algorithm a little by effectively checking
+     * j==0 before the MTF update. */
+    sym = prefix->symbol[i++];
+
+    for (j = 0; mtf[j] != sym; j += 1) {
+    }
+
+    XD3_ASSERT(j <= nsym);
+
+    for (k = j; k >= 1; k -= 1) {
+      mtf[k] = mtf[k - 1];
+    }
+
+    mtf[0] = (uint8_t)sym;
+
+    if (j == 0) {
+      mtf_run += 1;
+      continue;
+    }
+
+    if (mtf_run > 0) {
+      djw_update_1_2(&mtf_run, &mtf_i, prefix->mtfsym, freq_out);
+    }
+
+    /* Non-zero symbols are offset by RUN_1 */
+    prefix->mtfsym[mtf_i++] = (uint8_t)(j + RUN_1);
+    freq_out[j + RUN_1] += 1;
+  }
+
+  if (mtf_run > 0) {
+    djw_update_1_2(&mtf_run, &mtf_i, prefix->mtfsym, freq_out);
+  }
+
+  prefix->mcount = mtf_i;
+}
+
+/* Counts character frequencies of the input buffer, returns the size. */
+static usize_t djw_count_freqs(djw_weight *freq, xd3_output *input) {
+  xd3_output *in;
+  usize_t size = 0;
+
+  memset(freq, 0, sizeof(freq[0]) * ALPHABET_SIZE);
+
+  for (in = input; in; in = in->next_page) {
+    const uint8_t *p = in->base;
+    const uint8_t *p_max = p + in->next;
+
+    size += in->next;
+
+    do {
+      ++freq[*p];
+    } while (++p < p_max);
+  }
+
+  IF_DEBUG2({
+    int i;
+    DP(RINT "freqs: ");
+    for (i = 0; i < ALPHABET_SIZE; i += 1) {
+      DP(RINT "%u ", freq[i]);
+    }
+    DP(RINT "\n");
+  });
+
+  return size;
+}
+
+static void
+djw_compute_multi_prefix(usize_t groups,
+                         uint8_t clen[DJW_MAX_GROUPS][ALPHABET_SIZE],
+                         djw_prefix *prefix) {
+  usize_t gp, i;
+
+  prefix->scount = ALPHABET_SIZE;
+  memcpy(prefix->symbol, clen[0], ALPHABET_SIZE);
+
+  for (gp = 1; gp < groups; gp += 1) {
+    for (i = 0; i < ALPHABET_SIZE; i += 1) {
+      if (clen[gp][i] == 0) {
+        continue;
+      }
+
+      prefix->symbol[prefix->scount++] = clen[gp][i];
+    }
+  }
+}
+
+static void djw_compute_prefix_1_2(djw_prefix *prefix, djw_weight *freq) {
+  /* This +1 is for the 0 code-length. */
+  uint8_t clmtf[DJW_MAX_CODELEN + 1];
+
+  djw_init_clen_mtf_1_2(clmtf);
+
+  djw_compute_mtf_1_2(prefix, clmtf, freq, DJW_MAX_CODELEN);
+}
+
+static int djw_encode_prefix(xd3_stream *stream, xd3_output **output,
+                             bit_state *bstate, djw_prefix *prefix) {
+  int ret;
+  size_t i;
+  usize_t num_to_encode;
+  djw_weight clfreq[DJW_TOTAL_CODES];
+  uint8_t clclen[DJW_TOTAL_CODES];
+  usize_t clcode[DJW_TOTAL_CODES];
+
+  /* Move-to-front encode prefix symbols, count frequencies */
+  djw_compute_prefix_1_2(prefix, clfreq);
+
+  /* Compute codes */
+  djw_build_prefix(clfreq, clclen, DJW_TOTAL_CODES, DJW_MAX_CLCLEN);
+  djw_build_codes(clcode, clclen, DJW_TOTAL_CODES, DJW_MAX_CLCLEN);
+
+  /* Compute number of extra codes beyond basic ones for this template. */
+  num_to_encode = DJW_TOTAL_CODES;
+  while (num_to_encode > DJW_EXTRA_12OFFSET && clclen[num_to_encode - 1] == 0) {
+    num_to_encode -= 1;
+  }
+  XD3_ASSERT(num_to_encode - DJW_EXTRA_12OFFSET < (1 << DJW_EXTRA_CODE_BITS));
+
+  /* Encode: # of extra codes */
+  if ((ret = xd3_encode_bits(stream, output, bstate, DJW_EXTRA_CODE_BITS,
+                             num_to_encode - DJW_EXTRA_12OFFSET))) {
+    return ret;
+  }
+
+  /* Encode: MTF code lengths */
+  for (i = 0; i < num_to_encode; i += 1) {
+    if ((ret = xd3_encode_bits(stream, output, bstate, DJW_CLCLEN_BITS,
+                               clclen[i]))) {
+      return ret;
+    }
+  }
+
+  /* Encode: CLEN code lengths */
+  for (i = 0; i < prefix->mcount; i += 1) {
+    usize_t mtf_sym = prefix->mtfsym[i];
+    usize_t bits = clclen[mtf_sym];
+    usize_t code = clcode[mtf_sym];
+
+    if ((ret = xd3_encode_bits(stream, output, bstate, bits, code))) {
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+static void djw_compute_selector_1_2(djw_prefix *prefix, usize_t groups,
+                                     djw_weight *gbest_freq) {
+  uint8_t grmtf[DJW_MAX_GROUPS];
+  usize_t i;
+
+  for (i = 0; i < groups; i += 1) {
+    grmtf[i] = (uint8_t)i;
+  }
+
+  djw_compute_mtf_1_2(prefix, grmtf, gbest_freq, groups);
+}
+
+static int xd3_encode_howmany_groups(xd3_stream *stream, xd3_sec_cfg *cfg,
+                                     usize_t input_size, usize_t *ret_groups,
+                                     usize_t *ret_sector_size) {
+  usize_t cfg_groups = 0;
+  usize_t cfg_sector_size = 0;
+  usize_t sugg_groups = 0;
+  usize_t sugg_sector_size = 0;
+
+  if (cfg->ngroups != 0) {
+    if (cfg->ngroups > DJW_MAX_GROUPS) {
+      stream->msg = "invalid secondary encoder group number";
+      return XD3_INTERNAL;
+    }
+
+    cfg_groups = cfg->ngroups;
+  }
+
+  if (cfg->sector_size != 0) {
+    if (cfg->sector_size < DJW_SECTORSZ_MULT ||
+        cfg->sector_size > DJW_SECTORSZ_MAX ||
+        (cfg->sector_size % DJW_SECTORSZ_MULT) != 0) {
+      stream->msg = "invalid secondary encoder sector size";
+      return XD3_INTERNAL;
+    }
+
+    cfg_sector_size = cfg->sector_size;
+  }
+
+  if (cfg_groups == 0 || cfg_sector_size == 0) {
+    /* These values were found empirically using xdelta3-tune around version
+     * xdfs-0.256. */
+    switch (cfg->data_type) {
+    case DATA_SECTION:
+      if (input_size < 1000) {
+        sugg_groups = 1;
+        sugg_sector_size = 0;
+      } else if (input_size < 4000) {
+        sugg_groups = 2;
+        sugg_sector_size = 10;
+      } else if (input_size < 7000) {
+        sugg_groups = 3;
+        sugg_sector_size = 10;
+      } else if (input_size < 10000) {
+        sugg_groups = 4;
+        sugg_sector_size = 10;
+      } else if (input_size < 25000) {
+        sugg_groups = 5;
+        sugg_sector_size = 10;
+      } else if (input_size < 50000) {
+        sugg_groups = 7;
+        sugg_sector_size = 20;
+      } else if (input_size < 100000) {
+        sugg_groups = 8;
+        sugg_sector_size = 30;
+      } else {
+        sugg_groups = 8;
+        sugg_sector_size = 70;
+      }
+      break;
+    case INST_SECTION:
+      if (input_size < 7000) {
+        sugg_groups = 1;
+        sugg_sector_size = 0;
+      } else if (input_size < 10000) {
+        sugg_groups = 2;
+        sugg_sector_size = 50;
+      } else if (input_size < 25000) {
+        sugg_groups = 3;
+        sugg_sector_size = 50;
+      } else if (input_size < 50000) {
+        sugg_groups = 6;
+        sugg_sector_size = 40;
+      } else if (input_size < 100000) {
+        sugg_groups = 8;
+        sugg_sector_size = 40;
+      } else {
+        sugg_groups = 8;
+        sugg_sector_size = 40;
+      }
+      break;
+    case ADDR_SECTION:
+      if (input_size < 9000) {
+        sugg_groups = 1;
+        sugg_sector_size = 0;
+      } else if (input_size < 25000) {
+        sugg_groups = 2;
+        sugg_sector_size = 130;
+      } else if (input_size < 50000) {
+        sugg_groups = 3;
+        sugg_sector_size = 130;
+      } else if (input_size < 100000) {
+        sugg_groups = 5;
+        sugg_sector_size = 130;
+      } else {
+        sugg_groups = 7;
+        sugg_sector_size = 130;
+      }
+      break;
+    }
+
+    if (cfg_groups == 0) {
+      cfg_groups = sugg_groups;
+    }
+
+    if (cfg_sector_size == 0) {
+      cfg_sector_size = sugg_sector_size;
+    }
+  }
+
+  if (cfg_groups != 1 && cfg_sector_size == 0) {
+    switch (cfg->data_type) {
+    case DATA_SECTION:
+      cfg_sector_size = 20;
+      break;
+    case INST_SECTION:
+      cfg_sector_size = 50;
+      break;
+    case ADDR_SECTION:
+      cfg_sector_size = 130;
+      break;
+    }
+  }
+
+  (*ret_groups) = cfg_groups;
+  (*ret_sector_size) = cfg_sector_size;
+
+  XD3_ASSERT(cfg_groups > 0 && cfg_groups <= DJW_MAX_GROUPS);
+  XD3_ASSERT(cfg_groups == 1 || (cfg_sector_size >= DJW_SECTORSZ_MULT &&
+                                 cfg_sector_size <= DJW_SECTORSZ_MAX));
+
+  return 0;
+}
+
+static int xd3_encode_huff(xd3_stream *stream, djw_stream *h, xd3_output *input,
+                           xd3_output *output, xd3_sec_cfg *cfg) {
+  int ret;
+  usize_t groups, sector_size;
+  bit_state bstate = BIT_STATE_ENCODE_INIT;
+  xd3_output *in;
+  usize_t output_bits;
+  usize_t input_bits;
+  usize_t input_bytes;
+  usize_t initial_offset = output->next;
+  djw_weight real_freq[ALPHABET_SIZE];
+  uint8_t *gbest = NULL;
+  uint8_t *gbest_mtf = NULL;
+
+  input_bytes = djw_count_freqs(real_freq, input);
+  input_bits = input_bytes * 8;
+
+  XD3_ASSERT(input_bytes > 0);
+
+  if ((ret = xd3_encode_howmany_groups(stream, cfg, input_bytes, &groups,
+                                       &sector_size))) {
+    return ret;
+  }
+
+  if (0) {
+  regroup:
+    /* Sometimes we dynamically decide there are too many groups.  Arrive
+     * here. */
+    output->next = initial_offset;
+    xd3_bit_state_encode_init(&bstate);
+  }
+
+  /* Encode: # of groups (3 bits) */
+  if ((ret = xd3_encode_bits(stream, &output, &bstate, DJW_GROUP_BITS,
+                             groups - 1))) {
+    goto failure;
+  }
+
+  if (groups == 1) {
+    /* Single Huffman group. */
+    usize_t code[ALPHABET_SIZE]; /* Codes */
+    uint8_t clen[ALPHABET_SIZE];
+    uint8_t prefix_mtfsym[ALPHABET_SIZE];
+    djw_prefix prefix;
+
+    output_bits =
+        djw_build_prefix(real_freq, clen, ALPHABET_SIZE, DJW_MAX_CODELEN);
+    djw_build_codes(code, clen, ALPHABET_SIZE, DJW_MAX_CODELEN);
+
+    if (output_bits + EFFICIENCY_BITS >= input_bits && !cfg->inefficient) {
+      goto nosecond;
+    }
+
+    /* Encode: prefix */
+    prefix.mtfsym = prefix_mtfsym;
+    prefix.symbol = clen;
+    prefix.scount = ALPHABET_SIZE;
+
+    if ((ret = djw_encode_prefix(stream, &output, &bstate, &prefix))) {
+      goto failure;
+    }
+
+    if (output_bits + (8 * output->next) + EFFICIENCY_BITS >= input_bits &&
+        !cfg->inefficient) {
+      goto nosecond;
+    }
+
+    /* Encode: data */
+    for (in = input; in; in = in->next_page) {
+      const uint8_t *p = in->base;
+      const uint8_t *p_max = p + in->next;
+
+      do {
+        usize_t sym = *p++;
+        usize_t bits = clen[sym];
+
+        IF_DEBUG(output_bits -= bits);
+
+        if ((ret =
+                 xd3_encode_bits(stream, &output, &bstate, bits, code[sym]))) {
+          goto failure;
+        }
+      } while (p < p_max);
+    }
+
+    XD3_ASSERT(output_bits == 0);
+  } else {
+    /* DJW Huffman */
+    djw_weight evolve_freq[DJW_MAX_GROUPS][ALPHABET_SIZE];
+    uint8_t evolve_clen[DJW_MAX_GROUPS][ALPHABET_SIZE];
+    djw_weight left = (djw_weight)input_bytes;
+    usize_t gp;
+    usize_t niter = 0;
+    usize_t select_bits;
+    usize_t sym1 = 0, sym2 = 0, s;
+    usize_t gcost[DJW_MAX_GROUPS];
+    usize_t gbest_code[DJW_MAX_GROUPS + 2];
+    uint8_t gbest_clen[DJW_MAX_GROUPS + 2];
+    usize_t gbest_max = 1 + (input_bytes - 1) / sector_size;
+    usize_t best_bits = 0;
+    usize_t gbest_no;
+    usize_t gpcnt;
+    const uint8_t *p;
+    IF_DEBUG2(usize_t gcount[DJW_MAX_GROUPS]);
+
+    /* Encode: sector size (5 bits) */
+    if ((ret = xd3_encode_bits(stream, &output, &bstate, DJW_SECTORSZ_BITS,
+                               (sector_size / DJW_SECTORSZ_MULT) - 1))) {
+      goto failure;
+    }
+
+    /* Dynamic allocation. */
+    if (gbest == NULL) {
+      if ((gbest = (uint8_t *)xd3_alloc(stream, gbest_max, 1)) == NULL) {
+        ret = ENOMEM;
+        goto failure;
+      }
+    }
+
+    if (gbest_mtf == NULL) {
+      if ((gbest_mtf = (uint8_t *)xd3_alloc(stream, gbest_max, 1)) == NULL) {
+        ret = ENOMEM;
+        goto failure;
+      }
+    }
+
+    /* OPT: Some of the inner loops can be optimized, as shown in bzip2 */
+
+    /* Generate initial code length tables. */
+    for (gp = 0; gp < groups; gp += 1) {
+      djw_weight sum = 0;
+      djw_weight goal = (djw_weight)(left / (groups - gp));
+
+      IF_DEBUG2(usize_t nz = 0);
+
+      /* Due to the single-code granularity of this distribution, it may
+       * be that we can't generate a distribution for each group.  In that
+       * case subtract one group and try again.  If (inefficient), we're
+       * testing group behavior, so don't mess things up. */
+      if (goal == 0 && !cfg->inefficient) {
+        IF_DEBUG2(
+            DP(RINT "too many groups (%" XD3_W "u), dropping one\n", groups));
+        groups -= 1;
+        goto regroup;
+      }
+
+      /* Sum == goal is possible when (cfg->inefficient)... */
+      while (sum < goal) {
+        XD3_ASSERT(sym2 < ALPHABET_SIZE);
+        IF_DEBUG2(nz += real_freq[sym2] != 0);
+        sum += real_freq[sym2++];
+      }
+
+      IF_DEBUG2(DP(RINT "group %" XD3_W "u has symbols %" XD3_W "u..%" XD3_W
+                        "u (%" XD3_W "u non-zero) "
+                        "(%u/%" XD3_W "u = %.3f)\n",
+                   gp, sym1, sym2, nz, sum, input_bytes,
+                   sum / (double)input_bytes););
+
+      for (s = 0; s < ALPHABET_SIZE; s += 1) {
+        evolve_clen[gp][s] = (s >= sym1 && s <= sym2) ? 1 : 16;
+      }
+
+      left -= sum;
+      sym1 = sym2 + 1;
+    }
+
+  repeat:
+
+    niter += 1;
+    gbest_no = 0;
+    memset(evolve_freq, 0, sizeof(evolve_freq[0]) * groups);
+    IF_DEBUG2(memset(gcount, 0, sizeof(gcount[0]) * groups));
+
+    /* For each input page (loop is irregular to allow non-pow2-size group
+     * size. */
+    in = input;
+    p = in->base;
+
+    /* For each group-size sector. */
+    do {
+      const uint8_t *p0 = p;
+      xd3_output *in0 = in;
+      usize_t best = 0;
+      usize_t winner = 0;
+
+      /* Select best group for each sector, update evolve_freq. */
+      memset(gcost, 0, sizeof(gcost[0]) * groups);
+
+      /* For each byte in sector. */
+      for (gpcnt = 0; gpcnt < sector_size; gpcnt += 1) {
+        /* For each group. */
+        for (gp = 0; gp < groups; gp += 1) {
+          gcost[gp] += evolve_clen[gp][*p];
+        }
+
+        /* Check end-of-input-page. */
+#define GP_PAGE()                                                              \
+  if ((usize_t)(++p - in->base) == in->next) {                                 \
+    in = in->next_page;                                                        \
+    if (in == NULL) {                                                          \
+      break;                                                                   \
+    }                                                                          \
+    p = in->base;                                                              \
+  }
+
+        GP_PAGE();
+      }
+
+      /* Find min cost group for this sector */
+      best = USIZE_T_MAX;
+      for (gp = 0; gp < groups; gp += 1) {
+        if (gcost[gp] < best) {
+          best = gcost[gp];
+          winner = gp;
+        }
+      }
+
+      XD3_ASSERT(gbest_no < gbest_max);
+      gbest[gbest_no++] = (uint8_t)winner;
+      IF_DEBUG2(gcount[winner] += 1);
+
+      p = p0;
+      in = in0;
+
+      /* Update group frequencies. */
+      for (gpcnt = 0; gpcnt < sector_size; gpcnt += 1) {
+        evolve_freq[winner][*p] += 1;
+
+        GP_PAGE();
+      }
+    } while (in != NULL);
+
+    XD3_ASSERT(gbest_no == gbest_max);
+
+    /* Recompute code lengths. */
+    output_bits = 0;
+    for (gp = 0; gp < groups; gp += 1) {
+      int i;
+      uint8_t evolve_zero[ALPHABET_SIZE];
+      int any_zeros = 0;
+
+      memset(evolve_zero, 0, sizeof(evolve_zero));
+
+      /* Cannot allow a zero clen when the real frequency is non-zero.
+       * Note: this means we are going to encode a fairly long code for
+       * these unused entries.  An improvement would be to implement a
+       * NOTUSED code for when these are actually zero, but this requires
+       * another data structure (evolve_zero) since we don't know when
+       * evolve_freq[i] == 0...  Briefly tested, looked worse. */
+      for (i = 0; i < ALPHABET_SIZE; i += 1) {
+        if (evolve_freq[gp][i] == 0 && real_freq[i] != 0) {
+          evolve_freq[gp][i] = 1;
+          evolve_zero[i] = 1;
+          any_zeros = 1;
+        }
+      }
+
+      output_bits += djw_build_prefix(evolve_freq[gp], evolve_clen[gp],
+                                      ALPHABET_SIZE, DJW_MAX_CODELEN);
+
+      /* The above faking of frequencies does not matter for the last
+       * iteration, but we don't know when that is yet.  However, it also
+       * breaks the output_bits computation.  Necessary for accuracy, and
+       * for the (output_bits==0) assert after all bits are output. */
+      if (any_zeros) {
+        IF_DEBUG2(usize_t save_total = output_bits);
+
+        for (i = 0; i < ALPHABET_SIZE; i += 1) {
+          if (evolve_zero[i]) {
+            output_bits -= evolve_clen[gp][i];
+          }
+        }
+
+        IF_DEBUG2(DP(RINT "evolve_zero reduced %" XD3_W
+                          "u bits in group %" XD3_W "u\n",
+                     save_total - output_bits, gp));
+      }
+    }
+
+    IF_DEBUG2(DP(RINT "pass %" XD3_W "u total bits: %" XD3_W "u group uses: ",
+                 niter, output_bits);
+              for (gp = 0; gp < groups; gp += 1) {
+                DP(RINT "%" XD3_W "u ", gcount[gp]);
+              } DP(RINT "\n"););
+
+    /* End iteration. */
+
+    IF_DEBUG2(if (niter > 1 && best_bits < output_bits) {
+      DP(RINT "iteration lost %" XD3_W "u bits\n", output_bits - best_bits);
+    });
+
+    if (niter == 1 || (niter < DJW_MAX_ITER &&
+                       (best_bits - output_bits) >= DJW_MIN_IMPROVEMENT)) {
+      best_bits = output_bits;
+      goto repeat;
+    }
+
+    /* Efficiency check. */
+    if (output_bits + EFFICIENCY_BITS >= input_bits && !cfg->inefficient) {
+      goto nosecond;
+    }
+
+    IF_DEBUG2(DP(RINT "djw compression: %" XD3_W "u -> %0.3f\n", input_bytes,
+                 output_bits / 8.0));
+
+    /* Encode: prefix */
+    {
+      uint8_t prefix_symbol[DJW_MAX_GROUPS * ALPHABET_SIZE];
+      uint8_t prefix_mtfsym[DJW_MAX_GROUPS * ALPHABET_SIZE];
+      uint8_t prefix_repcnt[DJW_MAX_GROUPS * ALPHABET_SIZE];
+      djw_prefix prefix;
+
+      prefix.symbol = prefix_symbol;
+      prefix.mtfsym = prefix_mtfsym;
+      prefix.repcnt = prefix_repcnt;
+
+      djw_compute_multi_prefix(groups, evolve_clen, &prefix);
+      if ((ret = djw_encode_prefix(stream, &output, &bstate, &prefix))) {
+        goto failure;
+      }
+    }
+
+    /* Encode: selector frequencies */
+    {
+      /* DJW_MAX_GROUPS +2 is for RUN_0, RUN_1 symbols. */
+      djw_weight gbest_freq[DJW_MAX_GROUPS + 2];
+      djw_prefix gbest_prefix;
+      usize_t i;
+
+      gbest_prefix.scount = gbest_no;
+      gbest_prefix.symbol = gbest;
+      gbest_prefix.mtfsym = gbest_mtf;
+
+      djw_compute_selector_1_2(&gbest_prefix, groups, gbest_freq);
+
+      select_bits =
+          djw_build_prefix(gbest_freq, gbest_clen, groups + 1, DJW_MAX_GBCLEN);
+      djw_build_codes(gbest_code, gbest_clen, groups + 1, DJW_MAX_GBCLEN);
+
+      for (i = 0; i < groups + 1; i += 1) {
+        if ((ret = xd3_encode_bits(stream, &output, &bstate, DJW_GBCLEN_BITS,
+                                   gbest_clen[i]))) {
+          goto failure;
+        }
+      }
+
+      for (i = 0; i < gbest_prefix.mcount; i += 1) {
+        usize_t gp_mtf = gbest_mtf[i];
+        usize_t gp_sel_bits = gbest_clen[gp_mtf];
+        usize_t gp_sel_code = gbest_code[gp_mtf];
+
+        XD3_ASSERT(gp_mtf < groups + 1);
+
+        if ((ret = xd3_encode_bits(stream, &output, &bstate, gp_sel_bits,
+                                   gp_sel_code))) {
+          goto failure;
+        }
+
+        IF_DEBUG(select_bits -= gp_sel_bits);
+      }
+
+      XD3_ASSERT(select_bits == 0);
+    }
+
+    /* Efficiency check. */
+    if (output_bits + select_bits + (8 * output->next) + EFFICIENCY_BITS >=
+            input_bits &&
+        !cfg->inefficient) {
+      goto nosecond;
+    }
+
+    /* Encode: data */
+    {
+      usize_t evolve_code[DJW_MAX_GROUPS][ALPHABET_SIZE];
+      usize_t sector = 0;
+
+      /* Build code tables for each group. */
+      for (gp = 0; gp < groups; gp += 1) {
+        djw_build_codes(evolve_code[gp], evolve_clen[gp], ALPHABET_SIZE,
+                        DJW_MAX_CODELEN);
+      }
+
+      /* Now loop over the input. */
+      in = input;
+      p = in->base;
+
+      do {
+        /* For each sector. */
+        usize_t gp_best = gbest[sector];
+        usize_t *gp_codes = evolve_code[gp_best];
+        uint8_t *gp_clens = evolve_clen[gp_best];
+
+        XD3_ASSERT(sector < gbest_no);
+
+        sector += 1;
+
+        /* Encode the sector data. */
+        for (gpcnt = 0; gpcnt < sector_size; gpcnt += 1) {
+          usize_t sym = *p;
+          usize_t bits = gp_clens[sym];
+          usize_t code = gp_codes[sym];
+
+          IF_DEBUG(output_bits -= bits);
+
+          if ((ret = xd3_encode_bits(stream, &output, &bstate, bits, code))) {
+            goto failure;
+          }
+
+          GP_PAGE();
+        }
+      } while (in != NULL);
+
+      XD3_ASSERT(select_bits == 0);
+      XD3_ASSERT(output_bits == 0);
+    }
+  }
+
+  ret = xd3_flush_bits(stream, &output, &bstate);
+
+  if (0) {
+  nosecond:
+    stream->msg = "secondary compression was inefficient";
+    ret = XD3_NOSECOND;
+  }
+
+failure:
+
+  xd3_free(stream, gbest);
+  xd3_free(stream, gbest_mtf);
+  return ret;
+}
+#endif /* XD3_ENCODER */
+
+/*********************************************************************/
+/*                              DECODE                               */
+/*********************************************************************/
+
+static void djw_build_decoder(xd3_stream *stream, usize_t asize,
+                              usize_t abs_max, const uint8_t *clen,
+                              uint8_t *inorder, usize_t *base, usize_t *limit,
+                              usize_t *min_clenp, usize_t *max_clenp) {
+  usize_t i, l;
+  const uint8_t *ci;
+  usize_t nr_clen[DJW_TOTAL_CODES];
+  usize_t tmp_base[DJW_TOTAL_CODES];
+  usize_t min_clen;
+  usize_t max_clen;
+
+  /* Assumption: the two temporary arrays are large enough to hold abs_max. */
+  XD3_ASSERT(abs_max <= DJW_MAX_CODELEN);
+
+  /* This looks something like the start of zlib's inftrees.c */
+  memset(nr_clen, 0, sizeof(nr_clen[0]) * (abs_max + 1));
+
+  /* Count number of each code length */
+  i = asize;
+  ci = clen;
+  do {
+    /* Caller _must_ check that values are in-range.  Most of the time the
+     * caller decodes a specific number of bits, which imply the max value,
+     * and the other time the caller decodes a huffman value, which must be
+     * in-range.  Therefore, its an assertion and this function cannot
+     * otherwise fail. */
+    XD3_ASSERT(*ci <= abs_max);
+
+    nr_clen[*ci++]++;
+  } while (--i != 0);
+
+  /* Compute min, max. */
+  for (i = 1; i <= abs_max; i += 1) {
+    if (nr_clen[i]) {
+      break;
+    }
+  }
+  min_clen = i;
+  for (i = abs_max; i != 0; i -= 1) {
+    if (nr_clen[i]) {
+      break;
+    }
+  }
+  max_clen = i;
+
+  /* Fill the BASE, LIMIT table. */
+  tmp_base[min_clen] = 0;
+  base[min_clen] = 0;
+  limit[min_clen] = nr_clen[min_clen] - 1;
+  for (i = min_clen + 1; i <= max_clen; i += 1) {
+    usize_t last_limit = ((limit[i - 1] + 1) << 1);
+    tmp_base[i] = tmp_base[i - 1] + nr_clen[i - 1];
+    limit[i] = last_limit + nr_clen[i] - 1;
+    base[i] = last_limit - tmp_base[i];
+  }
+
+  /* Fill the inorder array, canonically ordered codes. */
+  ci = clen;
+  for (i = 0; i < asize; i += 1) {
+    if ((l = *ci++) != 0) {
+      inorder[tmp_base[l]++] = (uint8_t)i;
+    }
+  }
+
+  *min_clenp = min_clen;
+  *max_clenp = max_clen;
+}
+
+static inline int
+djw_decode_symbol(xd3_stream *stream, bit_state *bstate, const uint8_t **input,
+                  const uint8_t *input_end, const uint8_t *inorder,
+                  const usize_t *base, const usize_t *limit, usize_t min_clen,
+                  usize_t max_clen, usize_t *sym, usize_t max_sym) {
+  usize_t code = 0;
+  usize_t bits = 0;
+
+  /* OPT: Supposedly a small lookup table improves speed here... */
+
+  /* Code outline is similar to xd3_decode_bits... */
+  if (bstate->cur_mask == 0x100) {
+    goto next_byte;
+  }
+
+  for (;;) {
+    do {
+      if (bits == max_clen) {
+        goto corrupt;
+      }
+
+      bits += 1;
+      code = (code << 1);
+
+      if (bstate->cur_byte & bstate->cur_mask) {
+        code |= 1;
+      }
+
+      bstate->cur_mask <<= 1;
+
+      if (bits >= min_clen && code <= limit[bits]) {
+        goto done;
+      }
+    } while (bstate->cur_mask != 0x100);
+
+  next_byte:
+
+    if (*input == input_end) {
+      stream->msg = "secondary decoder end of input";
+      return XD3_INVALID_INPUT;
+    }
+
+    bstate->cur_byte = *(*input)++;
+    bstate->cur_mask = 1;
+  }
+
+done:
+
+  if (base[bits] <= code) {
+    usize_t offset = code - base[bits];
+
+    if (offset <= max_sym) {
+      IF_DEBUG2(DP(RINT "(j) %" XD3_W "u ", code));
+      *sym = inorder[offset];
+      return 0;
+    }
+  }
+
+corrupt:
+  stream->msg = "secondary decoder invalid code";
+  return XD3_INVALID_INPUT;
+}
+
+static int djw_decode_clclen(xd3_stream *stream, bit_state *bstate,
+                             const uint8_t **input, const uint8_t *input_end,
+                             uint8_t *cl_inorder, usize_t *cl_base,
+                             usize_t *cl_limit, usize_t *cl_minlen,
+                             usize_t *cl_maxlen, uint8_t *cl_mtf) {
+  int ret;
+  uint8_t cl_clen[DJW_TOTAL_CODES];
+  usize_t num_codes, value;
+  usize_t i;
+
+  /* How many extra code lengths to encode. */
+  if ((ret = xd3_decode_bits(stream, bstate, input, input_end,
+                             DJW_EXTRA_CODE_BITS, &num_codes))) {
+    return ret;
+  }
+
+  num_codes += DJW_EXTRA_12OFFSET;
+
+  /* Read num_codes. */
+  for (i = 0; i < num_codes; i += 1) {
+    if ((ret = xd3_decode_bits(stream, bstate, input, input_end,
+                               DJW_CLCLEN_BITS, &value))) {
+      return ret;
+    }
+
+    cl_clen[i] = (uint8_t)value;
+  }
+
+  /* Set the rest to zero. */
+  for (; i < DJW_TOTAL_CODES; i += 1) {
+    cl_clen[i] = 0;
+  }
+
+  /* No need to check for in-range clen values, because: */
+  XD3_ASSERT(1 << DJW_CLCLEN_BITS == DJW_MAX_CLCLEN + 1);
+
+  /* Build the code-length decoder. */
+  djw_build_decoder(stream, DJW_TOTAL_CODES, DJW_MAX_CLCLEN, cl_clen,
+                    cl_inorder, cl_base, cl_limit, cl_minlen, cl_maxlen);
+
+  /* Initialize the MTF state. */
+  djw_init_clen_mtf_1_2(cl_mtf);
+
+  return 0;
+}
+
+static inline int
+djw_decode_1_2(xd3_stream *stream, bit_state *bstate, const uint8_t **input,
+               const uint8_t *input_end, const uint8_t *inorder,
+               const usize_t *base, const usize_t *limit, const usize_t *minlen,
+               const usize_t *maxlen, uint8_t *mtfvals, usize_t elts,
+               usize_t skip_offset, uint8_t *values) {
+  usize_t n = 0, rep = 0, mtf = 0, s = 0;
+  int ret;
+
+  while (n < elts) {
+    /* Special case inside generic code: CLEN only: If not the first group,
+     * we already know the zero frequencies. */
+    if (skip_offset != 0 && n >= skip_offset && values[n - skip_offset] == 0) {
+      values[n++] = 0;
+      continue;
+    }
+
+    /* Repeat last symbol. */
+    if (rep != 0) {
+      values[n++] = mtfvals[0];
+      rep -= 1;
+      continue;
+    }
+
+    /* Symbol following last repeat code. */
+    if (mtf != 0) {
+      usize_t sym = djw_update_mtf(mtfvals, mtf);
+      values[n++] = (uint8_t)sym;
+      mtf = 0;
+      continue;
+    }
+
+    /* Decode next symbol/repeat code. */
+    if ((ret = djw_decode_symbol(stream, bstate, input, input_end, inorder,
+                                 base, limit, *minlen, *maxlen, &mtf,
+                                 DJW_TOTAL_CODES))) {
+      return ret;
+    }
+
+    if (mtf <= RUN_1) {
+      /* Repetition. */
+      rep = ((mtf + 1) << s);
+      mtf = 0;
+      s += 1;
+    } else {
+      /* Remove the RUN_1 MTF offset. */
+      mtf -= 1;
+      s = 0;
+    }
+  }
+
+  /* If (rep != 0) there were too many codes received. */
+  if (rep != 0) {
+    stream->msg = "secondary decoder invalid repeat code";
+    return XD3_INVALID_INPUT;
+  }
+
+  return 0;
+}
+
+static inline int
+djw_decode_prefix(xd3_stream *stream, bit_state *bstate, const uint8_t **input,
+                  const uint8_t *input_end, const uint8_t *cl_inorder,
+                  const usize_t *cl_base, const usize_t *cl_limit,
+                  const usize_t *cl_minlen, const usize_t *cl_maxlen,
+                  uint8_t *cl_mtf, usize_t groups, uint8_t *clen) {
+  return djw_decode_1_2(stream, bstate, input, input_end, cl_inorder, cl_base,
+                        cl_limit, cl_minlen, cl_maxlen, cl_mtf,
+                        ALPHABET_SIZE * groups, ALPHABET_SIZE, clen);
+}
+
+static int xd3_decode_huff(xd3_stream *stream, djw_stream *h,
+                           const uint8_t **input_pos,
+                           const uint8_t *const input_end, uint8_t **output_pos,
+                           const uint8_t *const output_end) {
+  const uint8_t *input = *input_pos;
+  uint8_t *output = *output_pos;
+  bit_state bstate = BIT_STATE_DECODE_INIT;
+  uint8_t *sel_group = NULL;
+  usize_t groups, gp;
+  usize_t output_bytes = (usize_t)(output_end - output);
+  usize_t sector_size;
+  usize_t sectors;
+  int ret;
+
+  /* Invalid input. */
+  if (output_bytes == 0) {
+    stream->msg = "secondary decoder invalid input";
+    return XD3_INVALID_INPUT;
+  }
+
+  /* Decode: number of groups */
+  if ((ret = xd3_decode_bits(stream, &bstate, &input, input_end, DJW_GROUP_BITS,
+                             &groups))) {
+    goto fail;
+  }
+
+  groups += 1;
+
+  if (groups > 1) {
+    /* Decode: group size */
+    if ((ret = xd3_decode_bits(stream, &bstate, &input, input_end,
+                               DJW_SECTORSZ_BITS, &sector_size))) {
+      goto fail;
+    }
+
+    sector_size = (sector_size + 1) * DJW_SECTORSZ_MULT;
+  } else {
+    /* Default for groups == 1 */
+    sector_size = output_bytes;
+  }
+
+  sectors = 1 + (output_bytes - 1) / sector_size;
+
+  /* TODO: In the case of groups==1, lots of extra stack space gets used here.
+   * Could dynamically allocate this memory, which would help with excess
+   * parameter passing, too.  Passing too many parameters in this file,
+   * simplify it! */
+
+  /* Outer scope: per-group symbol decoder tables. */
+  {
+    uint8_t inorder[DJW_MAX_GROUPS][ALPHABET_SIZE];
+    usize_t base[DJW_MAX_GROUPS][DJW_TOTAL_CODES];
+    usize_t limit[DJW_MAX_GROUPS][DJW_TOTAL_CODES];
+    usize_t minlen[DJW_MAX_GROUPS];
+    usize_t maxlen[DJW_MAX_GROUPS];
+
+    /* Nested scope: code length decoder tables. */
+    {
+      uint8_t clen[DJW_MAX_GROUPS][ALPHABET_SIZE];
+      uint8_t cl_inorder[DJW_TOTAL_CODES];
+      usize_t cl_base[DJW_MAX_CLCLEN + 2];
+      usize_t cl_limit[DJW_MAX_CLCLEN + 2];
+      uint8_t cl_mtf[DJW_TOTAL_CODES];
+      usize_t cl_minlen;
+      usize_t cl_maxlen;
+
+      /* Compute the code length decoder. */
+      if ((ret = djw_decode_clclen(stream, &bstate, &input, input_end,
+                                   cl_inorder, cl_base, cl_limit, &cl_minlen,
+                                   &cl_maxlen, cl_mtf))) {
+        goto fail;
+      }
+
+      /* Now decode each group decoder. */
+      if ((ret = djw_decode_prefix(stream, &bstate, &input, input_end,
+                                   cl_inorder, cl_base, cl_limit, &cl_minlen,
+                                   &cl_maxlen, cl_mtf, groups, clen[0]))) {
+        goto fail;
+      }
+
+      /* Prepare the actual decoding tables. */
+      for (gp = 0; gp < groups; gp += 1) {
+        djw_build_decoder(stream, ALPHABET_SIZE, DJW_MAX_CODELEN, clen[gp],
+                          inorder[gp], base[gp], limit[gp], &minlen[gp],
+                          &maxlen[gp]);
+      }
+    }
+
+    /* Decode: selector clens. */
+    {
+      uint8_t sel_inorder[DJW_MAX_GROUPS + 2];
+      usize_t sel_base[DJW_MAX_GBCLEN + 2];
+      usize_t sel_limit[DJW_MAX_GBCLEN + 2];
+      uint8_t sel_mtf[DJW_MAX_GROUPS + 2];
+      usize_t sel_minlen;
+      usize_t sel_maxlen;
+
+      /* Setup group selection. */
+      if (groups > 1) {
+        uint8_t sel_clen[DJW_MAX_GROUPS + 1];
+
+        for (gp = 0; gp < groups + 1; gp += 1) {
+          usize_t value;
+
+          if ((ret = xd3_decode_bits(stream, &bstate, &input, input_end,
+                                     DJW_GBCLEN_BITS, &value))) {
+            goto fail;
+          }
+
+          sel_clen[gp] = (uint8_t)value;
+          sel_mtf[gp] = (uint8_t)gp;
+        }
+
+        if ((sel_group = (uint8_t *)xd3_alloc(stream, sectors, 1)) == NULL) {
+          ret = ENOMEM;
+          goto fail;
+        }
+
+        djw_build_decoder(stream, groups + 1, DJW_MAX_GBCLEN, sel_clen,
+                          sel_inorder, sel_base, sel_limit, &sel_minlen,
+                          &sel_maxlen);
+
+        if ((ret =
+                 djw_decode_1_2(stream, &bstate, &input, input_end, sel_inorder,
+                                sel_base, sel_limit, &sel_minlen, &sel_maxlen,
+                                sel_mtf, sectors, 0, sel_group))) {
+          goto fail;
+        }
+      }
+
+      /* Now decode each sector. */
+      {
+        /* Initialize for (groups==1) case. */
+        uint8_t *gp_inorder = inorder[0];
+        usize_t *gp_base = base[0];
+        usize_t *gp_limit = limit[0];
+        usize_t gp_minlen = minlen[0];
+        usize_t gp_maxlen = maxlen[0];
+        usize_t c;
+
+        for (c = 0; c < sectors; c += 1) {
+          usize_t n;
+
+          if (groups >= 2) {
+            gp = sel_group[c];
+
+            XD3_ASSERT(gp < groups);
+
+            gp_inorder = inorder[gp];
+            gp_base = base[gp];
+            gp_limit = limit[gp];
+            gp_minlen = minlen[gp];
+            gp_maxlen = maxlen[gp];
+          }
+
+          if (output_end < output) {
+            stream->msg = "secondary decoder invalid input";
+            return XD3_INVALID_INPUT;
+          }
+
+          /* Decode next sector. */
+          n = xd3_min(sector_size, (usize_t)(output_end - output));
+
+          do {
+            usize_t sym;
+
+            if ((ret = djw_decode_symbol(
+                     stream, &bstate, &input, input_end, gp_inorder, gp_base,
+                     gp_limit, gp_minlen, gp_maxlen, &sym, ALPHABET_SIZE))) {
+              goto fail;
+            }
+
+            *output++ = (uint8_t)sym;
+          } while (--n);
+        }
+      }
+    }
+  }
+
+  IF_REGRESSION(
+      if ((ret = xd3_test_clean_bits(stream, &bstate))) { goto fail; });
+  XD3_ASSERT(ret == 0);
+
+fail:
+  xd3_free(stream, sel_group);
+
+  (*input_pos) = input;
+  (*output_pos) = output;
+  return ret;
+}
+
+#endif

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-fgk.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-fgk.h
@@ -1,0 +1,738 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   For demonstration purposes only.
+ */
+
+#ifndef _XDELTA3_FGK_h_
+#define _XDELTA3_FGK_h_
+
+/* An implementation of the FGK algorithm described by D.E. Knuth in
+ * "Dynamic Huffman Coding" in Journal of Algorithms 6. */
+
+/* A 32bit counter (fgk_weight) is used as the frequency counter for
+ * nodes in the huffman tree.  TODO: Need oto test for overflow and/or
+ * reset stats. */
+
+typedef struct _fgk_stream fgk_stream;
+typedef struct _fgk_node fgk_node;
+typedef struct _fgk_block fgk_block;
+typedef unsigned int fgk_bit;
+typedef uint32_t fgk_weight;
+
+struct _fgk_block {
+  union {
+    fgk_node *un_leader;
+    fgk_block *un_freeptr;
+  } un;
+};
+
+#define block_leader un.un_leader
+#define block_freeptr un.un_freeptr
+
+/* The code can also support fixed huffman encoding/decoding. */
+#define IS_ADAPTIVE 1
+
+/* weight is a count of the number of times this element has been seen
+ * in the current encoding/decoding.  parent, right_child, and
+ * left_child are pointers defining the tree structure.  right and
+ * left point to neighbors in an ordered sequence of weights.  The
+ * left child of a node is always guaranteed to have weight not
+ * greater than its sibling.  fgk_blockLeader points to the element
+ * with the same weight as itself which is closest to the next
+ * increasing weight block.  */
+struct _fgk_node {
+  fgk_weight weight;
+  fgk_node *parent;
+  fgk_node *left_child;
+  fgk_node *right_child;
+  fgk_node *left;
+  fgk_node *right;
+  fgk_block *my_block;
+};
+
+/* alphabet_size is the a count of the number of possible leaves in
+ * the huffman tree.  The number of total nodes counting internal
+ * nodes is ((2 * alphabet_size) - 1).  zero_freq_count is the number
+ * of elements remaining which have zero frequency.  zero_freq_exp and
+ * zero_freq_rem satisfy the equation zero_freq_count =
+ * 2^zero_freq_exp + zero_freq_rem.  root_node is the root of the
+ * tree, which is initialized to a node with zero frequency and
+ * contains the 0th such element.  free_node contains a pointer to the
+ * next available fgk_node space.  alphabet contains all the elements
+ * and is indexed by N.  remaining_zeros points to the head of the
+ * list of zeros.  */
+struct _fgk_stream {
+  usize_t alphabet_size;
+  usize_t zero_freq_count;
+  usize_t zero_freq_exp;
+  usize_t zero_freq_rem;
+  usize_t coded_depth;
+
+  usize_t total_nodes;
+  usize_t total_blocks;
+
+  fgk_bit *coded_bits;
+
+  fgk_block *block_array;
+  fgk_block *free_block;
+
+  fgk_node *decode_ptr;
+  fgk_node *remaining_zeros;
+  fgk_node *alphabet;
+  fgk_node *root_node;
+  fgk_node *free_node;
+};
+
+/*********************************************************************/
+/*                             Encoder                               */
+/*********************************************************************/
+
+static fgk_stream *fgk_alloc(xd3_stream *stream /*, usize_t alphabet_size */);
+static int fgk_init(xd3_stream *stream, fgk_stream *h, int is_encode);
+static usize_t fgk_encode_data(fgk_stream *h, usize_t n);
+static inline fgk_bit fgk_get_encoded_bit(fgk_stream *h);
+
+static int xd3_encode_fgk(xd3_stream *stream, fgk_stream *sec_stream,
+                          xd3_output *input, xd3_output *output,
+                          xd3_sec_cfg *cfg);
+
+/*********************************************************************/
+/* 			       Decoder                               */
+/*********************************************************************/
+
+static inline int fgk_decode_bit(fgk_stream *h, fgk_bit b);
+static usize_t fgk_decode_data(fgk_stream *h);
+static void fgk_destroy(xd3_stream *stream, fgk_stream *h);
+
+static int xd3_decode_fgk(xd3_stream *stream, fgk_stream *sec_stream,
+                          const uint8_t **input, const uint8_t *const input_end,
+                          uint8_t **output, const uint8_t *const output_end);
+
+/*********************************************************************/
+/* 			       Private                               */
+/*********************************************************************/
+
+static unsigned int fgk_find_nth_zero(fgk_stream *h, usize_t n);
+static usize_t fgk_nth_zero(fgk_stream *h, usize_t n);
+static void fgk_update_tree(fgk_stream *h, usize_t n);
+static fgk_node *fgk_increase_zero_weight(fgk_stream *h, usize_t n);
+static void fgk_eliminate_zero(fgk_stream *h, fgk_node *node);
+static void fgk_move_right(fgk_stream *h, fgk_node *node);
+static void fgk_promote(fgk_stream *h, fgk_node *node);
+static void fgk_init_node(fgk_node *node, usize_t i, usize_t size);
+static fgk_block *fgk_make_block(fgk_stream *h, fgk_node *l);
+static void fgk_free_block(fgk_stream *h, fgk_block *b);
+static void fgk_factor_remaining(fgk_stream *h);
+static inline void fgk_swap_ptrs(fgk_node **one, fgk_node **two);
+
+/*********************************************************************/
+/* 			    Basic Routines                           */
+/*********************************************************************/
+
+/* returns an initialized huffman encoder for an alphabet with the
+ * given size.  returns NULL if enough memory cannot be allocated */
+static fgk_stream *fgk_alloc(xd3_stream *stream /*, int alphabet_size0 */) {
+  usize_t alphabet_size0 = ALPHABET_SIZE;
+  fgk_stream *h;
+
+  if ((h = (fgk_stream *)xd3_alloc(stream, 1, sizeof(fgk_stream))) == NULL) {
+    return NULL;
+  }
+
+  h->total_nodes = (2 * alphabet_size0) - 1;
+  h->total_blocks = (2 * h->total_nodes);
+  h->alphabet = (fgk_node *)xd3_alloc(stream, h->total_nodes, sizeof(fgk_node));
+  h->block_array =
+      (fgk_block *)xd3_alloc(stream, h->total_blocks, sizeof(fgk_block));
+  h->coded_bits = (fgk_bit *)xd3_alloc(stream, alphabet_size0, sizeof(fgk_bit));
+
+  if (h->coded_bits == NULL || h->alphabet == NULL || h->block_array == NULL) {
+    fgk_destroy(stream, h);
+    return NULL;
+  }
+
+  h->alphabet_size = alphabet_size0;
+
+  return h;
+}
+
+static int fgk_init(xd3_stream *stream, fgk_stream *h, int is_encode) {
+  usize_t ui;
+  ssize_t si;
+
+  h->root_node = h->alphabet;
+  h->decode_ptr = h->root_node;
+  h->free_node = h->alphabet + h->alphabet_size;
+  h->remaining_zeros = h->alphabet;
+  h->coded_depth = 0;
+  h->zero_freq_count = h->alphabet_size + 2;
+
+  /* after two calls to factor_remaining, zero_freq_count == alphabet_size */
+  fgk_factor_remaining(h); /* set ZFE and ZFR */
+  fgk_factor_remaining(h); /* set ZFDB according to prev state */
+
+  IF_DEBUG(memset(h->alphabet, 0, sizeof(h->alphabet[0]) * h->total_nodes));
+
+  for (ui = 0; ui < h->total_blocks - 1; ui += 1) {
+    h->block_array[ui].block_freeptr = &h->block_array[ui + 1];
+  }
+
+  h->block_array[h->total_blocks - 1].block_freeptr = NULL;
+  h->free_block = h->block_array;
+
+  /* Zero frequency nodes are inserted in the first alphabet_size
+   * positions, with Value, weight, and a pointer to the next zero
+   * frequency node.  */
+  for (si = (ssize_t)h->alphabet_size - 1; si >= 0; si -= 1) {
+    fgk_init_node(h->alphabet + si, (usize_t)si, h->alphabet_size);
+  }
+
+  return 0;
+}
+
+static void fgk_swap_ptrs(fgk_node **one, fgk_node **two) {
+  fgk_node *tmp = *one;
+  *one = *two;
+  *two = tmp;
+}
+
+/* Takes huffman transmitter h and n, the nth elt in the alphabet, and
+ * returns the number of required to encode n. */
+static usize_t fgk_encode_data(fgk_stream *h, usize_t n) {
+  fgk_node *target_ptr = h->alphabet + n;
+
+  XD3_ASSERT(n < h->alphabet_size);
+
+  h->coded_depth = 0;
+
+  /* First encode the binary representation of the nth remaining
+   * zero frequency element in reverse such that bit, which will be
+   * encoded from h->coded_depth down to 0 will arrive in increasing
+   * order following the tree path.  If there is only one left, it
+   * is not neccesary to encode these bits. */
+  if (IS_ADAPTIVE && target_ptr->weight == 0) {
+    usize_t where, shift;
+    usize_t bits;
+
+    where = fgk_find_nth_zero(h, n);
+    shift = 1;
+
+    if (h->zero_freq_rem == 0) {
+      bits = h->zero_freq_exp;
+    } else {
+      bits = h->zero_freq_exp + 1;
+    }
+
+    while (bits > 0) {
+      h->coded_bits[h->coded_depth++] = (shift & where) && 1;
+
+      bits -= 1;
+      shift <<= 1;
+    };
+
+    target_ptr = h->remaining_zeros;
+  }
+
+  /* The path from root to node is filled into coded_bits in reverse so
+   * that it is encoded in the right order */
+  while (target_ptr != h->root_node) {
+    h->coded_bits[h->coded_depth++] =
+        (target_ptr->parent->right_child == target_ptr);
+
+    target_ptr = target_ptr->parent;
+  }
+
+  if (IS_ADAPTIVE) {
+    fgk_update_tree(h, n);
+  }
+
+  return h->coded_depth;
+}
+
+/* Should be called as many times as fgk_encode_data returns.
+ */
+static inline fgk_bit fgk_get_encoded_bit(fgk_stream *h) {
+  XD3_ASSERT(h->coded_depth > 0);
+
+  return h->coded_bits[--h->coded_depth];
+}
+
+/* This procedure updates the tree after alphabet[n] has been encoded
+ * or decoded.
+ */
+static void fgk_update_tree(fgk_stream *h, usize_t n) {
+  fgk_node *incr_node;
+
+  if (h->alphabet[n].weight == 0) {
+    incr_node = fgk_increase_zero_weight(h, n);
+  } else {
+    incr_node = h->alphabet + n;
+  }
+
+  while (incr_node != h->root_node) {
+    fgk_move_right(h, incr_node);
+    fgk_promote(h, incr_node);
+    incr_node->weight += 1;        /* incr the parent */
+    incr_node = incr_node->parent; /* repeat */
+  }
+
+  h->root_node->weight += 1;
+}
+
+static void fgk_move_right(fgk_stream *h, fgk_node *move_fwd) {
+  fgk_node **fwd_par_ptr, **back_par_ptr;
+  fgk_node *move_back, *tmp;
+
+  move_back = move_fwd->my_block->block_leader;
+
+  if (move_fwd == move_back || move_fwd->parent == move_back ||
+      move_fwd->weight == 0) {
+    return;
+  }
+
+  move_back->right->left = move_fwd;
+
+  if (move_fwd->left) {
+    move_fwd->left->right = move_back;
+  }
+
+  tmp = move_fwd->right;
+  move_fwd->right = move_back->right;
+
+  if (tmp == move_back) {
+    move_back->right = move_fwd;
+  } else {
+    tmp->left = move_back;
+    move_back->right = tmp;
+  }
+
+  tmp = move_back->left;
+  move_back->left = move_fwd->left;
+
+  if (tmp == move_fwd) {
+    move_fwd->left = move_back;
+  } else {
+    tmp->right = move_fwd;
+    move_fwd->left = tmp;
+  }
+
+  if (move_fwd->parent->right_child == move_fwd) {
+    fwd_par_ptr = &move_fwd->parent->right_child;
+  } else {
+    fwd_par_ptr = &move_fwd->parent->left_child;
+  }
+
+  if (move_back->parent->right_child == move_back) {
+    back_par_ptr = &move_back->parent->right_child;
+  } else {
+    back_par_ptr = &move_back->parent->left_child;
+  }
+
+  fgk_swap_ptrs(&move_fwd->parent, &move_back->parent);
+  fgk_swap_ptrs(fwd_par_ptr, back_par_ptr);
+
+  move_fwd->my_block->block_leader = move_fwd;
+}
+
+/* Shifts node, the leader of its block, into the next block. */
+static void fgk_promote(fgk_stream *h, fgk_node *node) {
+  fgk_node *my_left, *my_right;
+  fgk_block *cur_block;
+
+  my_right = node->right;
+  my_left = node->left;
+  cur_block = node->my_block;
+
+  if (node->weight == 0) {
+    return;
+  }
+
+  /* if left is right child, parent of remaining zeros case (?), means parent
+   * has same weight as right child. */
+  if (my_left == node->right_child && node->left_child &&
+      node->left_child->weight == 0) {
+    XD3_ASSERT(node->left_child == h->remaining_zeros);
+    XD3_ASSERT(node->right_child->weight ==
+               (node->weight + 1)); /* child weight was already incremented */
+
+    if (node->weight == (my_right->weight - 1) && my_right != h->root_node) {
+      fgk_free_block(h, cur_block);
+      node->my_block = my_right->my_block;
+      my_left->my_block = my_right->my_block;
+    }
+
+    return;
+  }
+
+  if (my_left == h->remaining_zeros) {
+    return;
+  }
+
+  /* true if not the leftmost node */
+  if (my_left->my_block == cur_block) {
+    my_left->my_block->block_leader = my_left;
+  } else {
+    fgk_free_block(h, cur_block);
+  }
+
+  /* node->parent != my_right */
+  if ((node->weight == (my_right->weight - 1)) && (my_right != h->root_node)) {
+    node->my_block = my_right->my_block;
+  } else {
+    node->my_block = fgk_make_block(h, node);
+  }
+}
+
+/* When an element is seen the first time this is called to remove it from the
+ * list of zero weight elements and introduce a new internal node to the tree.
+ */
+static fgk_node *fgk_increase_zero_weight(fgk_stream *h, usize_t n) {
+  fgk_node *this_zero, *new_internal, *zero_ptr;
+
+  this_zero = h->alphabet + n;
+
+  if (h->zero_freq_count == 1) {
+    /* this is the last one */
+    this_zero->right_child = NULL;
+
+    if (this_zero->right->weight == 1) {
+      this_zero->my_block = this_zero->right->my_block;
+    } else {
+      this_zero->my_block = fgk_make_block(h, this_zero);
+    }
+
+    h->remaining_zeros = NULL;
+
+    return this_zero;
+  }
+
+  zero_ptr = h->remaining_zeros;
+
+  new_internal = h->free_node++;
+
+  new_internal->parent = zero_ptr->parent;
+  new_internal->right = zero_ptr->right;
+  new_internal->weight = 0;
+  new_internal->right_child = this_zero;
+  new_internal->left = this_zero;
+
+  if (h->remaining_zeros == h->root_node) {
+    /* This is the first element to be coded */
+    h->root_node = new_internal;
+    this_zero->my_block = fgk_make_block(h, this_zero);
+    new_internal->my_block = fgk_make_block(h, new_internal);
+  } else {
+    new_internal->right->left = new_internal;
+
+    if (zero_ptr->parent->right_child == zero_ptr) {
+      zero_ptr->parent->right_child = new_internal;
+    } else {
+      zero_ptr->parent->left_child = new_internal;
+    }
+
+    if (new_internal->right->weight == 1) {
+      new_internal->my_block = new_internal->right->my_block;
+    } else {
+      new_internal->my_block = fgk_make_block(h, new_internal);
+    }
+
+    this_zero->my_block = new_internal->my_block;
+  }
+
+  fgk_eliminate_zero(h, this_zero);
+
+  new_internal->left_child = h->remaining_zeros;
+
+  this_zero->right = new_internal;
+  this_zero->left = h->remaining_zeros;
+  this_zero->parent = new_internal;
+  this_zero->left_child = NULL;
+  this_zero->right_child = NULL;
+
+  h->remaining_zeros->parent = new_internal;
+  h->remaining_zeros->right = this_zero;
+
+  return this_zero;
+}
+
+/* When a zero frequency element is encoded, it is followed by the
+ * binary representation of the index into the remaining elements.
+ * Sets a cache to the element before it so that it can be removed
+ * without calling this procedure again.  */
+static unsigned int fgk_find_nth_zero(fgk_stream *h, usize_t n) {
+  fgk_node *target_ptr = h->alphabet + n;
+  fgk_node *head_ptr = h->remaining_zeros;
+  unsigned int idx = 0;
+
+  while (target_ptr != head_ptr) {
+    head_ptr = head_ptr->right_child;
+    idx += 1;
+  }
+
+  return idx;
+}
+
+/* Splices node out of the list of zeros. */
+static void fgk_eliminate_zero(fgk_stream *h, fgk_node *node) {
+  if (h->zero_freq_count == 1) {
+    return;
+  }
+
+  fgk_factor_remaining(h);
+
+  if (node->left_child == NULL) {
+    h->remaining_zeros = h->remaining_zeros->right_child;
+    h->remaining_zeros->left_child = NULL;
+  } else if (node->right_child == NULL) {
+    node->left_child->right_child = NULL;
+  } else {
+    node->right_child->left_child = node->left_child;
+    node->left_child->right_child = node->right_child;
+  }
+}
+
+static void fgk_init_node(fgk_node *node, usize_t i, usize_t size) {
+  if (i < size - 1) {
+    node->right_child = node + 1;
+  } else {
+    node->right_child = NULL;
+  }
+
+  if (i >= 1) {
+    node->left_child = node - 1;
+  } else {
+    node->left_child = NULL;
+  }
+
+  node->weight = 0;
+  node->parent = NULL;
+  node->right = NULL;
+  node->left = NULL;
+  node->my_block = NULL;
+}
+
+/* The data structure used is an array of blocks, which are unions of
+ * free pointers and huffnode pointers.  free blocks are a linked list
+ * of free blocks, the front of which is h->free_block.  The used
+ * blocks are pointers to the head of each block.  */
+static fgk_block *fgk_make_block(fgk_stream *h, fgk_node *lead) {
+  fgk_block *ret = h->free_block;
+
+  XD3_ASSERT(h->free_block != NULL);
+
+  h->free_block = h->free_block->block_freeptr;
+
+  ret->block_leader = lead;
+
+  return ret;
+}
+
+/* Restores the block to the front of the free list. */
+static void fgk_free_block(fgk_stream *h, fgk_block *b) {
+  b->block_freeptr = h->free_block;
+  h->free_block = b;
+}
+
+/* sets zero_freq_count, zero_freq_rem, and zero_freq_exp to satsity
+ * the equation given above.  */
+static void fgk_factor_remaining(fgk_stream *h) {
+  unsigned int i;
+
+  i = (unsigned int)(--h->zero_freq_count);
+  h->zero_freq_exp = 0;
+
+  while (i > 1) {
+    h->zero_freq_exp += 1;
+    i >>= 1;
+  }
+
+  i = 1 << h->zero_freq_exp;
+
+  h->zero_freq_rem = h->zero_freq_count - i;
+}
+
+/* receives a bit at a time and returns true when a complete code has
+ * been received.
+ */
+static inline int fgk_decode_bit(fgk_stream *h, fgk_bit b) {
+  XD3_ASSERT(b == 1 || b == 0);
+
+  if (IS_ADAPTIVE && h->decode_ptr->weight == 0) {
+    usize_t bitsreq;
+
+    if (h->zero_freq_rem == 0) {
+      bitsreq = h->zero_freq_exp;
+    } else {
+      bitsreq = h->zero_freq_exp + 1;
+    }
+
+    h->coded_bits[h->coded_depth] = b;
+    h->coded_depth += 1;
+
+    return h->coded_depth >= bitsreq;
+  } else {
+    if (b) {
+      h->decode_ptr = h->decode_ptr->right_child;
+    } else {
+      h->decode_ptr = h->decode_ptr->left_child;
+    }
+
+    if (h->decode_ptr->left_child == NULL) {
+      /* If the weight is non-zero, finished. */
+      if (h->decode_ptr->weight != 0) {
+        return 1;
+      }
+
+      /* zero_freq_count is dropping to 0, finished. */
+      return h->zero_freq_count == 1;
+    } else {
+      return 0;
+    }
+  }
+}
+
+static usize_t fgk_nth_zero(fgk_stream *h, usize_t n) {
+  fgk_node *ret = h->remaining_zeros;
+
+  /* ERROR: if during this loop (ret->right_child == NULL) then the
+   * encoder's zero count is too high.  Could return an error code
+   * now, but is probably unnecessary overhead, since the caller
+   * should check integrity anyway. */
+  for (; n != 0 && ret->right_child != NULL; n -= 1) {
+    ret = ret->right_child;
+  }
+
+  return (usize_t)(ret - h->alphabet);
+}
+
+/* once fgk_decode_bit returns 1, this retrieves an index into the
+ * alphabet otherwise this returns 0, indicating more bits are
+ * required.
+ */
+static usize_t fgk_decode_data(fgk_stream *h) {
+  usize_t elt = (usize_t)(h->decode_ptr - h->alphabet);
+
+  if (IS_ADAPTIVE && h->decode_ptr->weight == 0) {
+    usize_t i = 0;
+    usize_t n = 0;
+
+    if (h->coded_depth > 0) {
+      for (; i < h->coded_depth - 1; i += 1) {
+        n |= h->coded_bits[i];
+        n <<= 1;
+      }
+    }
+
+    n |= h->coded_bits[i];
+    elt = fgk_nth_zero(h, n);
+  }
+
+  h->coded_depth = 0;
+
+  if (IS_ADAPTIVE) {
+    fgk_update_tree(h, elt);
+  }
+
+  h->decode_ptr = h->root_node;
+
+  return elt;
+}
+
+static void fgk_destroy(xd3_stream *stream, fgk_stream *h) {
+  if (h != NULL) {
+    xd3_free(stream, h->alphabet);
+    xd3_free(stream, h->coded_bits);
+    xd3_free(stream, h->block_array);
+    xd3_free(stream, h);
+  }
+}
+
+/*********************************************************************/
+/* 			       Xdelta                                */
+/*********************************************************************/
+
+static int xd3_encode_fgk(xd3_stream *stream, fgk_stream *sec_stream,
+                          xd3_output *input, xd3_output *output,
+                          xd3_sec_cfg *cfg) {
+  bit_state bstate = BIT_STATE_ENCODE_INIT;
+  xd3_output *cur_page;
+  int ret;
+
+  /* OPT: quit compression early if it looks bad */
+  for (cur_page = input; cur_page; cur_page = cur_page->next_page) {
+    const uint8_t *inp = cur_page->base;
+    const uint8_t *inp_max = inp + cur_page->next;
+
+    while (inp < inp_max) {
+      usize_t bits = fgk_encode_data(sec_stream, *inp++);
+
+      while (bits--) {
+        if ((ret = xd3_encode_bit(stream, &output, &bstate,
+                                  fgk_get_encoded_bit(sec_stream)))) {
+          return ret;
+        }
+      }
+    }
+  }
+
+  return xd3_flush_bits(stream, &output, &bstate);
+}
+
+static int xd3_decode_fgk(xd3_stream *stream, fgk_stream *sec_stream,
+                          const uint8_t **input_pos,
+                          const uint8_t *const input_max, uint8_t **output_pos,
+                          const uint8_t *const output_max) {
+  bit_state bstate;
+  uint8_t *output = *output_pos;
+  const uint8_t *input = *input_pos;
+
+  for (;;) {
+    if (input == input_max) {
+      stream->msg = "secondary decoder end of input";
+      return XD3_INTERNAL;
+    }
+
+    bstate.cur_byte = *input++;
+
+    for (bstate.cur_mask = 1; bstate.cur_mask != 0x100; bstate.cur_mask <<= 1) {
+      int done = fgk_decode_bit(sec_stream,
+                                (bstate.cur_byte & bstate.cur_mask) ? 1U : 0U);
+
+      if (!done) {
+        continue;
+      }
+
+      *output++ = (uint8_t)fgk_decode_data(sec_stream);
+
+      if (output == output_max) {
+        /* During regression testing: */
+        IF_REGRESSION({
+          int ret;
+          bstate.cur_mask <<= 1;
+          if ((ret = xd3_test_clean_bits(stream, &bstate))) {
+            return ret;
+          }
+        });
+
+        (*output_pos) = output;
+        (*input_pos) = input;
+        return 0;
+      }
+    }
+  }
+}
+
+#endif /* _XDELTA3_FGK_ */

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-hash.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-hash.h
@@ -1,0 +1,142 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#ifndef _XDELTA3_HASH_H_
+#define _XDELTA3_HASH_H_
+
+#include "xdelta3-internal.h"
+
+#if XD3_DEBUG
+#define SMALL_HASH_DEBUG1(s, inp)                                              \
+  uint32_t debug_state;                                                        \
+  uint32_t debug_hval = xd3_checksum_hash(                                     \
+      &(s)->small_hash,                                                        \
+      xd3_scksum(&debug_state, (inp), (s)->smatcher.small_look))
+#define SMALL_HASH_DEBUG2(s, inp)                                              \
+  XD3_ASSERT(debug_hval ==                                                     \
+             xd3_checksum_hash(                                                \
+                 &(s)->small_hash,                                             \
+                 xd3_scksum(&debug_state, (inp), (s)->smatcher.small_look)))
+#else
+#define SMALL_HASH_DEBUG1(s, inp)
+#define SMALL_HASH_DEBUG2(s, inp)
+#endif /* XD3_DEBUG */
+
+#if UNALIGNED_OK
+#define UNALIGNED_READ32(dest, src) (*(dest)) = (*(uint32_t *)(src))
+#else
+#define UNALIGNED_READ32(dest, src) memcpy((dest), (src), 4);
+#endif
+
+/* These are good hash multipliers for 32-bit and 64-bit LCGs: see
+ * "linear congruential generators of different sizes and good lattice
+ * structure" */
+#define xd3_hash_multiplier32 1597334677U
+#define xd3_hash_multiplier64 1181783497276652981ULL
+
+/* TODO: small cksum is hard-coded for 4 bytes (i.e., "look" is unused) */
+static inline uint32_t xd3_scksum(uint32_t *state, const uint8_t *base,
+                                  const usize_t look) {
+  UNALIGNED_READ32(state, base);
+  return (*state) * xd3_hash_multiplier32;
+}
+static inline uint32_t
+xd3_small_cksum_update(uint32_t *state, const uint8_t *base, usize_t look) {
+  UNALIGNED_READ32(state, base + 1);
+  return (*state) * xd3_hash_multiplier32;
+}
+
+#if XD3_ENCODER
+inline usize_t xd3_checksum_hash(const xd3_hash_cfg *cfg, const usize_t cksum) {
+  return (cksum >> cfg->shift) ^ (cksum & cfg->mask);
+}
+
+#if SIZEOF_USIZE_T == 4
+inline uint32_t xd3_large32_cksum(xd3_hash_cfg *cfg, const uint8_t *base,
+                                  const usize_t look) {
+  uint32_t h = 0;
+  for (usize_t i = 0; i < look; i++) {
+    h += base[i] * cfg->powers[i];
+  }
+  return h;
+}
+
+inline uint32_t xd3_large32_cksum_update(xd3_hash_cfg *cfg,
+                                         const uint32_t cksum,
+                                         const uint8_t *base,
+                                         const usize_t look) {
+  return xd3_hash_multiplier32 * cksum - cfg->multiplier * base[0] + base[look];
+}
+#endif
+
+#if SIZEOF_USIZE_T == 8
+inline uint64_t xd3_large64_cksum(xd3_hash_cfg *cfg, const uint8_t *base,
+                                  const usize_t look) {
+  uint64_t h = 0;
+  for (usize_t i = 0; i < look; i++) {
+    h += base[i] * cfg->powers[i];
+  }
+  return h;
+}
+
+inline uint64_t xd3_large64_cksum_update(xd3_hash_cfg *cfg,
+                                         const uint64_t cksum,
+                                         const uint8_t *base,
+                                         const usize_t look) {
+  return xd3_hash_multiplier64 * cksum - cfg->multiplier * base[0] + base[look];
+}
+#endif
+
+static usize_t xd3_size_hashtable_bits(usize_t slots) {
+  usize_t bits = (SIZEOF_USIZE_T * 8) - 1;
+  usize_t i;
+
+  for (i = 3; i <= bits; i += 1) {
+    if (slots < ((usize_t)1 << i)) {
+      /* Note: this is the compaction=1 setting measured in
+       * checksum_test */
+      bits = i - 1;
+      break;
+    }
+  }
+
+  return bits;
+}
+
+int xd3_size_hashtable(xd3_stream *stream, usize_t slots, usize_t look,
+                       xd3_hash_cfg *cfg) {
+  usize_t bits = xd3_size_hashtable_bits(slots);
+
+  cfg->size = ((usize_t)1 << bits);
+  cfg->mask = (cfg->size - 1);
+  cfg->shift = (SIZEOF_USIZE_T * 8) - bits;
+  cfg->look = look;
+
+  if ((cfg->powers = (usize_t *)xd3_alloc0(stream, look, sizeof(usize_t))) ==
+      NULL) {
+    return ENOMEM;
+  }
+
+  cfg->powers[look - 1] = 1;
+  for (int i = (int)look - 2; i >= 0; i--) {
+    cfg->powers[i] = cfg->powers[i + 1] * xd3_hash_multiplier;
+  }
+  cfg->multiplier = cfg->powers[0] * xd3_hash_multiplier;
+
+  return 0;
+}
+
+#endif /* XD3_ENCODER */
+#endif /* _XDELTA3_HASH_H_ */

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-internal.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-internal.h
@@ -1,0 +1,410 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#ifndef XDELTA3_INTERNAL_H__
+#define XDELTA3_INTERNAL_H__
+
+#include "xdelta3.h"
+
+typedef struct _main_file main_file;
+typedef struct _main_extcomp main_extcomp;
+
+void main_buffree(void *ptr);
+void *main_bufalloc(size_t size);
+void main_file_init(main_file *xfile);
+int main_file_close(main_file *xfile);
+void main_file_cleanup(main_file *xfile);
+int main_file_isopen(main_file *xfile);
+int main_file_open(main_file *xfile, const char *name, int mode);
+int main_file_exists(main_file *xfile);
+int main_file_stat(main_file *xfile, xoff_t *size);
+int xd3_whole_append_window(xd3_stream *stream);
+int xd3_main_cmdline(int argc, char **argv);
+int main_file_read(main_file *ifile, uint8_t *buf, size_t size, size_t *nread,
+                   const char *msg);
+int main_file_write(main_file *ofile, uint8_t *buf, usize_t size,
+                    const char *msg);
+void *main_malloc(size_t size);
+void main_free(void *ptr);
+
+int test_compare_files(const char *f0, const char *f1);
+usize_t xd3_bytes_on_srcblk(xd3_source *src, xoff_t blkno);
+xoff_t xd3_source_eof(const xd3_source *src);
+
+uint32_t xd3_large_cksum_update(uint32_t cksum, const uint8_t *base,
+                                usize_t look);
+int xd3_emit_byte(xd3_stream *stream, xd3_output **outputp, uint8_t code);
+
+int xd3_emit_bytes(xd3_stream *stream, xd3_output **outputp,
+                   const uint8_t *base, usize_t size);
+xd3_output *xd3_alloc_output(xd3_stream *stream, xd3_output *old_output);
+
+int xd3_encode_init_full(xd3_stream *stream);
+usize_t xd3_pow2_roundup(usize_t x);
+long get_millisecs_now(void);
+int xd3_process_stream(int is_encode, xd3_stream *stream,
+                       int (*func)(xd3_stream *), int close_stream,
+                       const uint8_t *input, usize_t input_size,
+                       uint8_t *output, usize_t *output_size,
+                       usize_t output_size_max);
+
+#if PYTHON_MODULE || SWIG_MODULE || NOT_MAIN
+int xd3_main_cmdline(int argc, char **argv);
+#endif
+
+#if REGRESSION_TEST
+int xd3_selftest(void);
+#endif
+
+/* main_file->mode values */
+typedef enum { XO_READ = 0, XO_WRITE = 1 } main_file_modes;
+
+#ifndef XD3_POSIX
+#define XD3_POSIX 0
+#endif
+#ifndef XD3_STDIO
+#define XD3_STDIO 0
+#endif
+#ifndef XD3_WIN32
+#define XD3_WIN32 0
+#endif
+#ifndef NOT_MAIN
+#define NOT_MAIN 0
+#endif
+
+/* If none are set, default to posix. */
+#if (XD3_POSIX + XD3_STDIO + XD3_WIN32) == 0
+#undef XD3_POSIX
+#define XD3_POSIX 1
+#endif
+
+struct _main_file {
+#if XD3_WIN32
+  HANDLE file;
+#elif XD3_STDIO
+  FILE *file;
+#elif XD3_POSIX
+  int file;
+#endif
+
+  int mode;                       /* XO_READ and XO_WRITE */
+  const char *filename;           /* File name or /dev/stdin,
+                                   * /dev/stdout, /dev/stderr. */
+  char *filename_copy;            /* File name or /dev/stdin,
+                                   * /dev/stdout, /dev/stderr. */
+  const char *realname;           /* File name or /dev/stdin,
+                                   * /dev/stdout, /dev/stderr. */
+  const main_extcomp *compressor; /* External compression struct. */
+  int compression_level;          /* Detected external compression level
+                                   * (0..9), or -1 if unknown.  Carried in the
+                                   * appheader so recompression reproduces the
+                                   * original bytes. */
+  int flags;                      /* RD_FIRST, RD_NONEXTERNAL, ... */
+  xoff_t nread;                   /* for input position */
+  xoff_t nwrite;                  /* for output position */
+  uint8_t *snprintf_buf;          /* internal snprintf() use */
+  int size_known;                 /* Set by main_set_souze */
+  xoff_t source_position;         /* for avoiding seek in getblk_func */
+  int seek_failed;                /* after seek fails once, try FIFO */
+};
+
+#ifndef UINT32_MAX
+#define UINT32_MAX 4294967295U
+#endif
+
+#ifndef UINT64_MAX
+#define UINT64_MAX 18446744073709551615ULL
+#endif
+
+#define UINT32_OFLOW_MASK 0xfe000000U
+#define UINT64_OFLOW_MASK 0xfe00000000000000ULL
+
+/*********************************************************************
+ Integer encoder/decoder functions
+ **********************************************************************/
+
+/* Consume N bytes of input, only used by the decoder. */
+#define DECODE_INPUT(n)                                                        \
+  do {                                                                         \
+    stream->total_in += (xoff_t)(n);                                           \
+    stream->avail_in -= (n);                                                   \
+    stream->next_in += (n);                                                    \
+  } while (0)
+
+#define DECODE_INTEGER_TYPE(PART, OFLOW)                                       \
+  while (stream->avail_in != 0) {                                              \
+    usize_t next = stream->next_in[0];                                         \
+                                                                               \
+    DECODE_INPUT(1);                                                           \
+                                                                               \
+    if (PART & OFLOW) {                                                        \
+      stream->msg = "overflow in decode_integer";                              \
+      return XD3_INVALID_INPUT;                                                \
+    }                                                                          \
+                                                                               \
+    PART = (PART << 7) | (next & 127);                                         \
+                                                                               \
+    if ((next & 128) == 0) {                                                   \
+      (*val) = PART;                                                           \
+      PART = 0;                                                                \
+      return 0;                                                                \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  stream->msg = "further input required";                                      \
+  return XD3_INPUT
+
+#define READ_INTEGER_TYPE(TYPE, OFLOW)                                         \
+  TYPE val = 0;                                                                \
+  const uint8_t *inp = (*inpp);                                                \
+  usize_t next;                                                                \
+                                                                               \
+  do {                                                                         \
+    if (inp == maxp) {                                                         \
+      stream->msg = "end-of-input in read_integer";                            \
+      return XD3_INVALID_INPUT;                                                \
+    }                                                                          \
+                                                                               \
+    if (val & OFLOW) {                                                         \
+      stream->msg = "overflow in read_intger";                                 \
+      return XD3_INVALID_INPUT;                                                \
+    }                                                                          \
+                                                                               \
+    next = (*inp++);                                                           \
+    val = (val << 7) | (next & 127);                                           \
+  } while (next & 128);                                                        \
+                                                                               \
+  (*valp) = val;                                                               \
+  (*inpp) = inp;                                                               \
+                                                                               \
+  return 0
+
+#define EMIT_INTEGER_TYPE()                                                    \
+  /* max 64-bit value in base-7 encoding is 9.1 bytes */                       \
+  uint8_t buf[10];                                                             \
+  usize_t bufi = 10;                                                           \
+                                                                               \
+  /* This loop performs division and turns on all MSBs. */                     \
+  do {                                                                         \
+    buf[--bufi] = (num & 127) | 128;                                           \
+    num >>= 7U;                                                                \
+  } while (num != 0);                                                          \
+                                                                               \
+  /* Turn off MSB of the last byte. */                                         \
+  buf[9] &= 127;                                                               \
+                                                                               \
+  return xd3_emit_bytes(stream, output, buf + bufi, 10 - bufi)
+
+#define IF_SIZEOF32(x)                                                         \
+  if (num < (1U << (7 * (x))))                                                 \
+    return (x);
+#define IF_SIZEOF64(x)                                                         \
+  if (num < (1ULL << (7 * (x))))                                               \
+    return (x);
+
+#if USE_UINT32
+static inline uint32_t xd3_sizeof_uint32_t(uint32_t num) {
+  IF_SIZEOF32(1);
+  IF_SIZEOF32(2);
+  IF_SIZEOF32(3);
+  IF_SIZEOF32(4);
+  return 5;
+}
+
+static inline int xd3_decode_uint32_t(xd3_stream *stream, uint32_t *val) {
+  DECODE_INTEGER_TYPE(stream->dec_32part, UINT32_OFLOW_MASK);
+}
+
+static inline int xd3_read_uint32_t(xd3_stream *stream, const uint8_t **inpp,
+                                    const uint8_t *maxp, uint32_t *valp) {
+  READ_INTEGER_TYPE(uint32_t, UINT32_OFLOW_MASK);
+}
+
+#if XD3_ENCODER
+static inline int xd3_emit_uint32_t(xd3_stream *stream, xd3_output **output,
+                                    uint32_t num) {
+  EMIT_INTEGER_TYPE();
+}
+#endif /* XD3_ENCODER */
+#endif /* USE_UINT32 */
+
+#if USE_UINT64
+static inline uint32_t xd3_sizeof_uint64_t(uint64_t num) {
+  IF_SIZEOF64(1);
+  IF_SIZEOF64(2);
+  IF_SIZEOF64(3);
+  IF_SIZEOF64(4);
+  IF_SIZEOF64(5);
+  IF_SIZEOF64(6);
+  IF_SIZEOF64(7);
+  IF_SIZEOF64(8);
+  IF_SIZEOF64(9);
+
+  return 10;
+}
+
+static inline int xd3_decode_uint64_t(xd3_stream *stream, uint64_t *val) {
+  DECODE_INTEGER_TYPE(stream->dec_64part, UINT64_OFLOW_MASK);
+}
+
+static inline int xd3_read_uint64_t(xd3_stream *stream, const uint8_t **inpp,
+                                    const uint8_t *maxp, uint64_t *valp) {
+  READ_INTEGER_TYPE(uint64_t, UINT64_OFLOW_MASK);
+}
+
+#if XD3_ENCODER
+static inline int xd3_emit_uint64_t(xd3_stream *stream, xd3_output **output,
+                                    uint64_t num) {
+  EMIT_INTEGER_TYPE();
+}
+#endif /* XD3_ENCODER */
+#endif /* USE_UINT64 */
+
+#if SIZEOF_USIZE_T == 4
+#define USIZE_T_MAX UINT32_MAX
+#define USIZE_T_MAXBLKSZ 0x80000000U
+#define XD3_MAXSRCWINSZ (1ULL << 31)
+#define xd3_large_cksum xd3_large32_cksum
+#define xd3_large_cksum_update xd3_large32_cksum_update
+#define xd3_hash_multiplier xd3_hash_multiplier32
+
+static inline uint32_t xd3_sizeof_size(usize_t num) {
+  return xd3_sizeof_uint32_t(num);
+}
+static inline int xd3_decode_size(xd3_stream *stream, usize_t *valp) {
+  return xd3_decode_uint32_t(stream, (uint32_t *)valp);
+}
+static inline int xd3_read_size(xd3_stream *stream, const uint8_t **inpp,
+                                const uint8_t *maxp, usize_t *valp) {
+  return xd3_read_uint32_t(stream, inpp, maxp, (uint32_t *)valp);
+}
+#if XD3_ENCODER
+static inline int xd3_emit_size(xd3_stream *stream, xd3_output **output,
+                                usize_t num) {
+  return xd3_emit_uint32_t(stream, output, num);
+}
+#endif
+
+#elif SIZEOF_USIZE_T == 8
+#define USIZE_T_MAX UINT64_MAX
+#define USIZE_T_MAXBLKSZ 0x8000000000000000ULL
+#define XD3_MAXSRCWINSZ (1ULL << 61)
+#define xd3_large_cksum xd3_large64_cksum
+#define xd3_large_cksum_update xd3_large64_cksum_update
+#define xd3_hash_multiplier xd3_hash_multiplier64
+
+static inline uint32_t xd3_sizeof_size(usize_t num) {
+  return xd3_sizeof_uint64_t(num);
+}
+static inline int xd3_decode_size(xd3_stream *stream, usize_t *valp) {
+  return xd3_decode_uint64_t(stream, (uint64_t *)valp);
+}
+static inline int xd3_read_size(xd3_stream *stream, const uint8_t **inpp,
+                                const uint8_t *maxp, usize_t *valp) {
+  return xd3_read_uint64_t(stream, inpp, maxp, (uint64_t *)valp);
+}
+#if XD3_ENCODER
+static inline int xd3_emit_size(xd3_stream *stream, xd3_output **output,
+                                usize_t num) {
+  return xd3_emit_uint64_t(stream, output, num);
+}
+#endif
+
+#endif /* SIZEOF_USIZE_T */
+
+#if SIZEOF_XOFF_T == 4
+#define XOFF_T_MAX UINT32_MAX
+
+static inline int xd3_decode_offset(xd3_stream *stream, xoff_t *valp) {
+  return xd3_decode_uint32_t(stream, (uint32_t *)valp);
+}
+#if XD3_ENCODER
+static inline int xd3_emit_offset(xd3_stream *stream, xd3_output **output,
+                                  xoff_t num) {
+  return xd3_emit_uint32_t(stream, output, num);
+}
+#endif
+
+#elif SIZEOF_XOFF_T == 8
+#define XOFF_T_MAX UINT64_MAX
+
+static inline int xd3_decode_offset(xd3_stream *stream, xoff_t *valp) {
+  return xd3_decode_uint64_t(stream, (uint64_t *)valp);
+}
+#if XD3_ENCODER
+static inline int xd3_emit_offset(xd3_stream *stream, xd3_output **output,
+                                  xoff_t num) {
+  return xd3_emit_uint64_t(stream, output, num);
+}
+#endif
+
+#endif
+
+#define USIZE_T_OVERFLOW(a, b) ((USIZE_T_MAX - (usize_t)(a)) < (usize_t)(b))
+#define XOFF_T_OVERFLOW(a, b) ((XOFF_T_MAX - (xoff_t)(a)) < (xoff_t)(b))
+
+/* Multiplication-overflow guard for allocation sizes.  The product is
+ * evaluated in size_t, the type the allocators pass to malloc.  A wrap
+ * here would yield an undersized buffer and a subsequent heap
+ * overflow.  Evaluates to non-zero when items * size would overflow
+ * size_t.  Both operands are evaluated once. */
+#define XD3_MUL_SIZE_OVERFLOW(items, size)                                     \
+  (((size_t)(size) != 0) &&                                                    \
+   ((size_t)(items) > ((size_t)SIZE_MAX) / (size_t)(size)))
+
+/* Checked narrowing of an absolute file offset (xoff_t) into a
+ * window-relative size or address (usize_t).  VCDIFF copy addresses are
+ * window-relative, so the encoder must reduce every xoff_t into a usize_t
+ * before emitting; the scheme is correct only while the value fits.  On the
+ * default build both types are 64-bit and the bound folds away, but on the
+ * XD3_USE_LARGESIZET=0 build usize_t is 32-bit and a bare cast silently
+ * truncates.  This converts that truncation into a clean error.  Stores the
+ * narrowed value through out on success and returns 0; returns
+ * XD3_INVALID_INPUT and leaves out unmodified when v exceeds USIZE_T_MAX.
+ * The SIZEOF guard avoids a tautological comparison when usize_t is already
+ * as wide as xoff_t. */
+static inline int xd3_to_usize(xoff_t v, usize_t *out) {
+#if SIZEOF_USIZE_T < SIZEOF_XOFF_T
+  if (v > (xoff_t)USIZE_T_MAX) {
+    return XD3_INVALID_INPUT;
+  }
+#endif
+  *out = (usize_t)v;
+  return 0;
+}
+
+int xd3_size_hashtable(xd3_stream *stream, usize_t slots, usize_t look,
+                       xd3_hash_cfg *cfg);
+
+usize_t xd3_checksum_hash(const xd3_hash_cfg *cfg, const usize_t cksum);
+
+#if USE_UINT32
+uint32_t xd3_large32_cksum(xd3_hash_cfg *cfg, const uint8_t *base,
+                           const usize_t look);
+uint32_t xd3_large32_cksum_update(xd3_hash_cfg *cfg, const uint32_t cksum,
+                                  const uint8_t *base, const usize_t look);
+#endif /* USE_UINT32 */
+
+#if USE_UINT64
+uint64_t xd3_large64_cksum(xd3_hash_cfg *cfg, const uint8_t *base,
+                           const usize_t look);
+uint64_t xd3_large64_cksum_update(xd3_hash_cfg *cfg, const uint64_t cksum,
+                                  const uint8_t *base, const usize_t look);
+#endif /* USE_UINT64 */
+
+#define MAX_LRU_SIZE 32U
+#define XD3_MINSRCWINSZ (XD3_ALLOCSIZE * MAX_LRU_SIZE)
+
+#endif // XDELTA3_INTERNAL_H__

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-list.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-list.h
@@ -1,0 +1,93 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#ifndef __XDELTA3_LIST__
+#define __XDELTA3_LIST__
+
+#define XD3_MAKELIST(LTYPE, ETYPE, LNAME)                                      \
+                                                                               \
+  static inline ETYPE *LTYPE##_entry(LTYPE *l) {                               \
+    return (ETYPE *)((char *)l - (ptrdiff_t)&((ETYPE *)0)->LNAME);             \
+  }                                                                            \
+                                                                               \
+  static inline void LTYPE##_init(LTYPE *l) {                                  \
+    l->next = l;                                                               \
+    l->prev = l;                                                               \
+  }                                                                            \
+                                                                               \
+  static inline void LTYPE##_add(LTYPE *prev, LTYPE *next, LTYPE *ins) {       \
+    next->prev = ins;                                                          \
+    prev->next = ins;                                                          \
+    ins->next = next;                                                          \
+    ins->prev = prev;                                                          \
+  }                                                                            \
+                                                                               \
+  static inline void LTYPE##_push_back(LTYPE *l, ETYPE *i) {                   \
+    LTYPE##_add(l->prev, l, &i->LNAME);                                        \
+  }                                                                            \
+                                                                               \
+  static inline void LTYPE##_del(LTYPE *next, LTYPE *prev) {                   \
+    next->prev = prev;                                                         \
+    prev->next = next;                                                         \
+  }                                                                            \
+                                                                               \
+  static inline ETYPE *LTYPE##_remove(ETYPE *f) {                              \
+    LTYPE *i = f->LNAME.next;                                                  \
+    LTYPE##_del(f->LNAME.next, f->LNAME.prev);                                 \
+    return LTYPE##_entry(i);                                                   \
+  }                                                                            \
+                                                                               \
+  static inline ETYPE *LTYPE##_pop_back(LTYPE *l) {                            \
+    LTYPE *i = l->prev;                                                        \
+    LTYPE##_del(i->next, i->prev);                                             \
+    return LTYPE##_entry(i);                                                   \
+  }                                                                            \
+                                                                               \
+  static inline ETYPE *LTYPE##_pop_front(LTYPE *l) {                           \
+    LTYPE *i = l->next;                                                        \
+    LTYPE##_del(i->next, i->prev);                                             \
+    return LTYPE##_entry(i);                                                   \
+  }                                                                            \
+                                                                               \
+  static inline int LTYPE##_empty(LTYPE *l) { return l == l->next; }           \
+                                                                               \
+  static inline ETYPE *LTYPE##_front(LTYPE *f) {                               \
+    return LTYPE##_entry(f->next);                                             \
+  }                                                                            \
+                                                                               \
+  static inline ETYPE *LTYPE##_back(LTYPE *f) {                                \
+    return LTYPE##_entry(f->prev);                                             \
+  }                                                                            \
+                                                                               \
+  static inline int LTYPE##_end(LTYPE *f, ETYPE *i) { return f == &i->LNAME; } \
+                                                                               \
+  static inline ETYPE *LTYPE##_next(ETYPE *f) {                                \
+    return LTYPE##_entry(f->LNAME.next);                                       \
+  }                                                                            \
+                                                                               \
+  static inline usize_t LTYPE##_length(LTYPE *l) {                             \
+    LTYPE *p;                                                                  \
+    usize_t c = 0;                                                             \
+                                                                               \
+    for (p = l->next; p != l; p = p->next) {                                   \
+      c += 1;                                                                  \
+    }                                                                          \
+                                                                               \
+    return c;                                                                  \
+  }                                                                            \
+                                                                               \
+  typedef int unused_##LTYPE
+
+#endif

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-lzma.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-lzma.h
@@ -1,0 +1,171 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/* Note: The use of the _easy_ decoder means we're not calling the
+ * xd3_stream malloc hooks.  TODO(jmacd) Fix if anyone cares. */
+
+#ifndef _XDELTA3_LZMA_H_
+#define _XDELTA3_LZMA_H_
+
+#include <lzma.h>
+
+typedef struct _xd3_lzma_stream xd3_lzma_stream;
+
+struct _xd3_lzma_stream {
+  lzma_stream lzma;
+  lzma_options_lzma options;
+  lzma_filter filters[2];
+};
+
+static xd3_sec_stream *xd3_lzma_alloc(xd3_stream *stream) {
+  return (xd3_sec_stream *)xd3_alloc(stream, sizeof(xd3_lzma_stream), 1);
+}
+
+static void xd3_lzma_destroy(xd3_stream *stream, xd3_sec_stream *sec_stream) {
+  xd3_lzma_stream *ls = (xd3_lzma_stream *)sec_stream;
+  lzma_end(&ls->lzma);
+  xd3_free(stream, ls);
+}
+
+static int xd3_lzma_init(xd3_stream *stream, xd3_lzma_stream *sec,
+                         int is_encode) {
+  int ret;
+
+  memset(&sec->lzma, 0, sizeof(sec->lzma));
+
+  if (is_encode) {
+    uint32_t preset =
+        (stream->flags & XD3_COMPLEVEL_MASK) >> XD3_COMPLEVEL_SHIFT;
+
+    if (lzma_lzma_preset(&sec->options, preset)) {
+      stream->msg = "invalid lzma preset";
+      return XD3_INVALID;
+    }
+
+    sec->filters[0].id = LZMA_FILTER_LZMA2;
+    sec->filters[0].options = &sec->options;
+    sec->filters[1].id = LZMA_VLI_UNKNOWN;
+
+    ret = lzma_stream_encoder(&sec->lzma, &sec->filters[0], LZMA_CHECK_NONE);
+  } else {
+    ret = lzma_stream_decoder(&sec->lzma, UINT64_MAX, LZMA_TELL_NO_CHECK);
+  }
+
+  if (ret != LZMA_OK) {
+    stream->msg = "lzma stream init failed";
+    return XD3_INTERNAL;
+  }
+
+  return 0;
+}
+
+static int xd3_decode_lzma(xd3_stream *stream, xd3_lzma_stream *sec,
+                           const uint8_t **input_pos,
+                           const uint8_t *const input_end, uint8_t **output_pos,
+                           const uint8_t *const output_end) {
+  uint8_t *output = *output_pos;
+  const uint8_t *input = *input_pos;
+  size_t avail_in = input_end - input;
+  size_t avail_out = output_end - output;
+
+  sec->lzma.avail_in = avail_in;
+  sec->lzma.next_in = input;
+  sec->lzma.avail_out = avail_out;
+  sec->lzma.next_out = output;
+
+  while (1) {
+    int lret = lzma_code(&sec->lzma, LZMA_RUN);
+
+    switch (lret) {
+    case LZMA_NO_CHECK:
+    case LZMA_OK:
+      if (sec->lzma.avail_out == 0) {
+        (*output_pos) = sec->lzma.next_out;
+        (*input_pos) = sec->lzma.next_in;
+        return 0;
+      }
+      break;
+
+    default:
+      stream->msg = "lzma decoding error";
+      return XD3_INTERNAL;
+    }
+  }
+}
+
+#if XD3_ENCODER
+
+static int xd3_encode_lzma(xd3_stream *stream, xd3_lzma_stream *sec,
+                           xd3_output *input, xd3_output *output,
+                           xd3_sec_cfg *cfg)
+
+{
+  lzma_action action = LZMA_RUN;
+
+  cfg->inefficient = 1; /* Can't skip windows */
+  sec->lzma.next_in = NULL;
+  sec->lzma.avail_in = 0;
+  sec->lzma.next_out = (output->base + output->next);
+  sec->lzma.avail_out = (output->avail - output->next);
+
+  while (1) {
+    int lret;
+    size_t nwrite;
+    if (sec->lzma.avail_in == 0 && input != NULL) {
+      sec->lzma.avail_in = input->next;
+      sec->lzma.next_in = input->base;
+
+      if ((input = input->next_page) == NULL) {
+        action = LZMA_SYNC_FLUSH;
+      }
+    }
+
+    lret = lzma_code(&sec->lzma, action);
+
+    nwrite = (output->avail - output->next) - sec->lzma.avail_out;
+
+    if (nwrite != 0) {
+      output->next += nwrite;
+
+      if (output->next == output->avail) {
+        if ((output = xd3_alloc_output(stream, output)) == NULL) {
+          return ENOMEM;
+        }
+
+        sec->lzma.next_out = output->base;
+        sec->lzma.avail_out = output->avail;
+      }
+    }
+
+    switch (lret) {
+    case LZMA_OK:
+      break;
+
+    case LZMA_STREAM_END:
+      return 0;
+
+    default:
+      stream->msg = "lzma encoding error";
+      return XD3_INTERNAL;
+    }
+  }
+
+  return 0;
+}
+
+#endif /* XD3_ENCODER */
+
+#endif /* _XDELTA3_LZMA_H_ */

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-main.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-main.h
@@ -1,0 +1,4488 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/* This is all the extra stuff you need for convenience to users in a
+ * command line application.  It contains these major components:
+ *
+ * 1. VCDIFF tools 2. external compression support (this is
+ * POSIX-specific).  3. a general read/write loop that handles all of
+ * the Xdelta decode/encode/VCDIFF-print functions 4. command-line
+ * interpreter 5. an Xdelta application header which stores default
+ * filename, external compression settings 6. output/error printing
+ * 7. basic file support and OS interface
+ */
+
+/* TODO list: 1. do exact gzip-like filename, stdout handling.  make a
+ * .vcdiff extension, refuse to encode to stdout without -cf, etc.
+ * 2. Allow the user to add a comment string to the app header without
+ * disturbing the default behavior.
+ */
+
+/* On error handling and printing:
+ *
+ * The xdelta library sets stream->msg to indicate what condition
+ * caused an internal failure, but many failures originate here and
+ * are printed here.  The return convention is 0 for success, as
+ * throughout Xdelta code, but special attention is required here for
+ * the operating system calls with different error handling.  See the
+ * main_file_* routines.  All errors in this file have a message
+ * printed at the time of occurance.  Since some of these calls occur
+ * within calls to the library, the error may end up being printed
+ * again with a more general error message.
+ */
+
+/*********************************************************************/
+
+#include <limits.h>
+
+#ifndef XD3_POSIX
+#define XD3_POSIX 0
+#endif
+#ifndef XD3_STDIO
+#define XD3_STDIO 0
+#endif
+#ifndef XD3_WIN32
+#define XD3_WIN32 0
+#endif
+#ifndef NOT_MAIN
+#define NOT_MAIN 0
+#endif
+
+/* Combines xd3_strerror() and strerror() */
+const char *xd3_mainerror(int err_num);
+
+#include "xdelta3-internal.h"
+
+int xsnprintf_func(char *str, size_t n, const char *fmt, ...) {
+  va_list a;
+  int ret;
+  va_start(a, fmt);
+  ret = vsnprintf_func(str, n, fmt, a);
+  va_end(a);
+  if (ret < 0) {
+    ret = (int)n;
+  }
+  return ret;
+}
+
+/* Handle externally-compressed inputs. */
+#ifndef EXTERNAL_COMPRESSION
+#define EXTERNAL_COMPRESSION 1
+#endif
+
+/* Armor mode: whole-file BLAKE3 verification carried in the app-header.  When
+ * compiled out (XD3_ARMOR=0) the -a/armor machinery is absent and the tool
+ * behaves as if armor were always disabled. */
+#ifndef XD3_ARMOR
+#define XD3_ARMOR 0
+#endif
+
+#if XD3_ARMOR
+#include <blake3.h>
+/* BLAKE3-256 rendered as lowercase hex, plus NUL. */
+#define XD3_BLAKE3_HEXLEN (2 * BLAKE3_OUT_LEN)
+#define XD3_BLAKE3_HEXBUF (XD3_BLAKE3_HEXLEN + 1)
+
+/* Distinct process exit code returned by decode when the supplied source
+ * already matches the delta's target digest, i.e. the patch is already
+ * applied / the source is already up to date.  Distinct from the generic
+ * failure code (1) so scripts can detect this case. */
+#define EXIT_ARMOR_UP_TO_DATE 2
+#endif
+
+#define PRINTHDR_SPECIAL -4378291
+
+/* The number of soft-config variables.  */
+#define XD3_SOFTCFG_VARCNT 7
+
+/* this is used as in XPR(NT XD3_LIB_ERRMSG (stream, ret)) to print an
+ * error message from the library. */
+#define XD3_LIB_ERRMSG(stream, ret)                                            \
+  "%s: %s\n", xd3_errstring(stream), xd3_mainerror(ret)
+
+#if XD3_POSIX
+#include <unistd.h> /* close, read, write... */
+#include <sys/types.h>
+#include <fcntl.h>
+#endif
+
+#ifndef _WIN32
+#include <unistd.h>   /* lots */
+#include <sys/time.h> /* gettimeofday() */
+#include <sys/stat.h> /* stat() and fstat() */
+#if defined(__linux__)
+#include <sys/ioctl.h>
+#include <linux/fs.h> /* BLKGETSIZE64 */
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__) ||  \
+    defined(__NetBSD__) || defined(__OpenBSD__)
+#include <sys/ioctl.h>
+#include <sys/disk.h> /* DKIOCGETBLOCK*, DIOCGMEDIASIZE */
+#endif
+#else
+#if defined(_MSC_VER)
+#define strtoll _strtoi64
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+#ifndef WIFEXITED
+#define WIFEXITED(stat) (((*((int *)&(stat))) & 0xff) == 0)
+#endif
+#ifndef WEXITSTATUS
+#define WEXITSTATUS(stat) (((*((int *)&(stat))) >> 8) & 0xff)
+#endif
+#ifndef S_ISREG
+// #   ifdef S_IFREG
+// #       define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+// #   else
+#define S_ISREG(m) 1
+// #   endif
+#endif /* !S_ISREG */
+
+// For standard input/output handles
+static STARTUPINFO winStartupInfo;
+#endif
+
+/**********************************************************************
+ ENUMS and TYPES
+ *********************************************************************/
+
+/* These flags (mainly pertaining to main_read() operations) are set
+ * in the main_file->flags variable.  All are related to with external
+ * decompression support.
+ *
+ * RD_FIRST causes the external decompression check when the input is
+ * first read.
+ *
+ * RD_NONEXTERNAL disables external decompression for reading a
+ * compressed input, in the case of Xdelta inputs.  Note: Xdelta is
+ * supported as an external compression type, which makes is the
+ * reason for this flag.  An example to justify this is: to create a
+ * delta between two files that are VCDIFF-compressed.  Two external
+ * Xdelta decoders are run to supply decompressed source and target
+ * inputs to the Xdelta encoder. */
+typedef enum {
+  RD_FIRST = (1 << 0),
+  RD_NONEXTERNAL = (1 << 1),
+  RD_DECOMPSET = (1 << 2),
+  RD_MAININPUT = (1 << 3),
+} xd3_read_flags;
+
+/* Main commands.  For example, CMD_PRINTHDR is the "xdelta printhdr"
+ * command. */
+typedef enum {
+  CMD_NONE = 0,
+  CMD_PRINTHDR,
+  CMD_PRINTHDRS,
+  CMD_PRINTDELTA,
+  CMD_RECODE,
+  CMD_MERGE_ARG,
+  CMD_MERGE,
+#if XD3_ENCODER
+  CMD_ENCODE,
+#endif
+  CMD_DECODE,
+  CMD_TEST,
+  CMD_CONFIG,
+} xd3_cmd;
+
+#if XD3_ENCODER
+#define CMD_DEFAULT CMD_ENCODE
+#define IS_ENCODE(cmd) (cmd == CMD_ENCODE)
+#else
+#define CMD_DEFAULT CMD_DECODE
+#define IS_ENCODE(cmd) (0)
+#endif
+
+typedef struct _main_merge main_merge;
+typedef struct _main_merge_list main_merge_list;
+
+/* Various strings and magic values used to detect and call external
+ * compression.  See below for examples. */
+struct _main_extcomp {
+  const char *recomp_cmdname;
+  const char *recomp_options;
+
+  const char *decomp_cmdname;
+  const char *decomp_options;
+
+  const char *ident;
+  const char *magic;
+  usize_t magic_size;
+  int flags;
+
+  /* Optionally recover the compression level (0..9) from the first bytes of a
+   * compressed stream, returning -1 when it cannot be determined.  NULL when
+   * the format carries no recoverable level. */
+  int (*detect_level)(const uint8_t *data, usize_t len);
+};
+
+/* Merge state: */
+
+struct _main_merge_list {
+  main_merge_list *next;
+  main_merge_list *prev;
+};
+
+struct _main_merge {
+  const char *filename;
+
+  main_merge_list link;
+};
+
+XD3_MAKELIST(main_merge_list, main_merge, link);
+
+/* TODO: really need to put options in a struct so that internal
+ * callers can easily reset state. */
+
+#define DEFAULT_VERBOSE 0
+
+/* Program options: various command line flags and options. */
+static int option_stdout = 0;
+static int option_force = 0;
+static int option_verbose = DEFAULT_VERBOSE;
+static int option_quiet = 0;
+static int option_use_appheader = 1;
+static uint8_t *option_appheader = NULL;
+static int option_use_secondary = 1;
+static const char *option_secondary = NULL;
+static int option_use_checksum = 1;
+static const char *option_smatch_config = NULL;
+static int option_no_compress = 0;
+static int option_no_output = 0; /* do not write output */
+static const char *option_source_filename = NULL;
+
+/* Armor mode (BLAKE3 whole-file verification) is on by default; -a disables
+ * it.  When armor is compiled out (XD3_ARMOR=0) this is forced on so the rest
+ * of the code takes the no-armor path. */
+#if XD3_ARMOR
+static int option_no_armor = 0;
+#else
+static int option_no_armor = 1;
+#endif
+
+static int option_level = XD3_DEFAULT_LEVEL;
+static usize_t option_iopt_size = XD3_DEFAULT_IOPT_SIZE;
+static usize_t option_winsize = XD3_DEFAULT_WINSIZE;
+
+/* option_srcwinsz is restricted to [16kB, 2GB] when usize_t is 32 bits. */
+static xoff_t option_srcwinsz = XD3_DEFAULT_SRCWINSZ;
+static usize_t option_sprevsz = XD3_DEFAULT_SPREVSZ;
+
+/* These variables are supressed to avoid their use w/o support.  main() warns
+ * appropriately when external compression is not enabled. */
+#if EXTERNAL_COMPRESSION
+static int num_subprocs = 0;
+static int option_force2 = 0;
+static int option_decompress_inputs = 1;
+static int option_recompress_outputs = 1;
+/* Embed the detected external-compression level in the app-header so the
+ * decoder reproduces it (on by default).  -G disables it to emit a legacy
+ * app-header that older xdelta3 versions can still recompress. */
+static int option_use_comp_level = 1;
+#endif
+
+/* This is for comparing "printdelta" output without attention to
+ * copy-instruction modes. */
+#if VCDIFF_TOOLS
+static int option_print_cpymode = 1; /* Note: see reset_defaults(). */
+#endif
+
+/* Static variables */
+IF_DEBUG(static int main_mallocs = 0;)
+
+static char *program_name = NULL;
+static uint8_t *appheader_used = NULL;
+static uint8_t *main_bdata = NULL;
+static usize_t main_bsize = 0;
+static int main_warned_no_checksum = 0;
+
+/* Hacks for VCDIFF tools, recode command. */
+static int allow_fake_source = 0;
+
+/* recode_stream is used by both recode/merge for reading vcdiff inputs */
+static xd3_stream *recode_stream = NULL;
+
+/* merge_stream is used by merge commands for storing the source encoding */
+static xd3_stream *merge_stream = NULL;
+
+#if XD3_ARMOR
+/* Armor verification state for the current decode/apply operation.  The
+ * expected hashes are parsed from the armored app-header; the target hasher
+ * accumulates the reconstructed output for after-the-fact verification. */
+static char armor_expect_source[XD3_BLAKE3_HEXBUF];
+static char armor_expect_target[XD3_BLAKE3_HEXBUF];
+static int armor_have_source = 0;   /* expected source hash present */
+static int armor_have_target = 0;   /* expected target hash present */
+static int armor_target_active = 0; /* feed output to the target hasher */
+static blake3_hasher armor_target_hasher;
+
+/* Armor merge-chain verification state, accumulated as the chain of deltas is
+ * read in order (the -m arguments first, then the final input). */
+static int armor_merge_count = 0;
+static int armor_merge_all = 1;    /* every link seen so far is armored */
+static int armor_merge_broken = 0; /* a chain-link mismatch was detected */
+static int armor_merge_have_first_source = 0;
+static char armor_merge_first_source[XD3_BLAKE3_HEXBUF];
+static int armor_merge_have_prev_target = 0;
+static char armor_merge_prev_target[XD3_BLAKE3_HEXBUF];
+static int armor_merge_have_last_target = 0;
+static char armor_merge_last_target[XD3_BLAKE3_HEXBUF];
+#endif
+/* Recover the bzip2 block-size level (1..9) from the "BZh<n>" header.  This is
+ * exact: the digit is part of the magic and maps directly to the -N flag. */
+static int main_detect_level_bzip2(const uint8_t *data, usize_t len) {
+  if (len < 4) {
+    return -1;
+  }
+  if (data[3] >= '1' && data[3] <= '9') {
+    return data[3] - '0';
+  }
+  return -1;
+}
+
+/* Best-effort recovery of the gzip level from the XFL byte (RFC 1952
+ * sec 2.3.1). Only the extremes are encoded: 2 == best, 4 == fastest.  Any
+ * other value maps to the default (6), which is correct for the common case but
+ * cannot recover intermediate levels exactly. */
+static int main_detect_level_gzip(const uint8_t *data, usize_t len) {
+  if (len < 9) {
+    return -1;
+  }
+  switch (data[8]) {
+  case 2:
+    return 9;
+  case 4:
+    return 1;
+  default:
+    return 6;
+  }
+}
+
+/* Best-effort recovery of the xz preset from the LZMA2 dictionary-size byte in
+ * the filter-flags.  The dictionary size maps to a preset only approximately:
+ * a couple of sizes are shared by two presets, in which case the more common
+ * (default-ish) preset is chosen.  Returns -1 when no LZMA2 filter is found in
+ * the expected header range. */
+static int main_detect_level_xz(const uint8_t *data, usize_t len) {
+  usize_t offs;
+  /* The LZMA2 filter flags follow the stream and block headers; their position
+   * varies with optional fields, so scan a small window for the filter ID. */
+  for (offs = 14; offs + 2 < len && offs < 26; offs += 1) {
+    if (data[offs] != 0x21 || data[offs + 1] != 0x01) {
+      continue; /* not the LZMA2 filter (ID 0x21, props size 1) */
+    }
+    switch (data[offs + 2]) {
+    case 12:
+      return 0;
+    case 16:
+      return 1;
+    case 18:
+      return 2;
+    case 20:
+      return 3; /* shared with preset 4 */
+    case 22:
+      return 6; /* shared with preset 5; 6 is the default */
+    case 24:
+      return 7;
+    case 26:
+      return 8;
+    case 28:
+      return 9;
+    default:
+      return -1;
+    }
+  }
+  return -1;
+}
+
+/* This array of compressor types is compiled even if EXTERNAL_COMPRESSION is
+ * false just so the program knows the mapping of IDENT->NAME. */
+static main_extcomp extcomp_types[] = {
+    {"bzip2", "-c", "bzip2", "-dc", "B", "BZh", 3, 0, main_detect_level_bzip2},
+    /* gzip -n suppresses the stored name/mtime so recompression is
+     * reproducible byte-for-byte. */
+    {"gzip", "-cn", "gzip", "-dc", "G", "\037\213", 2, 0,
+     main_detect_level_gzip},
+    {"compress", "-c", "uncompress", "-c", "Z", "\037\235", 2, 0, NULL},
+
+    /* Xz is lzma with a magic number http://tukaani.org/xz/format.html */
+    {"xz", "-c", "xz", "-dc", "Y", "\xfd\x37\x7a\x58\x5a\x00", 2, 0,
+     main_detect_level_xz},
+};
+
+static int main_input(xd3_cmd cmd, main_file *ifile, main_file *ofile,
+                      main_file *sfile);
+static void main_get_appheader(xd3_stream *stream, main_file *ifile,
+                               main_file *output, main_file *sfile);
+
+static int main_getblk_func(xd3_stream *stream, xd3_source *source,
+                            xoff_t blkno);
+static int main_file_seek(main_file *xfile, xoff_t pos);
+static int main_read_primary_input(main_file *file, uint8_t *buf, size_t size,
+                                   size_t *nread);
+
+static const char *main_format_bcnt(xoff_t r, shortbuf *buf);
+static int main_help(void);
+
+#if XD3_ENCODER
+static int xd3_merge_input_output(xd3_stream *stream, xd3_whole_state *source);
+#endif
+
+/* The code in xdelta3-blk.h is essentially part of this unit, see
+ * comments there. */
+#include "xdelta3-blkcache.h"
+
+static void (*xprintf_message_func)(const char *msg) = NULL;
+
+void xprintf(const char *fmt, ...) {
+  char buf[1000];
+  va_list a;
+  int size;
+  va_start(a, fmt);
+  size = vsnprintf_func(buf, 1000, fmt, a);
+  va_end(a);
+  if (size < 0) {
+    size = sizeof(buf) - 1;
+    buf[size] = 0;
+  }
+  if (xprintf_message_func != NULL) {
+    xprintf_message_func(buf);
+  } else {
+    size_t ignore = fwrite(buf, 1, size, stderr);
+    (void)ignore;
+  }
+}
+
+static int main_version(void) {
+  /* $Format: "  XPR(NTR \"Xdelta version $Xdelta3Version$, Copyright (C)
+   * Joshua MacDonald\\n\");" $ */
+  XPR(NTR "Xdelta version 3.2.0, Copyright (C) Joshua MacDonald\n");
+  XPR(NTR "Xdelta comes with ABSOLUTELY NO WARRANTY.\n");
+  XPR(NTR "Licensed under the Apache License, Version 2.0\n");
+  XPR(NTR "See \"LICENSE\" for details.\n");
+  return EXIT_SUCCESS;
+}
+
+static int main_config(void) {
+  main_version();
+
+  XPR(NTR "EXTERNAL_COMPRESSION=%d\n", EXTERNAL_COMPRESSION);
+  XPR(NTR "REGRESSION_TEST=%d\n", REGRESSION_TEST);
+  XPR(NTR "SECONDARY_DJW=%d\n", SECONDARY_DJW);
+  XPR(NTR "SECONDARY_FGK=%d\n", SECONDARY_FGK);
+  XPR(NTR "SECONDARY_LZMA=%d\n", SECONDARY_LZMA);
+  XPR(NTR "UNALIGNED_OK=%d\n", UNALIGNED_OK);
+  XPR(NTR "VCDIFF_TOOLS=%d\n", VCDIFF_TOOLS);
+  XPR(NTR "XD3_ALLOCSIZE=%d\n", XD3_ALLOCSIZE);
+  XPR(NTR "XD3_DEBUG=%d\n", XD3_DEBUG);
+  XPR(NTR "XD3_ENCODER=%d\n", XD3_ENCODER);
+  XPR(NTR "XD3_POSIX=%d\n", XD3_POSIX);
+  XPR(NTR "XD3_STDIO=%d\n", XD3_STDIO);
+  XPR(NTR "XD3_WIN32=%d\n", XD3_WIN32);
+  XPR(NTR "XD3_USE_LARGEFILE64=%d\n", XD3_USE_LARGEFILE64);
+  XPR(NTR "XD3_USE_LARGESIZET=%d\n", XD3_USE_LARGESIZET);
+  XPR(NTR "XD3_DEFAULT_LEVEL=%d\n", XD3_DEFAULT_LEVEL);
+  XPR(NTR "XD3_DEFAULT_IOPT_SIZE=%d\n", XD3_DEFAULT_IOPT_SIZE);
+  XPR(NTR "XD3_DEFAULT_SPREVSZ=%d\n", XD3_DEFAULT_SPREVSZ);
+  XPR(NTR "XD3_DEFAULT_SRCWINSZ=%d\n", XD3_DEFAULT_SRCWINSZ);
+  XPR(NTR "XD3_DEFAULT_WINSIZE=%d\n", XD3_DEFAULT_WINSIZE);
+  XPR(NTR "XD3_HARDMAXWINSIZE=%d\n", XD3_HARDMAXWINSIZE);
+  XPR(NTR "sizeof(void*)=%d\n", (int)sizeof(void *));
+  XPR(NTR "sizeof(int)=%d\n", (int)sizeof(int));
+  XPR(NTR "sizeof(long)=%d\n", (int)sizeof(long));
+  XPR(NTR "sizeof(long long)=%d\n", (int)sizeof(long long));
+  XPR(NTR "sizeof(unsigned long long)=%d\n", (int)sizeof(unsigned long long));
+  XPR(NTR "sizeof(size_t)=%d\n", (int)sizeof(size_t));
+  XPR(NTR "sizeof(uint32_t)=%d\n", (int)sizeof(uint32_t));
+  XPR(NTR "sizeof(uint64_t)=%d\n", (int)sizeof(uint64_t));
+  XPR(NTR "sizeof(usize_t)=%d\n", (int)sizeof(usize_t));
+  XPR(NTR "sizeof(xoff_t)=%d\n", (int)sizeof(xoff_t));
+
+  return EXIT_SUCCESS;
+}
+
+static void reset_defaults(void) {
+  option_stdout = 0;
+  option_force = 0;
+  option_verbose = DEFAULT_VERBOSE;
+  option_quiet = 0;
+  option_appheader = NULL;
+  option_use_secondary = 1;
+  option_secondary = NULL;
+  option_smatch_config = NULL;
+  option_no_compress = 0;
+  option_no_output = 0;
+  option_source_filename = NULL;
+  program_name = NULL;
+  appheader_used = NULL;
+  main_bdata = NULL;
+  main_bsize = 0;
+  main_warned_no_checksum = 0;
+  allow_fake_source = 0;
+  option_smatch_config = NULL;
+
+  main_lru_reset();
+
+  option_use_appheader = 1;
+  option_use_checksum = 1;
+#if XD3_ARMOR
+  option_no_armor = 0;
+#else
+  option_no_armor = 1;
+#endif
+#if EXTERNAL_COMPRESSION
+  option_force2 = 0;
+  option_decompress_inputs = 1;
+  option_recompress_outputs = 1;
+  option_use_comp_level = 1;
+  num_subprocs = 0;
+#endif
+#if VCDIFF_TOOLS
+  option_print_cpymode = 1;
+#endif
+  option_level = XD3_DEFAULT_LEVEL;
+  option_iopt_size = XD3_DEFAULT_IOPT_SIZE;
+  option_winsize = XD3_DEFAULT_WINSIZE;
+  option_srcwinsz = XD3_DEFAULT_SRCWINSZ;
+  option_sprevsz = XD3_DEFAULT_SPREVSZ;
+}
+
+static void *main_malloc1(size_t size) {
+  void *r = malloc(size);
+  if (r == NULL) {
+    XPR(NT "malloc: %s\n", xd3_mainerror(ENOMEM));
+  }
+  return r;
+}
+
+void *main_bufalloc(size_t size) {
+#if XD3_WIN32
+  return VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+#else
+  return main_malloc1(size);
+#endif
+}
+
+void *main_malloc(size_t size) {
+  void *r = main_malloc1(size);
+  if (r) {
+    IF_DEBUG(main_mallocs += 1);
+  }
+  return r;
+}
+
+static void *main_alloc(void *opaque, size_t items, usize_t size) {
+  if (XD3_MUL_SIZE_OVERFLOW(items, size)) {
+    return NULL;
+  }
+  return main_malloc1(items * size);
+}
+
+static void main_free1(void *opaque, void *ptr) { free(ptr); }
+
+void main_free(void *ptr) {
+  if (ptr) {
+    IF_DEBUG(main_mallocs -= 1);
+    main_free1(NULL, ptr);
+    IF_DEBUG(XD3_ASSERT(main_mallocs >= 0));
+  }
+}
+
+void main_buffree(void *ptr) {
+#if XD3_WIN32
+  VirtualFree(ptr, 0, MEM_RELEASE);
+#else
+  main_free1(NULL, ptr);
+#endif
+}
+
+/* This ensures that (ret = errno) always indicates failure, in case errno was
+ * accidentally not set.  If this prints there's a bug somewhere. */
+static int get_errno(void) {
+#ifndef _WIN32
+  if (errno == 0) {
+    XPR(NT "you found a bug: expected errno != 0\n");
+    errno = XD3_INTERNAL;
+  }
+  return errno;
+#else
+  DWORD err_num = GetLastError();
+  if (err_num == NO_ERROR) {
+    err_num = XD3_INTERNAL;
+  }
+  return err_num;
+#endif
+}
+
+const char *xd3_mainerror(int err_num) {
+#ifndef _WIN32
+  const char *x = xd3_strerror(err_num);
+  if (x != NULL) {
+    return x;
+  }
+  return strerror(err_num);
+#else
+  static char err_buf[256];
+  const char *x = xd3_strerror(err_num);
+  if (x != NULL) {
+    return x;
+  }
+  memset(err_buf, 0, 256);
+  FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                NULL, err_num, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                err_buf, 256, NULL);
+  if (err_buf[0] != 0 && err_buf[strlen(err_buf) - 1] == '\n') {
+    err_buf[strlen(err_buf) - 1] = 0;
+  }
+  return err_buf;
+#endif
+}
+
+long get_millisecs_now(void) {
+#ifndef _WIN32
+  struct timeval tv;
+
+  gettimeofday(&tv, NULL);
+
+  return (tv.tv_sec) * 1000L + (tv.tv_usec) / 1000;
+#else
+  SYSTEMTIME st;
+  FILETIME ft;
+  __int64 *pi = (__int64 *)&ft;
+  GetLocalTime(&st);
+  SystemTimeToFileTime(&st, &ft);
+  return (long)((*pi) / 10000);
+#endif
+}
+
+/* Always >= 1 millisec, right? */
+static long get_millisecs_since(void) {
+  static long last = 0;
+  long now = get_millisecs_now();
+  long diff = now - last;
+  last = now;
+  return diff;
+}
+
+static const char *main_format_bcnt(xoff_t r, shortbuf *buf) {
+  static const char *fmts[] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"};
+  usize_t i;
+
+  for (i = 0; i < SIZEOF_ARRAY(fmts) - 1; i += 1) {
+    xoff_t new_r;
+
+    if (r == 0) {
+      short_sprintf(*buf, "0 %s", fmts[i]);
+      return buf->buf;
+    }
+
+    if (r >= 1 && r < 10) {
+      short_sprintf(*buf, "%.2f %s", (double)r, fmts[i]);
+      return buf->buf;
+    }
+
+    if (r >= 10 && r < 100) {
+      short_sprintf(*buf, "%.1f %s", (double)r, fmts[i]);
+      return buf->buf;
+    }
+
+    if (r >= 100 && r < 1000) {
+      short_sprintf(*buf, "%" XD3_Q "u %s", r, fmts[i]);
+      return buf->buf;
+    }
+
+    new_r = r / 1024;
+
+    if (new_r < 10) {
+      short_sprintf(*buf, "%.2f %s", (double)r / 1024.0, fmts[i + 1]);
+      return buf->buf;
+    }
+
+    if (new_r < 100) {
+      short_sprintf(*buf, "%.1f %s", (double)r / 1024.0, fmts[i + 1]);
+      return buf->buf;
+    }
+
+    r = new_r;
+  }
+  XD3_ASSERT(0);
+  return "";
+}
+
+static char *main_format_rate(xoff_t bytes, long millis, shortbuf *buf) {
+  xoff_t r = (xoff_t)(1.0 * bytes / (1.0 * millis / 1000.0));
+  static shortbuf lbuf;
+
+  main_format_bcnt(r, &lbuf);
+  short_sprintf(*buf, "%s/s", lbuf.buf);
+  return buf->buf;
+}
+
+static char *main_format_millis(long millis, shortbuf *buf) {
+  if (millis < 1000) {
+    short_sprintf(*buf, "%lu ms", millis);
+  } else if (millis < 10000) {
+    short_sprintf(*buf, "%.1f sec", millis / 1000.0);
+  } else {
+    short_sprintf(*buf, "%lu sec", millis / 1000L);
+  }
+  return buf->buf;
+}
+
+/* A safe version of strtol for xoff_t. */
+static int main_strtoxoff(const char *s, xoff_t *xo, char which) {
+  char *e;
+  xoff_t x;
+
+  XD3_ASSERT(s && *s != 0);
+
+  {
+#if SIZEOF_XOFF_T == SIZEOF_UNSIGNED_LONG_LONG
+    unsigned long long xx = strtoull(s, &e, 0);
+    unsigned long long bad = ULLONG_MAX;
+#elif SIZEOF_XOFF_T <= SIZEOF_UNSIGNED_LONG
+    unsigned long xx = strtoul(s, &e, 0);
+    unsigned long long bad = ULONG_MAX;
+#else
+/* Something wrong with SIZEOF_XOFF_T, SIZEOF_UNSIGNED_LONG, etc. */
+#error Bad configure script
+#endif
+
+    if (xx == bad) {
+      XPR(NT "-%c: negative integer: %s\n", which, s);
+      return EXIT_FAILURE;
+    }
+
+    x = xx;
+  }
+
+  if (*e != 0) {
+    XPR(NT "-%c: invalid integer: %s\n", which, s);
+    return EXIT_FAILURE;
+  }
+
+  (*xo) = x;
+  return 0;
+}
+
+static int main_atoux(const char *arg, xoff_t *xo, xoff_t low, xoff_t high,
+                      char which) {
+  xoff_t x;
+  int ret;
+
+  if ((ret = main_strtoxoff(arg, &x, which))) {
+    return ret;
+  }
+
+  if (x < low) {
+    XPR(NT "-%c: minimum value: %" XD3_Q "u\n", which, low);
+    return EXIT_FAILURE;
+  }
+  if (high != 0 && x > high) {
+    XPR(NT "-%c: maximum value: %" XD3_Q "u\n", which, high);
+    return EXIT_FAILURE;
+  }
+  (*xo) = x;
+  return 0;
+}
+
+static int main_atou(const char *arg, usize_t *uo, usize_t low, usize_t high,
+                     char which) {
+  int ret;
+  xoff_t xo;
+  if ((ret = main_atoux(arg, &xo, low, high, which))) {
+    return ret;
+  }
+  *uo = (usize_t)xo;
+  return 0;
+}
+
+/******************************************************************
+ FILE BASICS
+ ******************************************************************/
+
+/* With all the variation in file system-call semantics, arguments,
+ * return values and error-handling for the POSIX and STDIO file APIs,
+ * the insides of these functions make me sick, which is why these
+ * wrappers exist. */
+
+#define XOPEN_OPNAME (xfile->mode == XO_READ ? "read" : "write")
+#define XOPEN_STDIO (xfile->mode == XO_READ ? "rb" : "wb")
+#define XOPEN_POSIX                                                            \
+  (xfile->mode == XO_READ ? O_RDONLY : O_WRONLY | O_CREAT | O_TRUNC)
+#define XOPEN_MODE (xfile->mode == XO_READ ? 0 : 0666)
+
+#define XF_ERROR(op, name, ret)                                                \
+  do {                                                                         \
+    if (!option_quiet) {                                                       \
+      XPR(NT "file %s failed: %s: %s: %s\n", (op), XOPEN_OPNAME, (name),       \
+          xd3_mainerror(ret));                                                 \
+    }                                                                          \
+  } while (0)
+
+#if XD3_STDIO
+#define XFNO(f) fileno(f->file)
+#define XSTDOUT_XF(f)                                                          \
+  {                                                                            \
+    (f)->file = stdout;                                                        \
+    (f)->filename = "/dev/stdout";                                             \
+  }
+#define XSTDIN_XF(f)                                                           \
+  {                                                                            \
+    (f)->file = stdin;                                                         \
+    (f)->filename = "/dev/stdin";                                              \
+  }
+
+#elif XD3_POSIX
+#define XFNO(f) f->file
+#define XSTDOUT_XF(f)                                                          \
+  {                                                                            \
+    (f)->file = STDOUT_FILENO;                                                 \
+    (f)->filename = "/dev/stdout";                                             \
+  }
+#define XSTDIN_XF(f)                                                           \
+  {                                                                            \
+    (f)->file = STDIN_FILENO;                                                  \
+    (f)->filename = "/dev/stdin";                                              \
+  }
+
+#elif XD3_WIN32
+#define XFNO(f) -1
+#define XSTDOUT_XF(f)                                                          \
+  {                                                                            \
+    (f)->file = GetStdHandle(STD_OUTPUT_HANDLE);                               \
+    (f)->filename = "(stdout)";                                                \
+  }
+#define XSTDIN_XF(f)                                                           \
+  {                                                                            \
+    (f)->file = GetStdHandle(STD_INPUT_HANDLE);                                \
+    (f)->filename = "(stdin)";                                                 \
+  }
+#endif
+
+void main_file_init(main_file *xfile) {
+  memset(xfile, 0, sizeof(*xfile));
+
+  xfile->compression_level = -1;
+
+#if XD3_POSIX
+  xfile->file = -1;
+#endif
+#if XD3_WIN32
+  xfile->file = INVALID_HANDLE_VALUE;
+#endif
+}
+
+int main_file_isopen(main_file *xfile) {
+#if XD3_STDIO
+  return xfile->file != NULL;
+
+#elif XD3_POSIX
+  return xfile->file != -1;
+
+#elif XD3_WIN32
+  return xfile->file != INVALID_HANDLE_VALUE;
+#endif
+}
+
+int main_file_close(main_file *xfile) {
+  int ret = 0;
+
+  if (!main_file_isopen(xfile)) {
+    return 0;
+  }
+
+#if XD3_STDIO
+  ret = fclose(xfile->file);
+  xfile->file = NULL;
+
+#elif XD3_POSIX
+  ret = close(xfile->file);
+  xfile->file = -1;
+
+#elif XD3_WIN32
+  if (!CloseHandle(xfile->file)) {
+    ret = get_errno();
+  }
+  xfile->file = INVALID_HANDLE_VALUE;
+#endif
+
+  if (ret != 0) {
+    XF_ERROR("close", xfile->filename, ret = get_errno());
+  }
+  return ret;
+}
+
+void main_file_cleanup(main_file *xfile) {
+  XD3_ASSERT(xfile != NULL);
+
+  if (main_file_isopen(xfile)) {
+    main_file_close(xfile);
+  }
+
+  if (xfile->snprintf_buf != NULL) {
+    main_free(xfile->snprintf_buf);
+    xfile->snprintf_buf = NULL;
+  }
+
+  if (xfile->filename_copy != NULL) {
+    main_free(xfile->filename_copy);
+    xfile->filename_copy = NULL;
+  }
+}
+
+int main_file_open(main_file *xfile, const char *name, int mode) {
+  int ret = 0;
+
+  xfile->mode = mode;
+
+  XD3_ASSERT(name != NULL);
+  XD3_ASSERT(!main_file_isopen(xfile));
+  if (name[0] == 0) {
+    XPR(NT "invalid file name: empty string\n");
+    return XD3_INVALID;
+  }
+
+  IF_DEBUG1(DP(RINT "[main] open source %s\n", name));
+
+#if XD3_STDIO
+  xfile->file = fopen(name, XOPEN_STDIO);
+
+  ret = (xfile->file == NULL) ? get_errno() : 0;
+
+#elif XD3_POSIX
+  /* TODO: Should retry this call if interrupted, similar to read/write */
+  if ((ret = open(name, XOPEN_POSIX, XOPEN_MODE)) < 0) {
+    ret = get_errno();
+  } else {
+    xfile->file = ret;
+    ret = 0;
+  }
+
+#elif XD3_WIN32
+  xfile->file = CreateFile(
+      name, (mode == XO_READ) ? GENERIC_READ : GENERIC_WRITE, FILE_SHARE_READ,
+      NULL,
+      (mode == XO_READ) ? OPEN_EXISTING
+                        : (option_force ? CREATE_ALWAYS : CREATE_NEW),
+      FILE_ATTRIBUTE_NORMAL, NULL);
+  if (xfile->file == INVALID_HANDLE_VALUE) {
+    ret = get_errno();
+  }
+#endif
+  if (ret) {
+    XF_ERROR("open", name, ret);
+  } else {
+    xfile->realname = name;
+    xfile->nread = 0;
+  }
+  return ret;
+}
+
+#ifdef S_ISBLK
+/* Query the byte size of an open block device.  There is no portable
+ * POSIX way to do this, so each platform needs its own ioctl.  On
+ * success returns 0 and sets *size; on failure (including platforms
+ * with no known method) returns an errno, in which case the caller
+ * treats the source as unsized (the historical degraded behavior). */
+static int main_blockdev_size(int fd, xoff_t *size) {
+#if defined(__linux__) && defined(BLKGETSIZE64)
+  uint64_t bytes = 0;
+  if (ioctl(fd, BLKGETSIZE64, &bytes) < 0) {
+    return get_errno();
+  }
+  (*size) = (xoff_t)bytes;
+  return 0;
+#elif defined(__APPLE__) && defined(DKIOCGETBLOCKCOUNT)
+  uint32_t blocksize = 0;
+  uint64_t blockcount = 0;
+  if (ioctl(fd, DKIOCGETBLOCKSIZE, &blocksize) < 0 ||
+      ioctl(fd, DKIOCGETBLOCKCOUNT, &blockcount) < 0) {
+    return get_errno();
+  }
+  (*size) = (xoff_t)blockcount * (xoff_t)blocksize;
+  return 0;
+#elif defined(DIOCGMEDIASIZE)
+  off_t bytes = 0; /* FreeBSD/DragonFly */
+  if (ioctl(fd, DIOCGMEDIASIZE, &bytes) < 0) {
+    return get_errno();
+  }
+  (*size) = (xoff_t)bytes;
+  return 0;
+#else
+  (void)fd;
+  (void)size;
+  return ENOTTY; /* No known method; caller falls back to unsized. */
+#endif
+}
+#endif /* S_ISBLK */
+
+int main_file_stat(main_file *xfile, xoff_t *size) {
+  int ret = 0;
+#if XD3_WIN32
+  if (GetFileType(xfile->file) != FILE_TYPE_DISK) {
+    return -1;
+  }
+#if (_WIN32_WINNT >= 0x0500)
+  {
+    LARGE_INTEGER li;
+    if (GetFileSizeEx(xfile->file, &li) == 0) {
+      return get_errno();
+    }
+    *size = li.QuadPart;
+  }
+#else
+  {
+    DWORD filesize = GetFileSize(xfile->file, NULL);
+    if (filesize == INVALID_FILE_SIZE) {
+      return get_errno()
+    }
+    *size = filesize;
+  }
+#endif
+#else
+  struct stat sbuf;
+  if (fstat(XFNO(xfile), &sbuf) < 0) {
+    ret = get_errno();
+    return ret;
+  }
+
+  if (S_ISREG(sbuf.st_mode)) {
+    (*size) = sbuf.st_size;
+  }
+#ifdef S_ISBLK
+  else if (S_ISBLK(sbuf.st_mode)) {
+    /* stat() reports st_size == 0 for block devices; query the real
+     * device size so the source is treated as seekable and sized
+     * rather than falling into non-seekable (FIFO) mode. */
+    if ((ret = main_blockdev_size(XFNO(xfile), size))) {
+      return ret;
+    }
+  }
+#endif
+  else {
+    return ESPIPE;
+  }
+#endif
+  return ret;
+}
+
+int main_file_exists(main_file *xfile) {
+  struct stat sbuf;
+  return stat(xfile->filename, &sbuf) == 0 && S_ISREG(sbuf.st_mode);
+}
+
+#if (XD3_POSIX || EXTERNAL_COMPRESSION)
+/* POSIX-generic code takes a function pointer to read() or write().
+ * This calls the function repeatedly until the buffer is full or EOF.
+ * The NREAD parameter is not set for write, NULL is passed.  Return
+ * is signed, < 0 indicate errors, otherwise byte count. */
+typedef int(xd3_posix_func)(int fd, uint8_t *buf, usize_t size);
+
+static int xd3_posix_io(int fd, uint8_t *buf, size_t size, xd3_posix_func *func,
+                        size_t *nread) {
+  int ret;
+  size_t nproc = 0;
+
+  while (nproc < size) {
+    size_t tryread = xd3_min(size - nproc, 1U << 30);
+    ssize_t result = (*func)(fd, buf + nproc, tryread);
+
+    if (result < 0) {
+      ret = get_errno();
+      if (ret != EAGAIN && ret != EINTR) {
+        return ret;
+      }
+      continue;
+    }
+
+    if (nread != NULL && result == 0) {
+      break;
+    }
+
+    nproc += result;
+  }
+  if (nread != NULL) {
+    (*nread) = nproc;
+  }
+  return 0;
+}
+
+/* Thin wrappers with the xd3_posix_func signature, used instead of an
+ * incompatible function-pointer cast of read()/write(). */
+static int xd3_posix_read_func(int fd, uint8_t *buf, usize_t size) {
+  return (int)read(fd, buf, size);
+}
+
+static int xd3_posix_write_func(int fd, uint8_t *buf, usize_t size) {
+  return (int)write(fd, buf, size);
+}
+#endif
+
+#if XD3_WIN32
+static int xd3_win32_io(HANDLE file, uint8_t *buf, size_t size, int is_read,
+                        size_t *nread) {
+  int ret = 0;
+  size_t nproc = 0;
+
+  while (nproc < size) {
+    DWORD nproc2 = 0; /* hmm */
+    DWORD nremain = (DWORD)(size - nproc);
+    if ((is_read ? ReadFile(file, buf + nproc, nremain, &nproc2, NULL)
+                 : WriteFile(file, buf + nproc, nremain, &nproc2, NULL)) == 0) {
+      ret = get_errno();
+      if (ret != ERROR_HANDLE_EOF && ret != ERROR_BROKEN_PIPE) {
+        return ret;
+      }
+      /* By falling through here, we'll break this loop in the
+       * read case in case of eof or broken pipe. */
+    }
+
+    nproc += nproc2;
+
+    if (nread != NULL && nproc2 == 0) {
+      break;
+    }
+  }
+  if (nread != NULL) {
+    (*nread) = nproc;
+  }
+  return 0;
+}
+#endif
+
+/* POSIX is unbuffered, while STDIO is buffered.  main_file_read()
+ * should always be called on blocks. */
+int main_file_read(main_file *ifile, uint8_t *buf, size_t size, size_t *nread,
+                   const char *msg) {
+  int ret = 0;
+  IF_DEBUG1(
+      DP(RINT "[main] read %s up to %" XD3_Z "u\n", ifile->filename, size));
+
+#if XD3_STDIO
+  size_t result;
+
+  result = fread(buf, 1, size, ifile->file);
+
+  if (result < size && ferror(ifile->file)) {
+    ret = get_errno();
+  } else {
+    *nread = result;
+  }
+
+#elif XD3_POSIX
+  ret = xd3_posix_io(ifile->file, buf, size, xd3_posix_read_func, nread);
+#elif XD3_WIN32
+  ret = xd3_win32_io(ifile->file, buf, size, 1 /* is_read */, nread);
+#endif
+
+  if (ret) {
+    XPR(NT "%s: %s: %s\n", msg, ifile->filename, xd3_mainerror(ret));
+  } else {
+    if (option_verbose > 4) {
+      XPR(NT "read %s: %" XD3_Z "u bytes\n", ifile->filename, (*nread));
+    }
+    ifile->nread += (*nread);
+  }
+
+  return ret;
+}
+
+int main_file_write(main_file *ofile, uint8_t *buf, usize_t size,
+                    const char *msg) {
+  int ret = 0;
+
+  IF_DEBUG1(DP(RINT "[main] write %" XD3_W "u\n bytes", size));
+
+#if XD3_STDIO
+  usize_t result;
+
+  result = fwrite(buf, 1, size, ofile->file);
+
+  if (result != size) {
+    ret = get_errno();
+  }
+
+#elif XD3_POSIX
+  ret = xd3_posix_io(ofile->file, buf, size, xd3_posix_write_func, NULL);
+
+#elif XD3_WIN32
+  ret = xd3_win32_io(ofile->file, buf, size, 0, NULL);
+
+#endif
+
+  if (ret) {
+    XPR(NT "%s: %s: %s\n", msg, ofile->filename, xd3_mainerror(ret));
+  } else {
+    if (option_verbose > 5) {
+      XPR(NT "write %s: %" XD3_W "u bytes\n", ofile->filename, size);
+    }
+    ofile->nwrite += size;
+  }
+
+  return ret;
+}
+
+static int main_file_seek(main_file *xfile, xoff_t pos) {
+  int ret = 0;
+
+#if XD3_STDIO
+  /* Note: fseek's offset is long, which is 32-bit on Windows; the
+   * XD3_WIN32 path uses 64-bit seeks for large files. */
+  if (fseek(xfile->file, (long)pos, SEEK_SET) != 0) {
+    ret = get_errno();
+  }
+
+#elif XD3_POSIX
+  if ((xoff_t)lseek(xfile->file, pos, SEEK_SET) != pos) {
+    ret = get_errno();
+  }
+
+#elif XD3_WIN32
+#if (_WIN32_WINNT >= 0x0500)
+  LARGE_INTEGER move, out;
+  move.QuadPart = pos;
+  if (SetFilePointerEx(xfile->file, move, &out, FILE_BEGIN) == 0) {
+    ret = get_errno();
+  }
+#else
+  if (SetFilePointer(xfile->file, (LONG)pos, NULL, FILE_BEGIN) ==
+      INVALID_SET_FILE_POINTER) {
+    ret = get_errno();
+  }
+#endif
+#endif
+
+  return ret;
+}
+
+/* This function simply writes the stream output buffer, if there is
+ * any, for encode, decode and recode commands.  (The VCDIFF tools use
+ * main_print_func()). */
+static int main_write_output(xd3_stream *stream, main_file *ofile) {
+  int ret;
+
+  IF_DEBUG1(DP(RINT "[main] write(%s) %" XD3_W "u\n bytes", ofile->filename,
+               stream->avail_out));
+
+#if XD3_ARMOR
+  /* Accumulate the reconstructed target for armor verification.  Done before
+   * the option_no_output early return so -J still verifies. */
+  if (armor_target_active && stream->avail_out > 0) {
+    blake3_hasher_update(&armor_target_hasher, stream->next_out,
+                         stream->avail_out);
+  }
+#endif
+
+  if (option_no_output) {
+    return 0;
+  }
+
+  if (stream->avail_out > 0 &&
+      (ret = main_file_write(ofile, stream->next_out, stream->avail_out,
+                             "write failed"))) {
+    return ret;
+  }
+
+  return 0;
+}
+
+static int main_set_secondary_flags(xd3_config *config) {
+  int ret;
+  if (!option_use_secondary) {
+    return 0;
+  }
+  if (option_secondary == NULL) {
+    /* Set a default secondary compressor if LZMA is built in, otherwise
+     * default to no secondary compressor. */
+    if (SECONDARY_LZMA) {
+      config->flags |= XD3_SEC_LZMA;
+    }
+  } else {
+    if (strcmp(option_secondary, "lzma") == 0 && SECONDARY_LZMA) {
+      config->flags |= XD3_SEC_LZMA;
+    } else if (strcmp(option_secondary, "fgk") == 0 && SECONDARY_FGK) {
+      config->flags |= XD3_SEC_FGK;
+    } else if (strncmp(option_secondary, "djw", 3) == 0 && SECONDARY_DJW) {
+      usize_t level = XD3_DEFAULT_SECONDARY_LEVEL;
+
+      config->flags |= XD3_SEC_DJW;
+
+      if (strlen(option_secondary) > 3 &&
+          (ret = main_atou(option_secondary + 3, &level, 0, 9, 'S')) != 0 &&
+          !option_quiet) {
+        return XD3_INVALID;
+      }
+
+      /* XD3_SEC_NOXXXX flags disable secondary compression on
+       * a per-section basis.  For djw, ngroups=1 indicates
+       * minimum work, ngroups=0 uses default settings, which
+       * is > 1 groups by default. */
+      if (level < 1) {
+        config->flags |= XD3_SEC_NODATA;
+      }
+      if (level < 7) {
+        config->sec_data.ngroups = 1;
+      } else {
+        config->sec_data.ngroups = 0;
+      }
+
+      if (level < 3) {
+        config->flags |= XD3_SEC_NOINST;
+      }
+      if (level < 8) {
+        config->sec_inst.ngroups = 1;
+      } else {
+        config->sec_inst.ngroups = 0;
+      }
+
+      if (level < 5) {
+        config->flags |= XD3_SEC_NOADDR;
+      }
+      if (level < 9) {
+        config->sec_addr.ngroups = 1;
+      } else {
+        config->sec_addr.ngroups = 0;
+      }
+    } else if (*option_secondary == 0 ||
+               strcmp(option_secondary, "none") == 0) {
+    } else {
+      if (!option_quiet) {
+        XPR(NT "unrecognized or not compiled secondary compressor: %s\n",
+            option_secondary);
+      }
+      return XD3_INVALID;
+    }
+  }
+
+  if (option_verbose) {
+    XPR(NT "secondary compression: %s\n",
+        (config->flags | XD3_SEC_LZMA)
+            ? "lzma"
+            : ((config->flags | XD3_SEC_FGK)
+                   ? "fgk"
+                   : ((config->flags | XD3_SEC_DJW) ? "djw" : "none")));
+  }
+
+  return 0;
+}
+
+/******************************************************************
+ VCDIFF TOOLS
+ *****************************************************************/
+
+#include "xdelta3-merge.h"
+
+#if VCDIFF_TOOLS
+
+/* The following macros let VCDIFF print using main_file_write(),
+ * for example:
+ *
+ *   VC(UT "trying to be portable: %d\n", x)VE;
+ */
+#define SNPRINTF_BUFSIZE 1024
+#define VC                                                                     \
+  do { if (((ret = xsnprintf_func
+#define UT (char *)xfile->snprintf_buf, SNPRINTF_BUFSIZE,
+#define VE ) >= SNPRINTF_BUFSIZE			       \
+  && (ret = main_print_overflow(ret)) != 0)		       \
+  || (ret = main_file_write(xfile, xfile->snprintf_buf,        \
+			    (usize_t)ret, "print")) != 0)                     \
+  {                                                                            \
+    return ret;                                                                \
+  }                                                                            \
+  }                                                                            \
+  while (0)
+
+static int main_print_overflow(int x) {
+  XPR(NT "internal print buffer overflow: %d bytes\n", x);
+  return XD3_INTERNAL;
+}
+
+/* This function prints a single VCDIFF window. */
+static int main_print_window(xd3_stream *stream, main_file *xfile) {
+  int ret;
+  usize_t size = 0;
+
+  VC(UT "  Offset Code Type1 Size1  @Addr1 + Type2 Size2 @Addr2\n") VE;
+
+  while (stream->inst_sect.buf < stream->inst_sect.buf_max) {
+    usize_t code = stream->inst_sect.buf[0];
+    const uint8_t *addr_before = stream->addr_sect.buf;
+    const uint8_t *inst_before = stream->inst_sect.buf;
+    usize_t addr_bytes;
+    usize_t inst_bytes;
+    usize_t size_before = size;
+
+    if ((ret = xd3_decode_instruction(stream))) {
+      XPR(NT "instruction decode error at %" XD3_Q "u: %s\n",
+          stream->dec_winstart + size, stream->msg);
+      return ret;
+    }
+
+    addr_bytes = (usize_t)(stream->addr_sect.buf - addr_before);
+    inst_bytes = (usize_t)(stream->inst_sect.buf - inst_before);
+
+    VC(UT "  %06" XD3_Q "u %03" XD3_W "u  %s %6" XD3_W "u",
+       stream->dec_winstart + size, option_print_cpymode ? code : 0,
+       xd3_rtype_to_string((xd3_rtype)stream->dec_current1.type,
+                           option_print_cpymode),
+       stream->dec_current1.size)
+    VE;
+
+    if (stream->dec_current1.type != XD3_NOOP) {
+      if (stream->dec_current1.type >= XD3_CPY) {
+        if (stream->dec_current1.addr >= stream->dec_cpylen) {
+          VC(UT " T@%-6" XD3_W "u",
+             stream->dec_current1.addr - stream->dec_cpylen)
+          VE;
+        } else {
+          VC(UT " S@%-6" XD3_Q "u",
+             stream->dec_cpyoff + stream->dec_current1.addr)
+          VE;
+        }
+      } else {
+        VC(UT "        ") VE;
+      }
+
+      size += stream->dec_current1.size;
+    }
+
+    if (stream->dec_current2.type != XD3_NOOP) {
+      VC(UT "  %s %6" XD3_W "u",
+         xd3_rtype_to_string((xd3_rtype)stream->dec_current2.type,
+                             option_print_cpymode),
+         stream->dec_current2.size)
+      VE;
+
+      if (stream->dec_current2.type >= XD3_CPY) {
+        if (stream->dec_current2.addr >= stream->dec_cpylen) {
+          VC(UT " T@%-6" XD3_W "u",
+             stream->dec_current2.addr - stream->dec_cpylen)
+          VE;
+        } else {
+          VC(UT " S@%-6" XD3_Q "u",
+             stream->dec_cpyoff + stream->dec_current2.addr)
+          VE;
+        }
+      }
+
+      size += stream->dec_current2.size;
+    }
+
+    VC(UT "\n") VE;
+
+    if (option_verbose && addr_bytes + inst_bytes >= (size - size_before) &&
+        (stream->dec_current1.type >= XD3_CPY ||
+         stream->dec_current2.type >= XD3_CPY)) {
+      VC(UT "  %06" XD3_Q "u (inefficiency) %" XD3_W "u encoded as %" XD3_W
+            "u bytes\n",
+         stream->dec_winstart + size_before, size - size_before,
+         addr_bytes + inst_bytes)
+      VE;
+    }
+  }
+
+  if (stream->dec_tgtlen != size && (stream->flags & XD3_SKIP_WINDOW) == 0) {
+    XPR(NT "target window size inconsistency");
+    return XD3_INTERNAL;
+  }
+
+  if (stream->dec_position != stream->dec_maxpos) {
+    XPR(NT "target window position inconsistency");
+    return XD3_INTERNAL;
+  }
+
+  if (stream->addr_sect.buf != stream->addr_sect.buf_max) {
+    XPR(NT "address section inconsistency");
+    return XD3_INTERNAL;
+  }
+
+  return 0;
+}
+
+static int main_print_vcdiff_file(main_file *xfile, main_file *file,
+                                  const char *type) {
+  int ret; /* Used by above macros */
+  if (file->filename) {
+    VC(UT "XDELTA filename (%s):     %s\n", type, file->filename) VE;
+  }
+  if (file->compressor) {
+    VC(UT "XDELTA ext comp (%s):     %s\n", type,
+       file->compressor->recomp_cmdname)
+    VE;
+  }
+  return 0;
+}
+
+/* This function prints a VCDIFF input, mainly for debugging purposes. */
+static int main_print_func(xd3_stream *stream, main_file *xfile) {
+  int ret;
+
+  if (option_no_output) {
+    return 0;
+  }
+
+  if (xfile->snprintf_buf == NULL) {
+    if ((xfile->snprintf_buf = (uint8_t *)main_malloc(SNPRINTF_BUFSIZE)) ==
+        NULL) {
+      return ENOMEM;
+    }
+  }
+
+  if (stream->dec_winstart == 0) {
+    VC(UT "VCDIFF version:               0\n") VE;
+    VC(UT "VCDIFF header size:           %" XD3_W "u\n", stream->dec_hdrsize)
+    VE;
+    VC(UT "VCDIFF header indicator:      ") VE;
+    if ((stream->dec_hdr_ind & VCD_SECONDARY) != 0)
+      VC(UT "VCD_SECONDARY ") VE;
+    if ((stream->dec_hdr_ind & VCD_CODETABLE) != 0)
+      VC(UT "VCD_CODETABLE ") VE;
+    if ((stream->dec_hdr_ind & VCD_APPHEADER) != 0)
+      VC(UT "VCD_APPHEADER ") VE;
+    if (stream->dec_hdr_ind == 0)
+      VC(UT "none") VE;
+    VC(UT "\n") VE;
+
+    IF_SEC(VC(UT "VCDIFF secondary compressor:  %s\n",
+              stream->sec_type ? stream->sec_type->name : "none") VE);
+    IF_NSEC(VC(UT "VCDIFF secondary compressor: unsupported\n") VE);
+
+    if (stream->dec_hdr_ind & VCD_APPHEADER) {
+      uint8_t *apphead;
+      usize_t appheadsz;
+      ret = xd3_get_appheader(stream, &apphead, &appheadsz);
+
+      if (ret == 0 && appheadsz > 0) {
+        int sq = option_quiet;
+        main_file i, o, s;
+        XD3_ASSERT(apphead != NULL);
+        VC(UT "VCDIFF application header:    ") VE;
+        if ((ret = main_file_write(xfile, apphead, appheadsz, "print")) != 0) {
+          return ret;
+        }
+        VC(UT "\n") VE;
+
+        main_file_init(&i);
+        main_file_init(&o);
+        main_file_init(&s);
+        option_quiet = 1;
+        main_get_appheader(stream, &i, &o, &s);
+        option_quiet = sq;
+        if ((ret = main_print_vcdiff_file(xfile, &o, "output"))) {
+          return ret;
+        }
+        if ((ret = main_print_vcdiff_file(xfile, &s, "source"))) {
+          return ret;
+        }
+        main_file_cleanup(&i);
+        main_file_cleanup(&o);
+        main_file_cleanup(&s);
+      }
+    }
+  } else {
+    VC(UT "\n") VE;
+  }
+
+  VC(UT "VCDIFF window number:         %" XD3_Q "u\n", stream->current_window)
+  VE;
+  VC(UT "VCDIFF window indicator:      ") VE;
+  if ((stream->dec_win_ind & VCD_SOURCE) != 0)
+    VC(UT "VCD_SOURCE ") VE;
+  if ((stream->dec_win_ind & VCD_TARGET) != 0)
+    VC(UT "VCD_TARGET ") VE;
+  if ((stream->dec_win_ind & VCD_ADLER32) != 0)
+    VC(UT "VCD_ADLER32 ") VE;
+  if (stream->dec_win_ind == 0)
+    VC(UT "none") VE;
+  VC(UT "\n") VE;
+
+  if ((stream->dec_win_ind & VCD_ADLER32) != 0) {
+    VC(UT "VCDIFF adler32 checksum:      %08X\n", stream->dec_adler32) VE;
+  }
+
+  if (stream->dec_del_ind != 0) {
+    VC(UT "VCDIFF delta indicator:       ") VE;
+    if ((stream->dec_del_ind & VCD_DATACOMP) != 0)
+      VC(UT "VCD_DATACOMP ") VE;
+    if ((stream->dec_del_ind & VCD_INSTCOMP) != 0)
+      VC(UT "VCD_INSTCOMP ") VE;
+    if ((stream->dec_del_ind & VCD_ADDRCOMP) != 0)
+      VC(UT "VCD_ADDRCOMP ") VE;
+    if (stream->dec_del_ind == 0)
+      VC(UT "none") VE;
+    VC(UT "\n") VE;
+  }
+
+  if (stream->dec_winstart != 0) {
+    VC(UT "VCDIFF window at offset:      %" XD3_Q "u\n", stream->dec_winstart)
+    VE;
+  }
+
+  if (SRCORTGT(stream->dec_win_ind)) {
+    VC(UT "VCDIFF copy window length:    %" XD3_W "u\n", stream->dec_cpylen) VE;
+    VC(UT "VCDIFF copy window offset:    %" XD3_Q "u\n", stream->dec_cpyoff) VE;
+  }
+
+  VC(UT "VCDIFF delta encoding length: %" XD3_W "u\n",
+     (usize_t)stream->dec_enclen)
+  VE;
+  VC(UT "VCDIFF target window length:  %" XD3_W "u\n",
+     (usize_t)stream->dec_tgtlen)
+  VE;
+
+  VC(UT "VCDIFF data section length:   %" XD3_W "u\n",
+     (usize_t)stream->data_sect.size)
+  VE;
+  VC(UT "VCDIFF inst section length:   %" XD3_W "u\n",
+     (usize_t)stream->inst_sect.size)
+  VE;
+  VC(UT "VCDIFF addr section length:   %" XD3_W "u\n",
+     (usize_t)stream->addr_sect.size)
+  VE;
+
+  ret = 0;
+  if ((stream->flags & XD3_JUST_HDR) != 0) {
+    /* Print a header -- finished! */
+    ret = PRINTHDR_SPECIAL;
+  } else if ((stream->flags & XD3_SKIP_WINDOW) == 0) {
+    ret = main_print_window(stream, xfile);
+  }
+
+  return ret;
+}
+
+static int main_recode_copy(xd3_stream *stream, xd3_output *output,
+                            xd3_desect *input) {
+  int ret;
+
+  XD3_ASSERT(output != NULL);
+  XD3_ASSERT(output->next_page == NULL);
+
+  if ((ret = xd3_decode_allocate(recode_stream, input->size, &output->base,
+                                 &output->avail))) {
+    XPR(NT XD3_LIB_ERRMSG(stream, ret));
+    return ret;
+  }
+
+  memcpy(output->base,
+         /* Note: decoder advances buf, so get base of buffer with
+          * buf_max - size */
+         input->buf_max - input->size, input->size);
+  output->next = input->size;
+  return 0;
+}
+
+// Re-encode one window
+static int main_recode_func(xd3_stream *stream, main_file *ofile) {
+  int ret;
+  xd3_source decode_source;
+
+  XD3_ASSERT(stream->dec_state == DEC_FINISH);
+  XD3_ASSERT(recode_stream->enc_state == ENC_INIT ||
+             recode_stream->enc_state == ENC_INPUT);
+
+  // Copy partial decoder output to partial encoder inputs
+  if ((ret = main_recode_copy(recode_stream, DATA_HEAD(recode_stream),
+                              &stream->data_sect)) ||
+      (ret = main_recode_copy(recode_stream, INST_HEAD(recode_stream),
+                              &stream->inst_sect)) ||
+      (ret = main_recode_copy(recode_stream, ADDR_HEAD(recode_stream),
+                              &stream->addr_sect))) {
+    return ret;
+  }
+
+  // This jumps to xd3_emit_hdr()
+  recode_stream->enc_state = ENC_FLUSH;
+  recode_stream->avail_in = stream->dec_tgtlen;
+
+  if (SRCORTGT(stream->dec_win_ind)) {
+    recode_stream->src = &decode_source;
+    decode_source.srclen = stream->dec_cpylen;
+    decode_source.srcbase = stream->dec_cpyoff;
+  }
+
+  if (option_use_checksum && (stream->dec_win_ind & VCD_ADLER32) != 0) {
+    recode_stream->flags |= XD3_ADLER32_RECODE;
+    recode_stream->recode_adler32 = stream->dec_adler32;
+  }
+
+  if (option_use_appheader != 0 && option_appheader != NULL) {
+    xd3_set_appheader(recode_stream, option_appheader,
+                      (usize_t)strlen((char *)option_appheader));
+  } else if (option_use_appheader != 0 && option_appheader == NULL) {
+    if (stream->dec_appheader != NULL) {
+      xd3_set_appheader(recode_stream, stream->dec_appheader,
+                        stream->dec_appheadsz);
+    }
+  }
+
+  // Output loop
+  for (;;) {
+    switch ((ret = xd3_encode_input(recode_stream))) {
+    case XD3_INPUT: {
+      /* finished recoding one window */
+      stream->total_out = recode_stream->total_out;
+      return 0;
+    }
+    case XD3_OUTPUT: {
+      /* main_file_write below */
+      break;
+    }
+    case XD3_GOTHEADER:
+    case XD3_WINSTART:
+    case XD3_WINFINISH: {
+      /* ignore */
+      continue;
+    }
+    case XD3_GETSRCBLK:
+    case 0: {
+      return XD3_INTERNAL;
+    }
+    default:
+      return ret;
+    }
+
+    if ((ret = main_write_output(recode_stream, ofile))) {
+      return ret;
+    }
+
+    xd3_consume_output(recode_stream);
+  }
+}
+#endif /* VCDIFF_TOOLS */
+
+/*******************************************************************
+ VCDIFF merging
+ ******************************************************************/
+
+#if VCDIFF_TOOLS
+/* Modifies static state. */
+static int main_init_recode_stream(void) {
+  int ret;
+  int stream_flags = XD3_ADLER32_NOVER | XD3_SKIP_EMIT;
+  int recode_flags;
+  xd3_config recode_config;
+
+  XD3_ASSERT(recode_stream == NULL);
+
+  if ((recode_stream = (xd3_stream *)main_malloc(sizeof(xd3_stream))) == NULL) {
+    return ENOMEM;
+  }
+
+  recode_flags = (stream_flags & XD3_SEC_TYPE);
+
+  recode_config.alloc = main_alloc;
+  recode_config.freef = main_free1;
+
+  xd3_init_config(&recode_config, recode_flags);
+
+  if ((ret = main_set_secondary_flags(&recode_config)) ||
+      (ret = xd3_config_stream(recode_stream, &recode_config)) ||
+      (ret = xd3_encode_init_partial(recode_stream)) ||
+      (ret = xd3_whole_state_init(recode_stream))) {
+    XPR(NT XD3_LIB_ERRMSG(recode_stream, ret));
+    xd3_free_stream(recode_stream);
+    recode_stream = NULL;
+    return ret;
+  }
+
+  return 0;
+}
+
+/* This processes the sequence of -m arguments.  The final input
+ * is processed as part of the ordinary main_input() loop. */
+static int main_merge_arguments(main_merge_list *merges) {
+  int ret = 0;
+  int count = 0;
+  main_merge *merge = NULL;
+  xd3_stream merge_input;
+
+  if (main_merge_list_empty(merges)) {
+    return 0;
+  }
+
+  if ((ret = xd3_config_stream(&merge_input, NULL)) ||
+      (ret = xd3_whole_state_init(&merge_input))) {
+    XPR(NT XD3_LIB_ERRMSG(&merge_input, ret));
+    return ret;
+  }
+
+  merge = main_merge_list_front(merges);
+  while (!main_merge_list_end(merges, merge)) {
+    main_file mfile;
+    main_file_init(&mfile);
+    mfile.filename = merge->filename;
+    mfile.flags = RD_NONEXTERNAL;
+
+    if ((ret = main_file_open(&mfile, merge->filename, XO_READ))) {
+      goto error;
+    }
+
+    ret = main_input(CMD_MERGE_ARG, &mfile, NULL, NULL);
+
+    if (ret == 0) {
+      if (count++ == 0) {
+        /* The first merge source is the next merge input. */
+        xd3_swap_whole_state(&recode_stream->whole_target,
+                             &merge_input.whole_target);
+      } else {
+        /* Merge the recode_stream with merge_input. */
+        ret = xd3_merge_input_output(recode_stream, &merge_input.whole_target);
+
+        /* Save the next merge source in merge_input. */
+        xd3_swap_whole_state(&recode_stream->whole_target,
+                             &merge_input.whole_target);
+      }
+    }
+
+    main_file_cleanup(&mfile);
+
+    if (recode_stream != NULL) {
+      xd3_free_stream(recode_stream);
+      main_free(recode_stream);
+      recode_stream = NULL;
+    }
+
+    if (main_bdata != NULL) {
+      main_buffree(main_bdata);
+      main_bdata = NULL;
+      main_bsize = 0;
+    }
+
+    if (ret != 0) {
+      goto error;
+    }
+
+    merge = main_merge_list_next(merge);
+  }
+
+  XD3_ASSERT(merge_stream == NULL);
+
+  if ((merge_stream = (xd3_stream *)main_malloc(sizeof(xd3_stream))) == NULL) {
+    ret = ENOMEM;
+    goto error;
+  }
+
+  if ((ret = xd3_config_stream(merge_stream, NULL)) ||
+      (ret = xd3_whole_state_init(merge_stream))) {
+    XPR(NT XD3_LIB_ERRMSG(&merge_input, ret));
+    goto error;
+  }
+
+  xd3_swap_whole_state(&merge_stream->whole_target, &merge_input.whole_target);
+  ret = 0;
+error:
+  xd3_free_stream(&merge_input);
+  return ret;
+}
+
+/* This processes each window of the final merge input.  This routine
+ * does not output, it buffers the entire delta into memory. */
+static int main_merge_func(xd3_stream *stream, main_file *no_write) {
+  int ret;
+
+  if ((ret = xd3_whole_append_window(stream))) {
+    return ret;
+  }
+
+  return 0;
+}
+
+/* This is called after all windows have been read, as a final step in
+ * main_input().  This is only called for the final merge step. */
+static int main_merge_output(xd3_stream *stream, main_file *ofile) {
+  int ret;
+  usize_t inst_pos = 0;
+  xoff_t output_pos = 0;
+  xd3_source recode_source;
+  usize_t window_num = 0;
+  int at_least_once = 0;
+
+  /* merge_stream is set if there were arguments.  this stream's input
+   * needs to be applied to the merge_stream source. */
+  if ((merge_stream != NULL) &&
+      (ret = xd3_merge_input_output(stream, &merge_stream->whole_target))) {
+    XPR(NT XD3_LIB_ERRMSG(stream, ret));
+    return ret;
+  }
+
+  if (option_use_appheader != 0 && option_appheader != NULL) {
+    xd3_set_appheader(recode_stream, option_appheader,
+                      (usize_t)strlen((char *)option_appheader));
+  }
+#if XD3_ARMOR
+  /* Armored merge-chain verification and re-arming of the merged output. */
+  else if (option_use_appheader != 0 && !option_no_armor) {
+    if (armor_merge_broken) {
+      XPR(NT "armor: refusing to merge a broken armored chain; "
+             "use -a to disable armor\n");
+      return XD3_INVALID_INPUT;
+    }
+    if (armor_merge_count > 0 && armor_merge_all &&
+        armor_merge_have_first_source && armor_merge_have_last_target) {
+      /* Re-arm with the first link's source and the last link's target.  The
+       * merged delta has no associated filenames, so the name fields are just
+       * the digests. */
+      static uint8_t merged_appheader[2 * XD3_BLAKE3_HEXBUF + 8];
+      snprintf_func((char *)merged_appheader, sizeof(merged_appheader),
+                    "-#%s//-#%s/", armor_merge_last_target,
+                    armor_merge_first_source);
+      xd3_set_appheader(recode_stream, merged_appheader,
+                        (usize_t)strlen((char *)merged_appheader));
+      if (option_verbose) {
+        XPR(NT "armor: merged chain verified (%d links)\n", armor_merge_count);
+      }
+    } else if (armor_merge_count > 0 && !option_quiet) {
+      XPR(NT "armor: merged delta is not armored "
+             "(not all inputs carried digests)\n");
+    }
+  }
+#endif
+
+  /* Enter the ENC_INPUT state and bypass the next_in == NULL test
+   * and (leftover) input buffering logic. */
+  XD3_ASSERT(recode_stream->enc_state == ENC_INIT);
+  recode_stream->enc_state = ENC_INPUT;
+  recode_stream->next_in = main_bdata;
+  recode_stream->flags |= XD3_FLUSH;
+
+  /* This encodes the entire target. */
+  while (inst_pos < stream->whole_target.instlen || !at_least_once) {
+    xoff_t window_start = output_pos;
+    int window_srcset = 0;
+    xoff_t window_srcmin = 0;
+    xoff_t window_srcmax = 0;
+    usize_t window_pos = 0;
+    usize_t window_size;
+
+    /* at_least_once ensures that we encode at least one window,
+     * which handles the 0-byte case. */
+    at_least_once = 1;
+
+    XD3_ASSERT(recode_stream->enc_state == ENC_INPUT);
+
+    if ((ret = xd3_encode_input(recode_stream)) != XD3_WINSTART) {
+      XPR(NT "invalid merge state: %s\n", xd3_mainerror(ret));
+      return XD3_INVALID;
+    }
+
+    /* Window sizes must match from the input to the output, so that
+     * target copies are in-range (and so that checksums carry
+     * over). */
+    XD3_ASSERT(window_num < stream->whole_target.wininfolen);
+    window_size = stream->whole_target.wininfo[window_num].length;
+
+    /* Output position should also match. */
+    if (output_pos != stream->whole_target.wininfo[window_num].offset) {
+      XPR(NT "internal merge error: offset mismatch\n");
+      return XD3_INVALID;
+    }
+
+    if (option_use_checksum && (stream->dec_win_ind & VCD_ADLER32) != 0) {
+      recode_stream->flags |= XD3_ADLER32_RECODE;
+      recode_stream->recode_adler32 =
+          stream->whole_target.wininfo[window_num].adler32;
+    }
+
+    window_num++;
+
+    if (main_bsize < window_size) {
+      main_buffree(main_bdata);
+      main_bdata = NULL;
+      main_bsize = 0;
+      if ((main_bdata = (uint8_t *)main_bufalloc(window_size)) == NULL) {
+        return ENOMEM;
+      }
+      main_bsize = window_size;
+    }
+
+    /* This encodes a single target window. */
+    while (window_pos < window_size &&
+           inst_pos < stream->whole_target.instlen) {
+      xd3_winst *inst = &stream->whole_target.inst[inst_pos];
+      usize_t take = xd3_min(inst->size, window_size - window_pos);
+      xoff_t addr;
+
+      switch (inst->type) {
+      case XD3_RUN:
+        if ((ret = xd3_emit_run(recode_stream, window_pos, take,
+                                &stream->whole_target.adds[inst->addr]))) {
+          return ret;
+        }
+        break;
+
+      case XD3_ADD:
+        /* Adds are implicit, put them into the input buffer. */
+        memcpy(main_bdata + window_pos, stream->whole_target.adds + inst->addr,
+               take);
+        break;
+
+      default: /* XD3_COPY + copy mode */
+        if (inst->mode != 0) {
+          if (window_srcset) {
+            window_srcmin = xd3_min(window_srcmin, inst->addr);
+            window_srcmax = xd3_max(window_srcmax, inst->addr + take);
+          } else {
+            window_srcset = 1;
+            window_srcmin = inst->addr;
+            window_srcmax = inst->addr + take;
+          }
+          addr = inst->addr;
+        } else {
+          XD3_ASSERT(inst->addr >= window_start);
+          addr = inst->addr - window_start;
+        }
+        IF_DEBUG2({
+          XPR(NTR "[merge copy] winpos %" XD3_W "u take %" XD3_W "u "
+                  "addr %" XD3_Q "u mode %u\n",
+              window_pos, take, addr, inst->mode);
+        });
+        if ((ret = xd3_found_match(recode_stream, window_pos, take, addr,
+                                   inst->mode != 0))) {
+          return ret;
+        }
+        break;
+      }
+
+      window_pos += take;
+      output_pos += take;
+
+      if (take == inst->size) {
+        inst_pos += 1;
+      } else {
+        /* Modify the instruction for the next pass. */
+        if (inst->type != XD3_RUN) {
+          inst->addr += take;
+        }
+        inst->size -= take;
+      }
+    }
+
+    xd3_avail_input(recode_stream, main_bdata, window_pos);
+
+    recode_stream->enc_state = ENC_INSTR;
+
+    if (window_srcset) {
+      recode_stream->srcwin_decided = 1;
+      recode_stream->src = &recode_source;
+      recode_source.srclen = (usize_t)(window_srcmax - window_srcmin);
+      recode_source.srcbase = window_srcmin;
+      recode_stream->taroff = recode_source.srclen;
+
+      XD3_ASSERT(recode_source.srclen != 0);
+    } else {
+      recode_stream->srcwin_decided = 0;
+      recode_stream->src = NULL;
+      recode_stream->taroff = 0;
+    }
+
+    for (;;) {
+      switch ((ret = xd3_encode_input(recode_stream))) {
+      case XD3_INPUT: {
+        goto done_window;
+      }
+      case XD3_OUTPUT: {
+        /* main_file_write below */
+        break;
+      }
+      case XD3_GOTHEADER:
+      case XD3_WINSTART:
+      case XD3_WINFINISH: {
+        /* ignore */
+        continue;
+      }
+      case XD3_GETSRCBLK:
+      case 0: {
+        return XD3_INTERNAL;
+      }
+      default:
+        return ret;
+      }
+
+      if ((ret = main_write_output(recode_stream, ofile))) {
+        return ret;
+      }
+
+      xd3_consume_output(recode_stream);
+    }
+  done_window:
+    (void)0;
+  }
+
+  return 0;
+}
+#endif
+
+/*******************************************************************
+ Input decompression, output recompression
+ ******************************************************************/
+
+#if EXTERNAL_COMPRESSION
+/* This is tricky POSIX-specific code with lots of fork(), pipe(),
+ * dup(), waitpid(), and exec() business.  Most of this code
+ * originated in PRCS1, which did automatic package-file
+ * decompression.  It works with both XD3_POSIX and XD3_STDIO file
+ * disciplines.
+ *
+ * To automatically detect compressed inputs requires a child process
+ * to reconstruct the input stream, which was advanced in order to
+ * detect compression, because it may not be seekable.  In other
+ * words, the main program reads part of the input stream, and if it
+ * detects a compressed input it then forks a pipe copier process,
+ * which copies the first-read block out of the main-program's memory,
+ * then streams the remaining compressed input into the
+ * input-decompression pipe.
+ */
+
+#include <signal.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+
+/* Remember which pipe FD is which. */
+#define PIPE_READ_FD 0
+#define PIPE_WRITE_FD 1
+#define MAX_SUBPROCS                                                           \
+  4 /* max(source + copier + output,                                           \
+           source + copier + input + copier). */
+static pid_t ext_subprocs[MAX_SUBPROCS];
+
+/* Like write(), applies to a fd instead of a main_file, for the pipe
+ * copier subprocess.  Does not print an error, to facilitate ignoring
+ * trailing garbage, see main_pipe_copier(). */
+static int main_pipe_write(int outfd, uint8_t *exist_buf, usize_t remain) {
+  int ret;
+
+  if ((ret = xd3_posix_io(outfd, exist_buf, remain, xd3_posix_write_func,
+                          NULL))) {
+    return ret;
+  }
+
+  return 0;
+}
+
+/* A simple error-reporting waitpid interface. */
+static int main_waitpid_check(pid_t pid) {
+  int status;
+  int ret = 0;
+
+  if (waitpid(pid, &status, 0) < 0) {
+    ret = get_errno();
+    XPR(NT "external compression [pid %d] wait: %s\n", pid, xd3_mainerror(ret));
+  } else if (!WIFEXITED(status)) {
+    // SIGPIPE will be delivered to the child process whenever it
+    // writes data after this process closes the pipe,
+    // happens if xdelta does not require access to the entire
+    // source file.  Considered normal.
+    if (!WIFSIGNALED(status) || WTERMSIG(status) != SIGPIPE) {
+      ret = ECHILD;
+      XPR(NT "external compression [pid %d] signal %d\n", pid,
+          WIFSIGNALED(status) ? WTERMSIG(status) : WSTOPSIG(status));
+    } else if (option_verbose) {
+      XPR(NT "external compression sigpipe\n");
+    }
+  } else if (WEXITSTATUS(status) != 0) {
+    ret = ECHILD;
+    if (option_verbose > 1) {
+      /* Presumably, the error was printed by the subprocess. */
+      XPR(NT "external compression [pid %d] exit %d\n", pid,
+          WEXITSTATUS(status));
+    }
+  }
+
+  return ret;
+}
+
+/* Wait for any existing child processes to check for abnormal exit. */
+static int main_external_compression_finish(void) {
+  int i;
+  int ret;
+
+  for (i = 0; i < num_subprocs; i += 1) {
+    if (!ext_subprocs[i]) {
+      continue;
+    }
+
+    if ((ret = main_waitpid_check(ext_subprocs[i]))) {
+      return ret;
+    }
+
+    ext_subprocs[i] = 0;
+  }
+
+  return 0;
+}
+
+/* Kills any outstanding compression process. */
+static void main_external_compression_cleanup(void) {
+  int i;
+
+  for (i = 0; i < num_subprocs; i += 1) {
+    if (!ext_subprocs[i]) {
+      continue;
+    }
+
+    kill(ext_subprocs[i], SIGTERM);
+
+    ext_subprocs[i] = 0;
+  }
+}
+
+/* This runs as a forked process of main_input_decompress_setup() to
+ * copy input to the decompression process.  First, the available
+ * input is copied out of the existing buffer, then the buffer is
+ * reused to continue reading from the compressed input file. */
+static int main_pipe_copier(uint8_t *pipe_buf, usize_t pipe_bufsize,
+                            size_t nread, main_file *ifile, int outfd) {
+  int ret;
+  xoff_t skipped = 0;
+
+  /* Prevent SIGPIPE signals, allow EPIPE return values instead.  This
+   * is safe to comment-out, except that the -F flag will not work
+   * properly (the parent would need to treat WTERMSIG(status) ==
+   * SIGPIPE). */
+  struct sigaction sa;
+  sa.sa_handler = SIG_IGN;
+  sigaction(SIGPIPE, &sa, NULL);
+
+  for (;;) {
+    /* force_drain will be set when option_force and EPIPE cause us
+     * to skip data.  This is reset each time through the loop, so
+     * the break condition below works. */
+    int force_drain = 0;
+    if (nread > 0 && (ret = main_pipe_write(outfd, pipe_buf, nread))) {
+      if (ret == EPIPE) {
+        /* This causes the loop to continue reading until nread
+         * == 0. */
+        skipped += nread;
+        force_drain = 1;
+      } else {
+        XPR(NT "pipe write failed: %s\n", xd3_mainerror(ret));
+        return ret;
+      }
+    }
+
+    if (nread < pipe_bufsize && !force_drain) {
+      break;
+    }
+
+    if ((ret = main_file_read(ifile, pipe_buf, pipe_bufsize, &nread,
+                              "pipe read failed")) < 0) {
+      return ret;
+    }
+  }
+
+  if (option_verbose && skipped != 0) {
+    XPR(NT "skipping %" XD3_Q "u bytes in %s\n", skipped, ifile->filename);
+  }
+  return 0;
+}
+
+/* This function is called after we have read some amount of data from
+ * the input file and detected a compressed input.  Here we start a
+ * decompression subprocess by forking twice.  The first process runs
+ * the decompression command, the second process copies data to the
+ * input of the first. */
+static int main_input_decompress_setup(const main_extcomp *decomp,
+                                       main_file *ifile, uint8_t *input_buf,
+                                       usize_t input_bufsize, uint8_t *pipe_buf,
+                                       usize_t pipe_bufsize, usize_t pipe_avail,
+                                       size_t *nread) {
+  /* The two pipes: input and output file descriptors. */
+  int outpipefd[2], inpipefd[2];
+  int input_fd = -1; /* The resulting input_fd (output of decompression). */
+  pid_t decomp_id, copier_id; /* The two subprocs. */
+  int ret;
+
+  outpipefd[0] = outpipefd[1] = -1;
+  inpipefd[0] = inpipefd[1] = -1;
+
+  if (pipe(outpipefd) || pipe(inpipefd)) {
+    XPR(NT "pipe failed: %s\n", xd3_mainerror(ret = get_errno()));
+    goto pipe_cleanup;
+  }
+
+  if ((decomp_id = fork()) < 0) {
+    XPR(NT "fork failed: %s\n", xd3_mainerror(ret = get_errno()));
+    goto pipe_cleanup;
+  }
+
+  /* The first child runs the decompression process: */
+  if (decomp_id == 0) {
+    if (option_verbose > 2) {
+      XPR(NT "external decompression pid %d\n", getpid());
+    }
+
+    /* Setup pipes: write to the outpipe, read from the inpipe. */
+    if (dup2(outpipefd[PIPE_WRITE_FD], STDOUT_FILENO) < 0 ||
+        dup2(inpipefd[PIPE_READ_FD], STDIN_FILENO) < 0 ||
+        close(outpipefd[PIPE_READ_FD]) || close(outpipefd[PIPE_WRITE_FD]) ||
+        close(inpipefd[PIPE_READ_FD]) || close(inpipefd[PIPE_WRITE_FD]) ||
+        execlp(decomp->decomp_cmdname, decomp->decomp_cmdname,
+               decomp->decomp_options, option_force2 ? "-f" : NULL, NULL)) {
+      XPR(NT "child process %s failed to execute: %s\n", decomp->decomp_cmdname,
+          xd3_mainerror(get_errno()));
+    }
+
+    _exit(127);
+  }
+
+  XD3_ASSERT(num_subprocs < MAX_SUBPROCS);
+  ext_subprocs[num_subprocs++] = decomp_id;
+
+  if ((copier_id = fork()) < 0) {
+    XPR(NT "fork failed: %s\n", xd3_mainerror(ret = get_errno()));
+    goto pipe_cleanup;
+  }
+
+  /* The second child runs the copier process: */
+  if (copier_id == 0) {
+    int exitval = 0;
+
+    if (option_verbose > 2) {
+      XPR(NT "child pipe-copier pid %d\n", getpid());
+    }
+
+    if (close(inpipefd[PIPE_READ_FD]) || close(outpipefd[PIPE_READ_FD]) ||
+        close(outpipefd[PIPE_WRITE_FD]) ||
+        main_pipe_copier(pipe_buf, pipe_bufsize, pipe_avail, ifile,
+                         inpipefd[PIPE_WRITE_FD]) ||
+        close(inpipefd[PIPE_WRITE_FD])) {
+      XPR(NT "child copier process failed: %s\n", xd3_mainerror(get_errno()));
+      exitval = 1;
+    }
+
+    _exit(exitval);
+  }
+
+  XD3_ASSERT(num_subprocs < MAX_SUBPROCS);
+  ext_subprocs[num_subprocs++] = copier_id;
+
+  /* The parent closes both pipes after duplicating the output of
+   * compression. */
+  input_fd = dup(outpipefd[PIPE_READ_FD]);
+
+  if (input_fd < 0 || main_file_close(ifile) ||
+      close(outpipefd[PIPE_READ_FD]) || close(outpipefd[PIPE_WRITE_FD]) ||
+      close(inpipefd[PIPE_READ_FD]) || close(inpipefd[PIPE_WRITE_FD])) {
+    XPR(NT "dup/close failed: %s\n", xd3_mainerror(ret = get_errno()));
+    goto pipe_cleanup;
+  }
+
+#if XD3_STDIO
+  /* Note: fdopen() acquires the fd, closes it when finished. */
+  if ((ifile->file = fdopen(input_fd, "r")) == NULL) {
+    XPR(NT "fdopen failed: %s\n", xd3_mainerror(ret = get_errno()));
+    goto pipe_cleanup;
+  }
+
+#elif XD3_POSIX
+  ifile->file = input_fd;
+#endif
+
+  ifile->compressor = decomp;
+
+  /* Now the input file is decompressed. */
+  return main_file_read(ifile, input_buf, input_bufsize, nread,
+                        "input decompression failed");
+
+pipe_cleanup:
+  close(input_fd);
+  close(outpipefd[PIPE_READ_FD]);
+  close(outpipefd[PIPE_WRITE_FD]);
+  close(inpipefd[PIPE_READ_FD]);
+  close(inpipefd[PIPE_WRITE_FD]);
+  return ret;
+}
+
+/* This routine is called when the first buffer of input data is read
+ * by the main program (unless input decompression is disabled by
+ * command-line option).  If it recognizes the magic number of a known
+ * input type it invokes decompression.
+ *
+ * Skips decompression if the decompression type or the file type is
+ * RD_NONEXTERNAL.
+ *
+ * Behaves exactly like main_file_read, otherwise.
+ *
+ * This function uses a separate buffer to read the first small block
+ * of input.  If a compressed input is detected, the separate buffer
+ * is passed to the pipe copier.  This avoids using the same size
+ * buffer in both cases. */
+static int main_secondary_decompress_check(main_file *file, uint8_t *input_buf,
+                                           size_t input_size, size_t *nread) {
+  int ret;
+  usize_t i;
+  usize_t try_read = xd3_min(input_size, XD3_ALLOCSIZE);
+  size_t check_nread = 0;
+  uint8_t check_buf[XD3_ALLOCSIZE]; /* TODO: heap allocate */
+  const main_extcomp *decompressor = NULL;
+
+  if ((ret = main_file_read(file, check_buf, try_read, &check_nread,
+                            "input read failed"))) {
+    return ret;
+  }
+
+  if (file->flags & RD_DECOMPSET) {
+    /* This allows the application header to override the magic
+     * number, for whatever reason. */
+    decompressor = file->compressor;
+  } else {
+    for (i = 0; i < SIZEOF_ARRAY(extcomp_types); i += 1) {
+      const main_extcomp *decomp = &extcomp_types[i];
+
+      if (check_nread > decomp->magic_size) {
+        /* The following expr checks if we are trying to read a
+         * VCDIFF input, in which case do not treat it as
+         * "secondary" decompression. */
+        int skip_this_type =
+            (decomp->flags & RD_NONEXTERNAL) && (file->flags & RD_NONEXTERNAL);
+
+        if (skip_this_type) {
+          continue;
+        }
+
+        if (memcmp(check_buf, decomp->magic, decomp->magic_size) == 0) {
+          decompressor = decomp;
+          break;
+        }
+      }
+    }
+  }
+
+  if (decompressor != NULL) {
+    if (decompressor->detect_level != NULL) {
+      file->compression_level =
+          decompressor->detect_level(check_buf, (usize_t)check_nread);
+    }
+
+    if (!option_quiet) {
+      XPR(NT "externally compressed input: %s %s%s < %s\n",
+          decompressor->decomp_cmdname, decompressor->decomp_options,
+          (option_force2 ? " -f" : ""), file->filename);
+      if (file->flags & RD_MAININPUT) {
+        XPR(NT "WARNING: the encoder is automatically decompressing "
+               "the input file;\n");
+        XPR(NT "WARNING: the decoder will automatically recompress the "
+               "output file;\n");
+        XPR(NT "WARNING: this may result in different compressed data "
+               "and checksums\n");
+        XPR(NT "WARNING: despite being identical data; if this is an "
+               "issue, use -D\n");
+        XPR(NT "WARNING: to avoid decompression and/or use -R to avoid "
+               "recompression\n");
+        XPR(NT "WARNING: and/or manually decompress the input file; if "
+               "you know the\n");
+        XPR(NT "WARNING: compression settings that will produce "
+               "identical output\n");
+        XPR(NT "WARNING: you may set those flags using the environment "
+               "(e.g., GZIP=-9)\n");
+      }
+    }
+
+    file->size_known = 0;
+    return main_input_decompress_setup(decompressor, file, input_buf,
+                                       input_size, check_buf, XD3_ALLOCSIZE,
+                                       check_nread, nread);
+  }
+
+  /* Now read the rest of the input block. */
+  (*nread) = 0;
+
+  if (check_nread == try_read) {
+    ret = main_file_read(file, input_buf + try_read, input_size - try_read,
+                         nread, "input read failed");
+  }
+
+  memcpy(input_buf, check_buf, check_nread);
+
+  (*nread) += check_nread;
+
+  return 0;
+}
+
+/* Initiate re-compression of the output stream.  This is easier than
+ * input decompression because we know beforehand that the stream will
+ * be compressed, whereas the input has already been read when we
+ * decide it should be decompressed.  Thus, it only requires one
+ * subprocess and one pipe. */
+static int main_recompress_output(main_file *ofile) {
+  pid_t recomp_id; /* One subproc. */
+  int pipefd[2];   /* One pipe. */
+  int output_fd = -1;
+  int ret;
+  const main_extcomp *recomp = ofile->compressor;
+
+  pipefd[0] = pipefd[1] = -1;
+
+  if (pipe(pipefd)) {
+    XPR(NT "pipe failed: %s\n", xd3_mainerror(ret = get_errno()));
+    goto pipe_cleanup;
+  }
+
+  if ((recomp_id = fork()) < 0) {
+    XPR(NT "fork failed: %s\n", xd3_mainerror(ret = get_errno()));
+    goto pipe_cleanup;
+  }
+
+  /* The child runs the recompression process: */
+  if (recomp_id == 0) {
+    char level_arg[8];
+    const char *argv[5];
+    int argi = 0;
+
+    argv[argi++] = recomp->recomp_cmdname;
+    argv[argi++] = recomp->recomp_options;
+    if (ofile->compression_level >= 0 && ofile->compression_level <= 9) {
+      snprintf_func(level_arg, sizeof(level_arg), "-%d",
+                    ofile->compression_level);
+      argv[argi++] = level_arg;
+    }
+    if (option_force2) {
+      argv[argi++] = "-f";
+    }
+    argv[argi] = NULL;
+
+    if (option_verbose > 2) {
+      XPR(NT "external recompression pid %d\n", getpid());
+    }
+
+    /* Setup pipes: write to the output file, read from the pipe. */
+    if (dup2(XFNO(ofile), STDOUT_FILENO) < 0 ||
+        dup2(pipefd[PIPE_READ_FD], STDIN_FILENO) < 0 ||
+        close(pipefd[PIPE_READ_FD]) || close(pipefd[PIPE_WRITE_FD]) ||
+        execvp(recomp->recomp_cmdname, (char *const *)argv)) {
+      XPR(NT "child process %s failed to execute: %s\n", recomp->recomp_cmdname,
+          xd3_mainerror(get_errno()));
+    }
+
+    _exit(127);
+  }
+
+  XD3_ASSERT(num_subprocs < MAX_SUBPROCS);
+  ext_subprocs[num_subprocs++] = recomp_id;
+
+  /* The parent closes both pipes after duplicating the output-fd for
+   * writing to the compression pipe. */
+  output_fd = dup(pipefd[PIPE_WRITE_FD]);
+
+  if (output_fd < 0 || main_file_close(ofile) || close(pipefd[PIPE_READ_FD]) ||
+      close(pipefd[PIPE_WRITE_FD])) {
+    XPR(NT "close failed: %s\n", xd3_mainerror(ret = get_errno()));
+    goto pipe_cleanup;
+  }
+
+#if XD3_STDIO
+  /* Note: fdopen() acquires the fd, closes it when finished. */
+  if ((ofile->file = fdopen(output_fd, "w")) == NULL) {
+    XPR(NT "fdopen failed: %s\n", xd3_mainerror(ret = get_errno()));
+    goto pipe_cleanup;
+  }
+
+#elif XD3_POSIX
+  ofile->file = output_fd;
+#endif
+
+  /* Now the output file will be compressed. */
+  return 0;
+
+pipe_cleanup:
+  close(output_fd);
+  close(pipefd[PIPE_READ_FD]);
+  close(pipefd[PIPE_WRITE_FD]);
+  return ret;
+}
+#endif /* EXTERNAL_COMPRESSION */
+
+/* Identify the compressor that was used based on its ident string,
+ * which is passed in the application header. */
+static const main_extcomp *main_ident_compressor(const char *ident) {
+  usize_t i;
+
+  for (i = 0; i < SIZEOF_ARRAY(extcomp_types); i += 1) {
+    if (strcmp(extcomp_types[i].ident, ident) == 0) {
+      return &extcomp_types[i];
+    }
+  }
+
+  return NULL;
+}
+
+/* Return the main_extcomp record to use for this identifier, if possible. */
+static const main_extcomp *main_get_compressor(const char *ident) {
+  const main_extcomp *ext = main_ident_compressor(ident);
+
+  if (ext == NULL) {
+    if (!option_quiet) {
+      XPR(NT "warning: cannot recompress output: "
+             "unrecognized external compression ID: %s\n",
+          ident);
+    }
+    return NULL;
+  } else if (!EXTERNAL_COMPRESSION) {
+    if (!option_quiet) {
+      XPR(NT "warning: external support not compiled: "
+             "original input was compressed: %s\n",
+          ext->recomp_cmdname);
+    }
+    return NULL;
+  } else {
+    return ext;
+  }
+}
+
+/*********************************************************************
+ APPLICATION HEADER
+ *******************************************************************/
+
+#if XD3_ARMOR
+/* Render a BLAKE3-256 digest as lowercase hex with a trailing NUL. */
+static void main_armor_hex(const uint8_t digest[BLAKE3_OUT_LEN],
+                           char out[XD3_BLAKE3_HEXBUF]) {
+  static const char hexdig[] = "0123456789abcdef";
+  int i;
+  for (i = 0; i < BLAKE3_OUT_LEN; i += 1) {
+    out[2 * i] = hexdig[(digest[i] >> 4) & 0xf];
+    out[2 * i + 1] = hexdig[digest[i] & 0xf];
+  }
+  out[XD3_BLAKE3_HEXLEN] = 0;
+}
+
+/* True iff s is exactly XD3_BLAKE3_HEXLEN lowercase hex digits then NUL. */
+static int main_armor_is_hex(const char *s) {
+  usize_t i;
+  for (i = 0; i < XD3_BLAKE3_HEXLEN; i += 1) {
+    char c = s[i];
+    if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) {
+      return 0;
+    }
+  }
+  return s[XD3_BLAKE3_HEXLEN] == 0;
+}
+
+/* If the app-header name field is in armored "name#<64hex>" form, NUL-
+ * terminate the name at the last '#' and return a pointer to the hash;
+ * otherwise return NULL and leave name unchanged.  Filenames may contain
+ * '#', so the split is on the LAST '#' and the suffix must be valid hex. */
+static const char *main_armor_split(char *name) {
+  char *hash = strrchr(name, '#');
+  if (hash != NULL && main_armor_is_hex(hash + 1)) {
+    *hash = 0;
+    return hash + 1;
+  }
+  return NULL;
+}
+
+/* Compute the BLAKE3-256 over the *logical* bytes of a file, i.e. the bytes
+ * xdelta actually processes after any external decompression.  Hashing the
+ * logical (decompressed) content -- rather than the raw on-disk bytes -- makes
+ * armor independent of the exact compressed representation: decompression is
+ * deterministic, whereas recompression is not, so the decoder can reproduce
+ * this hash from the reconstructed content.  Armor requires a seekable
+ * (regular) file because the delta operation reads the same input a second
+ * time.  "type" names the input for messages.
+ *
+ * If "nonseekable" is non-NULL it receives 1 when the file is a stream
+ * (FIFO/pipe) that cannot be hashed, and the function returns 0 without a
+ * hash -- the caller decides whether to warn or fail.  If "nonseekable" is
+ * NULL, a non-seekable file is a hard error. */
+static int main_armor_hash_file(const char *filename, const char *type,
+                                char out_hex[XD3_BLAKE3_HEXBUF],
+                                int *nonseekable) {
+  main_file f;
+  blake3_hasher hasher;
+  uint8_t digest[BLAKE3_OUT_LEN];
+  uint8_t *buf = NULL;
+  xoff_t fsize = 0;
+  size_t bufsz = XD3_ALLOCSIZE;
+  int ret = 0;
+  int read_ret = 0;
+#if EXTERNAL_COMPRESSION
+  int subprocs_before = num_subprocs;
+  int saved_quiet = option_quiet;
+#endif
+
+  if (nonseekable != NULL) {
+    *nonseekable = 0;
+  }
+
+  main_file_init(&f);
+  /* RD_FIRST (and *not* RD_NONEXTERNAL) so the same external-decompression
+   * detection used by the real read applies here. */
+  f.flags = RD_FIRST;
+
+  if ((ret = main_file_open(&f, filename, XO_READ))) {
+    main_file_cleanup(&f);
+    return ret;
+  }
+
+  if (main_file_stat(&f, &fsize) != 0) {
+    main_file_close(&f);
+    main_file_cleanup(&f);
+    if (nonseekable != NULL) {
+      *nonseekable = 1;
+      return 0;
+    }
+    XPR(NT "armor requires a seekable %s: %s\n", type, filename);
+    return XD3_INVALID_INPUT;
+  }
+
+  if ((buf = (uint8_t *)main_malloc(bufsz)) == NULL) {
+    main_file_close(&f);
+    main_file_cleanup(&f);
+    return ENOMEM;
+  }
+
+  blake3_hasher_init(&hasher);
+
+#if EXTERNAL_COMPRESSION
+  /* Suppress the duplicate "externally compressed input" notice; the real
+   * read of this input prints it. */
+  option_quiet = 1;
+#endif
+
+  for (;;) {
+    size_t nread = 0;
+    if ((read_ret = main_read_primary_input(&f, buf, bufsz, &nread))) {
+      break;
+    }
+    if (nread == 0) {
+      break;
+    }
+    blake3_hasher_update(&hasher, buf, nread);
+  }
+
+#if EXTERNAL_COMPRESSION
+  option_quiet = saved_quiet;
+#endif
+
+  main_free(buf);
+  main_file_close(&f);
+  main_file_cleanup(&f);
+
+#if EXTERNAL_COMPRESSION
+  /* Reap any decompression subprocesses forked by this pass so they do not
+   * accumulate against MAX_SUBPROCS during the real operation. */
+  while (num_subprocs > subprocs_before) {
+    num_subprocs -= 1;
+    if (ext_subprocs[num_subprocs]) {
+      int wret = main_waitpid_check(ext_subprocs[num_subprocs]);
+      if (read_ret == 0 && wret != 0) {
+        read_ret = wret;
+      }
+      ext_subprocs[num_subprocs] = 0;
+    }
+  }
+#endif
+
+  ret = read_ret;
+
+  if (ret != 0) {
+    return ret;
+  }
+
+  blake3_hasher_finalize(&hasher, digest, sizeof(digest));
+  main_armor_hex(digest, out_hex);
+  return 0;
+}
+
+/* Parse a raw (read-only) app-header buffer and extract the armored source and
+ * target digests, if present.  The buffer is copied because parsing is
+ * destructive (it splits on '/' and '#'). */
+static void main_armor_parse_appheader(const uint8_t *apphead, usize_t sz,
+                                       int *have_source, char *source,
+                                       int *have_target, char *target) {
+  char *copy;
+  char *start;
+  char *slash;
+  int place = 0;
+  char *parsed[4];
+
+  *have_source = 0;
+  *have_target = 0;
+
+  if (apphead == NULL || sz == 0) {
+    return;
+  }
+
+  if ((copy = (char *)main_malloc(sz + 1)) == NULL) {
+    return;
+  }
+  memcpy(copy, apphead, sz);
+  copy[sz] = 0;
+
+  memset(parsed, 0, sizeof(parsed));
+  start = copy;
+  while ((slash = strchr(start, '/')) != NULL && place < 3) {
+    *slash = 0;
+    parsed[place++] = start;
+    start = slash + 1;
+  }
+  parsed[place++] = start;
+
+  if (place == 2 || place == 4) {
+    const char *th = main_armor_split(parsed[0]);
+    if (th != NULL) {
+      strcpy(target, th);
+      *have_target = 1;
+    }
+  }
+  if (place == 4) {
+    const char *sh = main_armor_split(parsed[2]);
+    if (sh != NULL) {
+      strcpy(source, sh);
+      *have_source = 1;
+    }
+  }
+
+  main_free(copy);
+}
+
+/* Record one delta of a merge chain (called in chain order) and verify that
+ * its source digest matches the previous link's target digest. */
+static void main_armor_merge_link(const uint8_t *apphead, usize_t sz) {
+  int have_source = 0;
+  int have_target = 0;
+  char source[XD3_BLAKE3_HEXBUF];
+  char target[XD3_BLAKE3_HEXBUF];
+  int idx = armor_merge_count;
+
+  main_armor_parse_appheader(apphead, sz, &have_source, source, &have_target,
+                             target);
+  armor_merge_count += 1;
+
+  if (!have_source || !have_target) {
+    /* A link missing either digest cannot be fully verified or re-armored. */
+    if (idx != 0 || !have_target) {
+      armor_merge_all = 0;
+    }
+  }
+
+  if (idx == 0) {
+    if (have_source) {
+      strcpy(armor_merge_first_source, source);
+      armor_merge_have_first_source = 1;
+    }
+  } else if (armor_merge_have_prev_target && have_source) {
+    if (strcmp(armor_merge_prev_target, source) != 0) {
+      armor_merge_broken = 1;
+      XPR(NT "armor: broken armored chain at merge link %d\n", idx);
+      XPR(NT "  previous target %s\n", armor_merge_prev_target);
+      XPR(NT "  this source     %s\n", source);
+    }
+  }
+
+  if (have_target) {
+    strcpy(armor_merge_prev_target, target);
+    armor_merge_have_prev_target = 1;
+    strcpy(armor_merge_last_target, target);
+    armor_merge_have_last_target = 1;
+  } else {
+    armor_merge_have_prev_target = 0;
+  }
+}
+#endif /* XD3_ARMOR */
+
+#if XD3_ENCODER
+static const char *main_apphead_string(const char *x) {
+  const char *y;
+
+  if (x == NULL) {
+    return "";
+  }
+
+  if (strcmp(x, "/dev/stdin") == 0 || strcmp(x, "/dev/stdout") == 0 ||
+      strcmp(x, "/dev/stderr") == 0) {
+    return "-";
+  }
+
+  // TODO: this is not portable
+  return (y = strrchr(x, '/')) == NULL ? x : y + 1;
+}
+
+/* Format the appheader compressor field as "<ident>" or "<ident><level>" (e.g.
+ * "B9") so the decoder can reproduce the original compression level.  Returns a
+ * pointer into buf, or the bare ident / "" when no level is known. */
+static const char *main_apphead_comp(const main_extcomp *comp, int level,
+                                     char *buf, size_t bufsize) {
+  if (comp == NULL) {
+    return "";
+  }
+  if (level >= 0 && level <= 9
+#if EXTERNAL_COMPRESSION
+      && option_use_comp_level
+#endif
+  ) {
+    snprintf_func(buf, bufsize, "%s%d", comp->ident, level);
+    return buf;
+  }
+  return comp->ident;
+}
+
+static int main_set_appheader(xd3_stream *stream, main_file *input,
+                              main_file *sfile) {
+  /* The user may disable the application header.  Once the appheader
+   * is set, this disables setting it again. */
+  if (appheader_used || !option_use_appheader) {
+    return 0;
+  }
+
+  /* The user may specify the application header, otherwise format the
+     default header. */
+  if (option_appheader) {
+    appheader_used = option_appheader;
+  } else {
+    const char *iname;
+    const char *icomp;
+    const char *sname;
+    const char *scomp;
+    char icomp_buf[8];
+    char scomp_buf[8];
+    usize_t len;
+#if XD3_ARMOR
+    /* Armored name fields carry "name#<64hex>".  Computed below when armor
+     * is enabled (the default). */
+    char thash[XD3_BLAKE3_HEXBUF];
+    char shash[XD3_BLAKE3_HEXBUF];
+    const char *tsep = "";
+    const char *thashstr = "";
+    const char *ssep = "";
+    const char *shashstr = "";
+    int armor = !option_no_armor;
+#endif
+
+    iname = main_apphead_string(input->filename);
+    icomp = main_apphead_comp(input->compressor, input->compression_level,
+                              icomp_buf, sizeof(icomp_buf));
+    len = (usize_t)strlen(iname) + (usize_t)strlen(icomp) + 2;
+
+    if (sfile->filename != NULL) {
+      sname = main_apphead_string(sfile->filename);
+      scomp = main_apphead_comp(sfile->compressor, sfile->compression_level,
+                                scomp_buf, sizeof(scomp_buf));
+      len += (usize_t)strlen(sname) + (usize_t)strlen(scomp) + 2;
+    } else {
+      sname = scomp = "";
+    }
+
+#if XD3_ARMOR
+    if (armor) {
+      int ret;
+      /* The target is the encoder input; the source is the -s file.  Both
+       * must be seekable regular files so they can be hashed up front. */
+      if (input->filename == NULL) {
+        XPR(NT "armor requires a seekable target; use -a to disable armor\n");
+        return XD3_INVALID_INPUT;
+      }
+      if ((ret =
+               main_armor_hash_file(input->filename, "target", thash, NULL))) {
+        return ret;
+      }
+      tsep = "#";
+      thashstr = thash;
+      len += (usize_t)(strlen(tsep) + strlen(thashstr));
+
+      if (sfile->filename != NULL) {
+        if ((ret = main_armor_hash_file(sfile->filename, "source", shash,
+                                        NULL))) {
+          return ret;
+        }
+        ssep = "#";
+        shashstr = shash;
+        len += (usize_t)(strlen(ssep) + strlen(shashstr));
+      }
+    }
+#endif
+
+    if ((appheader_used = (uint8_t *)main_malloc(len)) == NULL) {
+      return ENOMEM;
+    }
+
+#if XD3_ARMOR
+    if (armor) {
+      if (sfile->filename == NULL) {
+        snprintf_func((char *)appheader_used, len, "%s%s%s/%s", iname, tsep,
+                      thashstr, icomp);
+      } else {
+        snprintf_func((char *)appheader_used, len, "%s%s%s/%s/%s%s%s/%s", iname,
+                      tsep, thashstr, icomp, sname, ssep, shashstr, scomp);
+      }
+    } else
+#endif
+        if (sfile->filename == NULL) {
+      snprintf_func((char *)appheader_used, len, "%s/%s", iname, icomp);
+    } else {
+      snprintf_func((char *)appheader_used, len, "%s/%s/%s/%s", iname, icomp,
+                    sname, scomp);
+    }
+  }
+
+  xd3_set_appheader(stream, appheader_used,
+                    (usize_t)strlen((char *)appheader_used));
+
+  return 0;
+}
+#endif
+
+static void main_get_appheader_params(main_file *file, char **parsed,
+                                      int output, const char *type,
+                                      main_file *other) {
+  /* Set the filename if it was not specified.  If output, option_stdout (-c)
+   * overrides. */
+  if (file->filename == NULL && !(output && option_stdout) &&
+      strcmp(parsed[0], "-") != 0) {
+    file->filename = parsed[0];
+
+    if (other->filename != NULL) {
+      /* Take directory from the other file, if it has one. */
+      /* TODO: This results in nonsense names like /dev/foo.tar.gz
+       * and probably the filename-default logic interferes with
+       * multi-file operation and the standard file extension?
+       * Possibly the name header is bad, should be off by default.
+       * Possibly we just want to remember external/compression
+       * settings. */
+      const char *last_slash = strrchr(other->filename, '/');
+
+      if (last_slash != NULL) {
+        usize_t dlen = (usize_t)(last_slash - other->filename);
+
+        XD3_ASSERT(file->filename_copy == NULL);
+        file->filename_copy =
+            (char *)main_malloc(dlen + 2 + (usize_t)strlen(file->filename));
+
+        strncpy(file->filename_copy, other->filename, dlen);
+        file->filename_copy[dlen] = '/';
+        strcpy(file->filename_copy + dlen + 1, parsed[0]);
+
+        file->filename = file->filename_copy;
+      }
+    }
+
+    if (!option_quiet) {
+      XPR(NT "using default %s filename: %s\n", type, file->filename);
+    }
+  }
+
+  /* Set the compressor, initiate de/recompression later.  The compressor field
+   * is "<ident>" or "<ident><level>" (e.g. "B9"); split the trailing decimal
+   * level, if present, so recompression can reproduce the original level. */
+  if (file->compressor == NULL && *parsed[1] != 0) {
+    char ident[8];
+    const char *comp = parsed[1];
+    usize_t n = 0;
+
+    while (comp[n] != 0 && !(comp[n] >= '0' && comp[n] <= '9') &&
+           n + 1 < sizeof(ident)) {
+      ident[n] = comp[n];
+      n += 1;
+    }
+    ident[n] = 0;
+
+    if (comp[n] >= '0' && comp[n] <= '9') {
+      file->compression_level = comp[n] - '0';
+    }
+
+    file->flags |= RD_DECOMPSET;
+    file->compressor = main_get_compressor(ident);
+  }
+}
+
+static void main_get_appheader(xd3_stream *stream, main_file *ifile,
+                               main_file *output, main_file *sfile) {
+  uint8_t *apphead;
+  usize_t appheadsz;
+  int ret;
+
+  /* The user may disable the application header.  Once the appheader
+   * is set, this disables setting it again. */
+  if (!option_use_appheader) {
+    return;
+  }
+
+  ret = xd3_get_appheader(stream, &apphead, &appheadsz);
+
+  /* Ignore failure, it only means we haven't received a header yet. */
+  if (ret != 0) {
+    return;
+  }
+
+  if (appheadsz > 0) {
+    char *start = (char *)apphead;
+    char *slash;
+    int place = 0;
+    const int kMaxArgs = 4;
+    char *parsed[4];
+
+    memset(parsed, 0, sizeof(parsed));
+
+    while ((slash = strchr(start, '/')) != NULL && place < (kMaxArgs - 1)) {
+      *slash = 0;
+      parsed[place++] = start;
+      start = slash + 1;
+    }
+
+    parsed[place++] = start;
+
+#if XD3_ARMOR
+    /* Strip armored "name#<64hex>" digests from the name fields so default
+     * filenames never include the digest.  This is done even under -a
+     * (option_no_armor): -a means "do not verify", not "treat the delta as
+     * legacy".  Only record the digests for verification when armor is on. */
+    {
+      const char *th = NULL;
+      const char *sh = NULL;
+      if (place == 2 || place == 4) {
+        th = main_armor_split(parsed[0]);
+      }
+      if (place == 4) {
+        sh = main_armor_split(parsed[2]);
+      }
+      if (!option_no_armor) {
+        if (th != NULL) {
+          strcpy(armor_expect_target, th);
+          armor_have_target = 1;
+        }
+        if (sh != NULL) {
+          strcpy(armor_expect_source, sh);
+          armor_have_source = 1;
+        }
+      }
+    }
+#endif
+
+    /* First take the output parameters. */
+    if (place == 2 || place == 4) {
+      main_get_appheader_params(output, parsed, 1, "output", ifile);
+    }
+
+    /* Then take the source parameters. */
+    if (place == 4) {
+      main_get_appheader_params(sfile, parsed + 2, 0, "source", ifile);
+    }
+  }
+
+  option_use_appheader = 0;
+  return;
+}
+
+/*********************************************************************
+ Main I/O routines
+ **********************************************************************/
+
+/* This function acts like the above except it may also try to
+ * recognize a compressed input (source or target) when the first
+ * buffer of data is read.  The EXTERNAL_COMPRESSION code is called to
+ * search for magic numbers. */
+static int main_read_primary_input(main_file *file, uint8_t *buf, size_t size,
+                                   size_t *nread) {
+#if EXTERNAL_COMPRESSION
+  if (option_decompress_inputs && file->flags & RD_FIRST) {
+    file->flags &= ~RD_FIRST;
+    return main_secondary_decompress_check(file, buf, size, nread);
+  }
+#endif
+
+  return main_file_read(file, buf, size, nread, "input read failed");
+}
+
+/* Open the main output file, sets a default file name, initiate
+ * recompression.  This function is expected to fprint any error
+ * messages. */
+static int main_open_output(xd3_stream *stream, main_file *ofile) {
+  int ret;
+
+  if (option_no_output) {
+    return 0;
+  }
+
+  if (ofile->filename == NULL) {
+    XSTDOUT_XF(ofile);
+
+    if (option_verbose > 1) {
+      XPR(NT "using standard output: %s\n", ofile->filename);
+    }
+  } else {
+    /* Stat the file to check for overwrite. */
+    if (option_force == 0 && main_file_exists(ofile)) {
+      if (!option_quiet) {
+        XPR(NT "to overwrite output file specify -f: %s\n", ofile->filename);
+      }
+      return EEXIST;
+    }
+
+    if ((ret = main_file_open(ofile, ofile->filename, XO_WRITE))) {
+      return ret;
+    }
+
+    if (option_verbose > 1) {
+      XPR(NT "output %s\n", ofile->filename);
+    }
+  }
+
+#if EXTERNAL_COMPRESSION
+  /* Do output recompression. */
+  if (ofile->compressor != NULL && option_recompress_outputs == 1) {
+    if (!option_quiet) {
+      char level_str[8];
+      level_str[0] = 0;
+      if (ofile->compression_level >= 0 && ofile->compression_level <= 9) {
+        snprintf_func(level_str, sizeof(level_str), " -%d",
+                      ofile->compression_level);
+      }
+      XPR(NT "externally compressed output: %s %s%s%s > %s\n",
+          ofile->compressor->recomp_cmdname, ofile->compressor->recomp_options,
+          level_str, (option_force2 ? " -f" : ""), ofile->filename);
+    }
+
+    if ((ret = main_recompress_output(ofile))) {
+      return ret;
+    }
+  }
+#endif
+
+  return 0;
+}
+
+static usize_t main_get_winsize(main_file *ifile) {
+  xoff_t file_size = 0;
+  usize_t size = option_winsize;
+  static shortbuf iszbuf;
+
+  if (main_file_stat(ifile, &file_size) == 0) {
+    size = (usize_t)xd3_min(file_size, (xoff_t)size);
+  }
+
+  size = xd3_max(size, XD3_ALLOCSIZE);
+
+  if (option_verbose > 1) {
+    XPR(NT "input %s window size %s\n", ifile->filename,
+        main_format_bcnt(size, &iszbuf));
+  }
+
+  return size;
+}
+
+/*********************************************************************
+ Main routines
+ ********************************************************************/
+
+/* This is a generic input function.  It calls the xd3_encode_input or
+ * xd3_decode_input functions and makes calls to the various input
+ * handling routines above, which coordinate external decompression.
+ */
+static int main_input(xd3_cmd cmd, main_file *ifile, main_file *ofile,
+                      main_file *sfile) {
+  int ret;
+  xd3_stream stream;
+  size_t nread = 0;
+  usize_t winsize;
+  int stream_flags = 0;
+  xd3_config config;
+  xd3_source source;
+  xoff_t last_total_in = 0;
+  xoff_t last_total_out = 0;
+  long start_time;
+  int stdout_only = 0;
+  int (*input_func)(xd3_stream *);
+  int (*output_func)(xd3_stream *, main_file *);
+
+  memset(&stream, 0, sizeof(stream));
+  memset(&source, 0, sizeof(source));
+  memset(&config, 0, sizeof(config));
+
+  config.alloc = main_alloc;
+  config.freef = main_free1;
+
+  config.iopt_size = option_iopt_size;
+  config.sprevsz = option_sprevsz;
+
+  do_src_fifo = 0;
+
+  start_time = get_millisecs_now();
+
+#if XD3_ARMOR
+  /* Reset per-operation armor verification state. */
+  armor_have_source = 0;
+  armor_have_target = 0;
+  armor_target_active = 0;
+#endif
+
+  if (option_use_checksum) {
+    stream_flags |= XD3_ADLER32;
+  }
+
+  /* main_input setup. */
+  switch ((int)cmd) {
+#if VCDIFF_TOOLS
+    if (1) {
+    case CMD_PRINTHDR:
+      stream_flags |= XD3_JUST_HDR;
+    } else if (1) {
+    case CMD_PRINTHDRS:
+      stream_flags |= XD3_SKIP_WINDOW;
+    } else {
+    case CMD_PRINTDELTA:
+      stream_flags |= XD3_SKIP_EMIT;
+    }
+    ifile->flags |= RD_NONEXTERNAL;
+    input_func = xd3_decode_input;
+    output_func = main_print_func;
+    stream_flags |= XD3_ADLER32_NOVER;
+    stdout_only = 1;
+    break;
+
+  case CMD_RECODE:
+  case CMD_MERGE:
+  case CMD_MERGE_ARG:
+    /* No source will be read */
+    stream_flags |= XD3_ADLER32_NOVER | XD3_SKIP_EMIT;
+    ifile->flags |= RD_NONEXTERNAL;
+    input_func = xd3_decode_input;
+
+    if ((ret = main_init_recode_stream())) {
+      return EXIT_FAILURE;
+    }
+
+    if (cmd == CMD_RECODE) {
+      output_func = main_recode_func;
+    } else {
+      output_func = main_merge_func;
+    }
+    break;
+#endif /* VCDIFF_TOOLS */
+
+#if XD3_ENCODER
+  case CMD_ENCODE:
+    do_src_fifo = 1;
+    input_func = xd3_encode_input;
+    output_func = main_write_output;
+
+    if (option_no_compress) {
+      stream_flags |= XD3_NOCOMPRESS;
+    }
+    if (option_smatch_config) {
+      const char *s = option_smatch_config;
+      char *e;
+      long values[XD3_SOFTCFG_VARCNT];
+      int got;
+
+      config.smatch_cfg = XD3_SMATCH_SOFT;
+
+      for (got = 0; got < XD3_SOFTCFG_VARCNT; got += 1, s = e + 1) {
+        values[got] = strtol(s, &e, 10);
+
+        if ((values[got] < 0) || (e == s) ||
+            (got < XD3_SOFTCFG_VARCNT - 1 && *e == 0) ||
+            (got == XD3_SOFTCFG_VARCNT - 1 && *e != 0)) {
+          XPR(NT "invalid string match specifier (-C) %d: %s\n", got, s);
+          return EXIT_FAILURE;
+        }
+      }
+
+      config.smatcher_soft.large_look = values[0];
+      config.smatcher_soft.large_step = values[1];
+      config.smatcher_soft.small_look = values[2];
+      config.smatcher_soft.small_chain = values[3];
+      config.smatcher_soft.small_lchain = values[4];
+      config.smatcher_soft.max_lazy = values[5];
+      config.smatcher_soft.long_enough = values[6];
+    } else {
+      if (option_verbose > 2) {
+        XPR(NT "compression level: %d\n", option_level);
+      }
+      if (option_level == 0) {
+        stream_flags |= XD3_NOCOMPRESS;
+        config.smatch_cfg = XD3_SMATCH_FASTEST;
+      } else if (option_level == 1) {
+        config.smatch_cfg = XD3_SMATCH_FASTEST;
+      } else if (option_level == 2) {
+        config.smatch_cfg = XD3_SMATCH_FASTER;
+      } else if (option_level <= 5) {
+        config.smatch_cfg = XD3_SMATCH_FAST;
+      } else if (option_level == 6) {
+        config.smatch_cfg = XD3_SMATCH_DEFAULT;
+      } else {
+        config.smatch_cfg = XD3_SMATCH_SLOW;
+      }
+    }
+    break;
+#endif
+  case CMD_DECODE:
+    if (option_use_checksum == 0) {
+      stream_flags |= XD3_ADLER32_NOVER;
+    }
+    ifile->flags |= RD_NONEXTERNAL;
+    input_func = xd3_decode_input;
+    output_func = main_write_output;
+    break;
+  default:
+    XPR(NT "internal error\n");
+    return EXIT_FAILURE;
+  }
+
+  main_bsize = winsize = main_get_winsize(ifile);
+
+  if ((main_bdata = (uint8_t *)main_bufalloc(winsize)) == NULL) {
+    return EXIT_FAILURE;
+  }
+
+  config.winsize = winsize;
+  config.getblk = main_getblk_func;
+  config.flags = stream_flags;
+
+  if ((ret = main_set_secondary_flags(&config)) ||
+      (ret = xd3_config_stream(&stream, &config))) {
+    XPR(NT XD3_LIB_ERRMSG(&stream, ret));
+    return EXIT_FAILURE;
+  }
+
+#if VCDIFF_TOOLS
+  if ((cmd == CMD_MERGE || cmd == CMD_MERGE_ARG) &&
+      (ret = xd3_whole_state_init(&stream))) {
+    XPR(NT XD3_LIB_ERRMSG(&stream, ret));
+    return EXIT_FAILURE;
+  }
+#endif
+
+  if (cmd != CMD_DECODE) {
+    /* When not decoding, set source now.  The decoder delays this
+     * step until XD3_GOTHEADER. */
+    if (sfile && sfile->filename != NULL) {
+      if ((ret = main_set_source(&stream, cmd, sfile, &source))) {
+        return EXIT_FAILURE;
+      }
+
+      XD3_ASSERT(stream.src != NULL);
+    }
+  }
+
+  if (cmd == CMD_PRINTHDR || cmd == CMD_PRINTHDRS || cmd == CMD_PRINTDELTA ||
+      cmd == CMD_RECODE) {
+    if (sfile->filename == NULL) {
+      allow_fake_source = 1;
+      sfile->filename = "<placeholder>";
+      main_set_source(&stream, cmd, sfile, &source);
+    }
+  }
+
+  /* This times each window. */
+  get_millisecs_since();
+
+  /* Main input loop. */
+  do {
+    xoff_t input_offset;
+    xoff_t input_remain;
+    usize_t try_read;
+
+    input_offset = ifile->nread;
+
+    input_remain = XOFF_T_MAX - input_offset;
+
+    try_read = (usize_t)xd3_min((xoff_t)config.winsize, input_remain);
+
+    if ((ret = main_read_primary_input(ifile, main_bdata, try_read, &nread))) {
+      return EXIT_FAILURE;
+    }
+
+    /* If we've reached EOF tell the stream to flush. */
+    if (nread < try_read) {
+      stream.flags |= XD3_FLUSH;
+    }
+
+#if XD3_ENCODER
+    /* After the first main_read_primary_input completes, we know
+     * all the information needed to encode the application
+     * header. */
+    if (cmd == CMD_ENCODE &&
+        (ret = main_set_appheader(&stream, ifile, sfile))) {
+      return EXIT_FAILURE;
+    }
+#endif
+    xd3_avail_input(&stream, main_bdata, nread);
+
+    /* If we read zero bytes after encoding at least one window... */
+    if (nread == 0 && stream.current_window > 0) {
+      break;
+    }
+
+  again:
+    ret = input_func(&stream);
+
+    switch (ret) {
+    case XD3_INPUT:
+      continue;
+
+    case XD3_GOTHEADER: {
+      XD3_ASSERT(stream.current_window == 0);
+
+      /* Need to process the appheader as soon as possible.  It may
+       * contain a suggested default filename/decompression routine for
+       * the ofile, and it may contain default/decompression routine for
+       * the sources. */
+      if (cmd == CMD_DECODE) {
+        /* May need to set the sfile->filename if none was given. */
+        main_get_appheader(&stream, ifile, ofile, sfile);
+
+        /* Now open the source file. */
+        if ((sfile->filename != NULL) &&
+            (ret = main_set_source(&stream, cmd, sfile, &source))) {
+          return EXIT_FAILURE;
+        }
+
+#if XD3_ARMOR
+        /* Armor: verify the source up front, before applying anything, then
+         * arm the on-the-fly target hasher. */
+        if (armor_have_source) {
+          char got[XD3_BLAKE3_HEXBUF];
+          int nonseekable = 0;
+
+          if (sfile->filename == NULL) {
+            XPR(NT "armor: this delta requires a source but none was given; "
+                   "use -a to skip armor verification\n");
+            return EXIT_FAILURE;
+          }
+          if ((ret = main_armor_hash_file(sfile->filename, "source", got,
+                                          &nonseekable))) {
+            return EXIT_FAILURE;
+          }
+          if (nonseekable) {
+            /* A streaming (non-seekable) source cannot be read a second time
+             * to hash it, so armor cannot verify it.  Warn and proceed; the
+             * target is still verified on the fly. */
+            XPR(NT "WARNING: this delta is armored but the source is not "
+                   "seekable (streaming);\n");
+            XPR(NT "WARNING: the source cannot be verified.  Provide a "
+                   "seekable source file\n");
+            XPR(NT "WARNING: to verify it, or use -a to disable armor.\n");
+          } else if (strcmp(got, armor_expect_source) != 0) {
+            /* The source already matches the *target*: the patch is already
+             * applied / the source is up to date. */
+            if (armor_have_target && strcmp(got, armor_expect_target) == 0) {
+              XPR(NT "the source is already up to date: %s\n", sfile->filename);
+              XPR(NT "it already matches the target of this patch; "
+                     "nothing to do\n");
+              return EXIT_ARMOR_UP_TO_DATE;
+            }
+            XPR(NT "source file BLAKE3 mismatch: %s\n", sfile->filename);
+            XPR(NT "  expected %s\n", armor_expect_source);
+            XPR(NT "  actual   %s\n", got);
+            XPR(NT "the supplied source does not match the one used to build "
+                   "this patch\n");
+            return EXIT_FAILURE;
+          } else if (option_verbose) {
+            XPR(NT "armor: source verified (%s)\n", sfile->filename);
+          }
+        }
+        if (armor_have_target) {
+          blake3_hasher_init(&armor_target_hasher);
+          armor_target_active = 1;
+        }
+#endif
+      }
+#if XD3_ARMOR
+      /* Record each delta of a merge chain (in chain order) for armored
+       * chain verification. */
+      if (!option_no_armor && (cmd == CMD_MERGE || cmd == CMD_MERGE_ARG)) {
+        uint8_t *apphead = NULL;
+        usize_t appheadsz = 0;
+        if (xd3_get_appheader(&stream, &apphead, &appheadsz) == 0) {
+          main_armor_merge_link(apphead, appheadsz);
+        } else {
+          main_armor_merge_link(NULL, 0);
+        }
+        if (armor_merge_broken) {
+          XPR(NT "armor: refusing to merge a broken armored chain; "
+                 "use -a to disable armor\n");
+          return EXIT_FAILURE;
+        }
+      }
+#endif
+    }
+    /* FALLTHROUGH */
+    case XD3_WINSTART: {
+      /* e.g., set or unset XD3_SKIP_WINDOW. */
+      goto again;
+    }
+
+    case XD3_OUTPUT: {
+      /* Defer opening the output file until the stream produces its
+       * first output for both encoder and decoder, this way we
+       * delay long enough for the decoder to receive the
+       * application header.  (Or longer if there are skipped
+       * windows, but I can't think of any reason not to delay
+       * open.) */
+      if (ofile != NULL && !main_file_isopen(ofile) &&
+          (ret = main_open_output(&stream, ofile)) != 0) {
+        return EXIT_FAILURE;
+      }
+
+      if ((ret = output_func(&stream, ofile)) && (ret != PRINTHDR_SPECIAL)) {
+        return EXIT_FAILURE;
+      }
+
+      if (ret == PRINTHDR_SPECIAL) {
+        xd3_abort_stream(&stream);
+        ret = EXIT_SUCCESS;
+        goto done;
+      }
+
+      ret = 0;
+
+      xd3_consume_output(&stream);
+      goto again;
+    }
+
+    case XD3_WINFINISH: {
+      /* Warn loudly, once, if a delta being decoded carries no
+         integrity checksum, since a wrong source can then silently
+         produce corrupt output. */
+      if (cmd == CMD_DECODE && option_use_checksum && !option_quiet &&
+          !main_warned_no_checksum && (stream.dec_win_ind & VCD_ADLER32) == 0) {
+        main_warned_no_checksum = 1;
+        XPR(NT "WARNING: this delta has no integrity checksum; "
+               "the decoded output cannot be verified and a wrong "
+               "source may silently produce corrupt output\n");
+      }
+
+      if (IS_ENCODE(cmd) || cmd == CMD_DECODE || cmd == CMD_RECODE) {
+        if (!option_quiet && IS_ENCODE(cmd) && main_file_isopen(sfile)) {
+          /* Warn when no source copies are found */
+          if (option_verbose && !xd3_encoder_used_source(&stream)) {
+            XPR(NT "warning: input window %" XD3_Q "u..%" XD3_Q "u has "
+                   "no source copies\n",
+                stream.current_window * winsize,
+                (stream.current_window + 1) * winsize);
+            XD3_ASSERT(stream.src != NULL);
+          }
+
+          /* Limited i-buffer size affects source copies
+           * when the sourcewin is decided early. */
+          if (option_verbose > 1 && stream.srcwin_decided_early &&
+              stream.i_slots_used > stream.iopt_size) {
+            XPR(NT "warning: input position %" XD3_Q "u overflowed "
+                   "instruction buffer, needed %" XD3_W "u (vs. %" XD3_W "u), "
+                   "consider changing -I\n",
+                stream.current_window * winsize, stream.i_slots_used,
+                stream.iopt_size);
+          }
+        }
+
+        if (option_verbose) {
+          shortbuf rrateavg, wrateavg, tm;
+          shortbuf rdb, wdb;
+          shortbuf trdb, twdb;
+          shortbuf srcpos;
+          long millis = get_millisecs_since();
+          usize_t this_read = (usize_t)(stream.total_in - last_total_in);
+          usize_t this_write = (usize_t)(stream.total_out - last_total_out);
+          last_total_in = stream.total_in;
+          last_total_out = stream.total_out;
+
+          if (option_verbose > 1) {
+            XPR(NT "%" XD3_Q "u: in %s (%s): out %s (%s): "
+                   "total in %s: out %s: %s: srcpos %s\n",
+                stream.current_window, main_format_bcnt(this_read, &rdb),
+                main_format_rate(this_read, millis, &rrateavg),
+                main_format_bcnt(this_write, &wdb),
+                main_format_rate(this_write, millis, &wrateavg),
+                main_format_bcnt(stream.total_in, &trdb),
+                main_format_bcnt(stream.total_out, &twdb),
+                main_format_millis(millis, &tm),
+                main_format_bcnt(stream.srcwin_cksum_pos, &srcpos));
+          } else {
+            XPR(NT "%" XD3_Q "u: in %s: out %s: total in %s: "
+                   "out %s: %s\n",
+                stream.current_window, main_format_bcnt(this_read, &rdb),
+                main_format_bcnt(this_write, &wdb),
+                main_format_bcnt(stream.total_in, &trdb),
+                main_format_bcnt(stream.total_out, &twdb),
+                main_format_millis(millis, &tm));
+          }
+        }
+      }
+      goto again;
+    }
+
+    default:
+      /* input_func() error */
+      XPR(NT XD3_LIB_ERRMSG(&stream, ret));
+      if (!option_quiet && ret == XD3_INVALID_INPUT && sfile != NULL &&
+          sfile->filename != NULL) {
+        XPR(NT "normally this indicates that the source file is "
+               "incorrect\n");
+        XPR(NT "please verify the source file with sha1sum or "
+               "equivalent\n");
+      }
+      return EXIT_FAILURE;
+    }
+  } while (nread == config.winsize);
+done:
+  /* Close the inputs. (ifile must be open, sfile may be open) */
+  main_file_close(ifile);
+  if (sfile != NULL) {
+    main_file_close(sfile);
+  }
+
+#if VCDIFF_TOOLS
+  if (cmd == CMD_MERGE && (ret = main_merge_output(&stream, ofile))) {
+    return EXIT_FAILURE;
+  }
+
+  if (cmd == CMD_MERGE_ARG) {
+    xd3_swap_whole_state(&stream.whole_target, &recode_stream->whole_target);
+  }
+#endif /* VCDIFF_TOOLS */
+
+  /* If output file is not open yet because of delayed-open, it means
+   * we never encountered a window in the delta, but it could have had
+   * a VCDIFF header?  TODO: solve this elsewhere.  For now, it prints
+   * "nothing to output" below, but the check doesn't happen in case
+   * of option_no_output.  */
+  if (!option_no_output && ofile != NULL) {
+    if (!stdout_only && !main_file_isopen(ofile)) {
+      XPR(NT "nothing to output: %s\n", ifile->filename);
+      return EXIT_FAILURE;
+    }
+
+    /* Have to close the output before calling
+     * main_external_compression_finish, or else it hangs. */
+    if (main_file_close(ofile) != 0) {
+      return EXIT_FAILURE;
+    }
+  }
+
+#if XD3_ARMOR
+  /* Armor: verify the reconstructed target now that all output has been
+   * produced. */
+  if (armor_target_active) {
+    uint8_t digest[BLAKE3_OUT_LEN];
+    char got[XD3_BLAKE3_HEXBUF];
+
+    armor_target_active = 0;
+    blake3_hasher_finalize(&armor_target_hasher, digest, sizeof(digest));
+    main_armor_hex(digest, got);
+
+    if (strcmp(got, armor_expect_target) != 0) {
+      const char *oname =
+          (ofile != NULL && ofile->filename != NULL) ? ofile->filename : "-";
+      XPR(NT "target BLAKE3 mismatch after apply: %s\n", oname);
+      XPR(NT "  expected %s\n", armor_expect_target);
+      XPR(NT "  actual   %s\n", got);
+      return EXIT_FAILURE;
+    }
+    if (option_verbose) {
+      XPR(NT "armor: target verified\n");
+    }
+  }
+#endif
+
+#if EXTERNAL_COMPRESSION
+  if ((ret = main_external_compression_finish())) {
+    XPR(NT "external compression commands failed\n");
+    return EXIT_FAILURE;
+  }
+#endif
+
+  if ((ret = xd3_close_stream(&stream))) {
+    XPR(NT XD3_LIB_ERRMSG(&stream, ret));
+    return EXIT_FAILURE;
+  }
+
+#if XD3_ENCODER
+  if (option_verbose > 1 && cmd == CMD_ENCODE) {
+    XPR(NT "scanner configuration: %s\n", stream.smatcher.name);
+    XPR(NT "target hash table size: %" XD3_W "u\n", stream.small_hash.size);
+    if (sfile != NULL && sfile->filename != NULL) {
+      XPR(NT "source hash table size: %" XD3_W "u\n", stream.large_hash.size);
+    }
+  }
+
+  if (option_verbose > 2 && cmd == CMD_ENCODE) {
+    XPR(NT "source copies: %" XD3_Q "u (%" XD3_Q "u bytes)\n", stream.n_scpy,
+        stream.l_scpy);
+    XPR(NT "target copies: %" XD3_Q "u (%" XD3_Q "u bytes)\n", stream.n_tcpy,
+        stream.l_tcpy);
+    XPR(NT "adds: %" XD3_Q "u (%" XD3_Q "u bytes)\n", stream.n_add,
+        stream.l_add);
+    XPR(NT "runs: %" XD3_Q "u (%" XD3_Q "u bytes)\n", stream.n_run,
+        stream.l_run);
+  }
+#endif
+
+  xd3_free_stream(&stream);
+
+  if (option_verbose) {
+    shortbuf tm;
+    long end_time = get_millisecs_now();
+    xoff_t nwrite = ofile != NULL ? ofile->nwrite : 0;
+
+    XPR(NT "finished in %s; input %" XD3_Q "u output %" XD3_Q
+           "u bytes (%0.2f%%)\n",
+        main_format_millis(end_time - start_time, &tm), ifile->nread, nwrite,
+        100.0 * nwrite / ifile->nread);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+/* free memory before exit, reset single-use variables. */
+static void main_cleanup(void) {
+  if (appheader_used != NULL && appheader_used != option_appheader) {
+    main_free(appheader_used);
+    appheader_used = NULL;
+  }
+
+  main_buffree(main_bdata);
+  main_bdata = NULL;
+  main_bsize = 0;
+
+  main_lru_cleanup();
+
+  if (recode_stream != NULL) {
+    xd3_free_stream(recode_stream);
+    main_free(recode_stream);
+    recode_stream = NULL;
+  }
+
+  if (merge_stream != NULL) {
+    xd3_free_stream(merge_stream);
+    main_free(merge_stream);
+    merge_stream = NULL;
+  }
+
+  XD3_ASSERT(main_mallocs == 0);
+}
+
+static void setup_environment(int argc, char **argv, int *argc_out,
+                              char ***argv_out, char ***argv_free,
+                              char **env_free) {
+  int n, i, i0;
+  char *p, *v = getenv("XDELTA");
+  if (v == NULL) {
+    (*argc_out) = argc;
+    (*argv_out) = argv;
+    (*argv_free) = NULL;
+    (*env_free) = NULL;
+    return;
+  }
+
+  (*env_free) = (char *)main_malloc((usize_t)strlen(v) + 1);
+  if (*env_free == NULL) {
+    /* Allocation failed; fall back to the unmodified command line. */
+    (*argc_out) = argc;
+    (*argv_out) = argv;
+    (*argv_free) = NULL;
+    return;
+  }
+  strcpy(*env_free, v);
+
+  /* Space needed for extra args, at least # of spaces */
+  n = argc + 1;
+  for (p = *env_free; *p != 0;) {
+    if (*p++ == ' ') {
+      n++;
+    }
+  }
+
+  /* Guard the argv allocation size against integer overflow before
+   * multiplying.  On overflow, discard the parsed environment and fall
+   * back to the unmodified command line. */
+  if (n < 0 || XD3_MUL_SIZE_OVERFLOW(sizeof(char *), (size_t)n + 1)) {
+    main_free1(NULL, *env_free);
+    (*env_free) = NULL;
+    (*argc_out) = argc;
+    (*argv_out) = argv;
+    (*argv_free) = NULL;
+    return;
+  }
+
+  (*argv_free) = (char **)main_malloc(sizeof(char *) * ((size_t)n + 1));
+  if (*argv_free == NULL) {
+    main_free1(NULL, *env_free);
+    (*env_free) = NULL;
+    (*argc_out) = argc;
+    (*argv_out) = argv;
+    (*argv_free) = NULL;
+    return;
+  }
+  (*argv_out) = (*argv_free);
+  (*argv_out)[0] = argv[0];
+  (*argv_out)[n] = NULL;
+
+  i = 1;
+  for (p = *env_free; *p != 0;) {
+    (*argv_out)[i++] = p;
+    while (*p != ' ' && *p != 0) {
+      p++;
+    }
+    while (*p == ' ') {
+      *p++ = 0;
+    }
+  }
+
+  for (i0 = 1; i0 < argc; i0++) {
+    (*argv_out)[i++] = argv[i0];
+  }
+
+  /* Counting spaces is an upper bound, argv stays NULL terminated. */
+  (*argc_out) = i;
+  while (i <= n) {
+    (*argv_out)[i++] = NULL;
+  }
+}
+
+#if PYTHON_MODULE || SWIG_MODULE || NOT_MAIN
+int xd3_main_cmdline(int argc, char **argv)
+#else
+int main(int argc, char **argv)
+#endif
+{
+  static const char *flags =
+      "0123456789acdefhnqvDFGJNORVs:m:B:C:E:I:L:O:M:P:W:A::S::";
+  xd3_cmd cmd;
+  main_file ifile;
+  main_file ofile;
+  main_file sfile;
+  main_merge_list merge_order;
+  main_merge *merge;
+  int my_optind;
+  const char *my_optarg;
+  const char *my_optstr;
+  const char *sfilename;
+  int env_argc;
+  char **env_argv;
+  char **free_argv; /* malloc() in setup_environment() */
+  char *free_value; /* malloc() in setup_environment() */
+  int ret;
+
+#ifdef _WIN32
+  GetStartupInfo(&winStartupInfo);
+  setvbuf(stderr, NULL, _IONBF, 0); /* Do not buffer stderr */
+#endif
+
+  main_file_init(&ifile);
+  main_file_init(&ofile);
+  main_file_init(&sfile);
+  main_merge_list_init(&merge_order);
+
+  reset_defaults();
+
+  free_argv = NULL;
+  free_value = NULL;
+  setup_environment(argc, argv, &env_argc, &env_argv, &free_argv, &free_value);
+  cmd = CMD_NONE;
+  sfilename = NULL;
+  my_optind = 1;
+  argv = env_argv;
+  argc = env_argc;
+  program_name = env_argv[0];
+
+takearg:
+  my_optarg = NULL;
+  my_optstr = argv[my_optind];
+
+  /* This doesn't use getopt() because it makes trouble for -P & python which
+   * reenter main() and thus care about freeing all memory.  I never had much
+   * trust for getopt anyway, it's too opaque.  This implements a fairly
+   * standard non-long-option getopt with support for named operations (e.g.,
+   * "xdelta3 [encode|decode|printhdr...] < in > out"). */
+  if (my_optstr) {
+    if (*my_optstr == '-') {
+      my_optstr += 1;
+    } else if (cmd == CMD_NONE) {
+      goto nonflag;
+    } else {
+      my_optstr = NULL;
+    }
+  }
+  while (my_optstr) {
+    const char *s;
+    my_optarg = NULL;
+    if ((ret = *my_optstr++) == 0) {
+      my_optind += 1;
+      goto takearg;
+    }
+
+    /* Option handling: first check for one ':' following the option in
+     * flags, then check for two.  The syntax allows:
+     *
+     * 1. -Afoo                   defines optarg="foo"
+     * 2. -A foo                  defines optarg="foo"
+     * 3. -A ""                   defines optarg="" (allows empty-string)
+     * 4. -A [EOA or -moreargs]   error (mandatory case)
+     * 5. -A [EOA -moreargs]      defines optarg=NULL (optional case)
+     * 6. -A=foo                  defines optarg="foo"
+     * 7. -A=                     defines optarg="" (mandatory case)
+     * 8. -A=                     defines optarg=NULL (optional case)
+     *
+     * See tests in test_command_line_arguments().
+     */
+    s = strchr(flags, ret);
+    if (s && s[1] && s[1] == ':') {
+      int option = s[2] && s[2] == ':';
+
+      /* Case 1, set optarg to the remaining characters. */
+      my_optarg = my_optstr;
+      my_optstr = "";
+
+      /* Case 2-5 */
+      if (*my_optarg == 0) {
+        /* Condition 4-5 */
+        int have_arg = (my_optind < (argc - 1) && *argv[my_optind + 1] != '-');
+
+        if (!have_arg) {
+          if (!option) {
+            /* Case 4 */
+            XPR(NT "-%c: requires an argument\n", ret);
+            ret = EXIT_FAILURE;
+            goto cleanup;
+          }
+          /* Case 5. */
+          my_optarg = NULL;
+        } else {
+          /* Case 2-3. */
+          my_optarg = argv[++my_optind];
+        }
+      }
+      /* Case 6-8. */
+      else if (*my_optarg == '=') {
+        /* Remove the = in all cases. */
+        my_optarg += 1;
+
+        if (option && *my_optarg == 0) {
+          /* Case 8. */
+          my_optarg = NULL;
+        }
+      }
+    }
+
+    switch (ret) {
+    /* case: if no '-' was found, maybe check for a command name. */
+    nonflag:
+      if (strcmp(my_optstr, "decode") == 0) {
+        cmd = CMD_DECODE;
+      } else if (strcmp(my_optstr, "encode") == 0) {
+#if XD3_ENCODER
+        cmd = CMD_ENCODE;
+#else
+        XPR(NT "encoder support not compiled\n");
+        return EXIT_FAILURE;
+#endif
+      } else if (strcmp(my_optstr, "config") == 0) {
+        cmd = CMD_CONFIG;
+      }
+#if REGRESSION_TEST
+      else if (strcmp(my_optstr, "test") == 0) {
+        cmd = CMD_TEST;
+      }
+#endif
+#if VCDIFF_TOOLS
+      else if (strcmp(my_optstr, "printhdr") == 0) {
+        cmd = CMD_PRINTHDR;
+      } else if (strcmp(my_optstr, "printhdrs") == 0) {
+        cmd = CMD_PRINTHDRS;
+      } else if (strcmp(my_optstr, "printdelta") == 0) {
+        cmd = CMD_PRINTDELTA;
+      } else if (strcmp(my_optstr, "recode") == 0) {
+        cmd = CMD_RECODE;
+      } else if (strcmp(my_optstr, "merge") == 0) {
+        cmd = CMD_MERGE;
+      }
+#endif
+
+      /* If no option was found and still no command, let the default
+       * command be encode.  The remaining args are treated as
+       * filenames. */
+      if (cmd == CMD_NONE) {
+        cmd = CMD_DEFAULT;
+        my_optstr = NULL;
+        break;
+      } else {
+        /* But if we find a command name, continue the getopt loop. */
+        my_optind += 1;
+        goto takearg;
+      }
+
+      /* gzip-like options */
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      option_level = ret - '0';
+      break;
+    case 'f':
+      option_force = 1;
+      break;
+    case 'F':
+#if EXTERNAL_COMPRESSION
+      option_force2 = 1;
+#else
+      XPR(NT "warning: -F option ignored, "
+             "external compression support was not compiled\n");
+      break;
+#endif
+    case 'v':
+      option_verbose += 1;
+      option_quiet = 0;
+      break;
+    case 'q':
+      option_quiet = 1;
+      option_verbose = 0;
+      break;
+    case 'c':
+      option_stdout = 1;
+      break;
+    case 'd':
+      if (cmd == CMD_NONE) {
+        cmd = CMD_DECODE;
+      } else {
+        ret = main_help();
+        goto exit;
+      }
+      break;
+    case 'e':
+#if XD3_ENCODER
+      if (cmd == CMD_NONE) {
+        cmd = CMD_ENCODE;
+      } else {
+        ret = main_help();
+        goto exit;
+      }
+      break;
+#else
+      XPR(NT "encoder support not compiled\n");
+      return EXIT_FAILURE;
+#endif
+
+    case 'n':
+      option_use_checksum = 0;
+      break;
+    case 'a':
+      option_no_armor = 1;
+      break;
+    case 'N':
+      option_no_compress = 1;
+      break;
+    case 'C':
+      option_smatch_config = my_optarg;
+      break;
+    case 'J':
+      option_no_output = 1;
+      break;
+    case 'S':
+      if (my_optarg == NULL) {
+        option_use_secondary = 0;
+        option_secondary = NULL;
+      } else {
+        option_use_secondary = 1;
+        option_secondary = my_optarg;
+      }
+      break;
+    case 'A':
+      if (my_optarg == NULL) {
+        option_use_appheader = 0;
+      } else {
+        option_appheader = (uint8_t *)my_optarg;
+      }
+      break;
+    case 'B': {
+      xoff_t bsize;
+      if ((ret = main_atoux(my_optarg, &bsize, XD3_MINSRCWINSZ, XD3_MAXSRCWINSZ,
+                            'B'))) {
+        goto exit;
+      }
+      option_srcwinsz = bsize;
+      break;
+    }
+    case 'I':
+      if ((ret = main_atou(my_optarg, &option_iopt_size, 0, 0, 'I'))) {
+        goto exit;
+      }
+      break;
+    case 'P':
+      if ((ret = main_atou(my_optarg, &option_sprevsz, 0, 0, 'P'))) {
+        goto exit;
+      }
+      break;
+    case 'W':
+      if ((ret = main_atou(my_optarg, &option_winsize, XD3_ALLOCSIZE,
+                           XD3_HARDMAXWINSIZE, 'W'))) {
+        goto exit;
+      }
+      break;
+    case 'D':
+#if EXTERNAL_COMPRESSION == 0
+      if (option_verbose > 0) {
+        XPR(NT "warning: -D option ignored, "
+               "external compression support was not compiled\n");
+      }
+#else
+      option_decompress_inputs = 0;
+#endif
+      break;
+    case 'R':
+#if EXTERNAL_COMPRESSION == 0
+      if (option_verbose > 0) {
+        XPR(NT "warning: -R option ignored, "
+               "external compression support was not compiled\n");
+      }
+#else
+      option_recompress_outputs = 0;
+#endif
+      break;
+    case 'G':
+#if EXTERNAL_COMPRESSION == 0
+      if (option_verbose > 0) {
+        XPR(NT "warning: -G option ignored, "
+               "external compression support was not compiled\n");
+      }
+#else
+      option_use_comp_level = 0;
+#endif
+      break;
+    case 's':
+      if (sfilename != NULL) {
+        XPR(NT "specify only one source file\n");
+        goto cleanup;
+      }
+
+      sfilename = my_optarg;
+      break;
+    case 'm':
+      if ((merge = (main_merge *)main_malloc(sizeof(main_merge))) == NULL) {
+        goto cleanup;
+      }
+      main_merge_list_push_back(&merge_order, merge);
+      merge->filename = my_optarg;
+      break;
+    case 'V':
+      ret = main_version();
+      goto exit;
+    default:
+      ret = main_help();
+      goto exit;
+    }
+  }
+
+  option_source_filename = sfilename;
+
+  /* In case there were no arguments, set the default command. */
+  if (cmd == CMD_NONE) {
+    cmd = CMD_DEFAULT;
+  }
+
+  argc -= my_optind;
+  argv += my_optind;
+
+  /* There may be up to two more arguments. */
+  if (argc > 2) {
+    XPR(NT "too many filenames: %s ...\n", argv[2]);
+    goto cleanup;
+  }
+
+  ifile.flags = RD_FIRST | RD_MAININPUT;
+  sfile.flags = RD_FIRST;
+  sfile.filename = option_source_filename;
+
+  /* The infile takes the next argument, if there is one.  But if not, infile
+   * is set to stdin. */
+  if (argc > 0) {
+    ifile.filename = argv[0];
+
+    if ((ret = main_file_open(&ifile, ifile.filename, XO_READ))) {
+      goto cleanup;
+    }
+  } else {
+    XSTDIN_XF(&ifile);
+  }
+
+  /* The ofile takes the following argument, if there is one.  But if not, it
+   * is left NULL until the application header is processed.  It will be set
+   * in main_open_output. */
+  if (argc > 1) {
+    /* Check for conflicting arguments. */
+    if (option_stdout && !option_quiet) {
+      XPR(NT "warning: -c option overrides output filename: %s\n", argv[1]);
+    }
+
+    if (!option_stdout) {
+      ofile.filename = argv[1];
+    }
+  }
+
+#if VCDIFF_TOOLS
+#if XD3_ARMOR
+  /* Reset armor merge-chain state once for the whole merge operation (it must
+   * persist across the per-delta main_input calls). */
+  if (cmd == CMD_MERGE) {
+    armor_merge_count = 0;
+    armor_merge_all = 1;
+    armor_merge_broken = 0;
+    armor_merge_have_first_source = 0;
+    armor_merge_have_prev_target = 0;
+    armor_merge_have_last_target = 0;
+  }
+#endif
+  if (cmd == CMD_MERGE && (ret = main_merge_arguments(&merge_order))) {
+    goto cleanup;
+  }
+#endif /* VCDIFF_TOOLS */
+
+  switch (cmd) {
+  case CMD_PRINTHDR:
+  case CMD_PRINTHDRS:
+  case CMD_PRINTDELTA:
+#if XD3_ENCODER
+  case CMD_ENCODE:
+  case CMD_RECODE:
+  case CMD_MERGE:
+#endif
+  case CMD_DECODE:
+    ret = main_input(cmd, &ifile, &ofile, &sfile);
+    break;
+
+#if REGRESSION_TEST
+  case CMD_TEST:
+    main_config();
+    ret = xd3_selftest();
+    break;
+#endif
+
+  case CMD_CONFIG:
+    ret = main_config();
+    break;
+
+  default:
+    ret = main_help();
+    break;
+  }
+
+  if (0) {
+  cleanup:
+    ret = EXIT_FAILURE;
+  exit:
+    (void)0;
+  }
+
+#if EXTERNAL_COMPRESSION
+  main_external_compression_cleanup();
+#endif
+
+  main_file_cleanup(&ifile);
+  main_file_cleanup(&ofile);
+  main_file_cleanup(&sfile);
+
+  while (!main_merge_list_empty(&merge_order)) {
+    merge = main_merge_list_pop_front(&merge_order);
+    main_free(merge);
+  }
+
+  main_free(free_argv);
+  main_free(free_value);
+
+  main_cleanup();
+
+  fflush(stdout);
+  fflush(stderr);
+  return ret;
+}
+
+static int main_help(void) {
+  main_version();
+
+  /* Note: update wiki when command-line features change */
+  XPR(NTR "usage: xdelta3 [command/options] [input [output]]\n");
+  XPR(NTR "make patch:\n");
+  XPR(NTR "\n");
+  XPR(NTR "  xdelta3.exe -e -s old_file new_file delta_file\n");
+  XPR(NTR "\n");
+  XPR(NTR "apply patch:\n");
+  XPR(NTR "\n");
+  XPR(NTR "  xdelta3.exe -d -s old_file delta_file decoded_new_file\n");
+  XPR(NTR "\n");
+  XPR(NTR "special command names:\n");
+  XPR(NTR "    config      prints xdelta3 configuration\n");
+  XPR(NTR "    decode      decompress the input\n");
+  XPR(NTR "    encode      compress the input%s\n",
+      XD3_ENCODER ? "" : " [Not compiled]");
+#if REGRESSION_TEST
+  XPR(NTR "    test        run the builtin tests\n");
+#endif
+#if VCDIFF_TOOLS
+  XPR(NTR "special commands for VCDIFF inputs:\n");
+  XPR(NTR "    printdelta  print information about the entire delta\n");
+  XPR(NTR "    printhdr    print information about the first window\n");
+  XPR(NTR "    printhdrs   print information about all windows\n");
+  XPR(NTR "    recode      encode with new application/secondary settings\n");
+  XPR(NTR "    merge       merge VCDIFF inputs (see below)\n");
+#endif
+  XPR(NTR "merge patches:\n");
+  XPR(NTR "\n");
+  XPR(NTR "  xdelta3 merge -m 1.vcdiff -m 2.vcdiff 3.vcdiff merged.vcdiff\n");
+  XPR(NTR "\n");
+  XPR(NTR "standard options:\n");
+  XPR(NTR "   -0 .. -9     compression level\n");
+  XPR(NTR "   -c           use stdout\n");
+  XPR(NTR "   -d           decompress\n");
+  XPR(NTR "   -e           compress%s\n", XD3_ENCODER ? "" : " [Not compiled]");
+  XPR(NTR "   -f           force (overwrite, ignore trailing garbage)\n");
+#if EXTERNAL_COMPRESSION
+  XPR(NTR "   -F           force the external-compression subprocess\n");
+#endif
+  XPR(NTR "   -h           show help\n");
+  XPR(NTR "   -q           be quiet\n");
+  XPR(NTR "   -v           be verbose (max 2)\n");
+  XPR(NTR "   -V           show version\n");
+
+  XPR(NTR "memory options:\n");
+  XPR(NTR "   -B bytes     source window size\n");
+  XPR(NTR "   -W bytes     input window size\n");
+  XPR(NTR "   -P size      compression duplicates window\n");
+  XPR(NTR "   -I size      instruction buffer size (0 = unlimited)\n");
+
+  XPR(NTR "compression options:\n");
+  XPR(NTR "   -s source    source file to copy from (if any)\n");
+  XPR(NTR "   -S [lzma|djw] enable/disable secondary compression\n");
+  XPR(NTR "   -N           disable small string-matching compression\n");
+  XPR(NTR "   -D           disable external decompression (encode/decode)\n");
+  XPR(NTR "   -R           disable external recompression (decode)\n");
+  XPR(NTR "   -G           omit detected compression level from app-header\n");
+  XPR(NTR
+      "                (encode; emits a legacy header older versions read)\n");
+  XPR(NTR "   -n           disable checksum (encode/decode)\n");
+#if XD3_ARMOR
+  XPR(NTR "   -a           disable armor (whole-file BLAKE3 verification,\n");
+  XPR(NTR "                on by default; requires a seekable source)\n");
+#endif
+  XPR(NTR "   -C           soft config (encode, undocumented)\n");
+  XPR(NTR "   -A [apphead] disable/provide application header (encode)\n");
+  XPR(NTR "   -J           disable output (check/compute only)\n");
+  XPR(NTR "   -m           arguments for \"merge\"\n");
+
+  XPR(NTR "the XDELTA environment variable may contain extra args:\n");
+  XPR(NTR "   XDELTA=\"-s source-x.y.tar.gz\" \\\n");
+  XPR(NTR "   tar --use-compress-program=xdelta3 \\\n");
+  XPR(NTR "       -cf target-x.z.tar.gz.vcdiff target-x.y\n");
+  return EXIT_FAILURE;
+}

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-merge.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-merge.h
@@ -1,0 +1,482 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#ifndef _XDELTA3_MERGE_H_
+#define _XDELTA3_MERGE_H_
+
+int xd3_merge_inputs(xd3_stream *stream, xd3_whole_state *source,
+                     xd3_whole_state *input);
+
+static int xd3_whole_state_init(xd3_stream *stream) {
+  XD3_ASSERT(stream->whole_target.adds == NULL);
+  XD3_ASSERT(stream->whole_target.inst == NULL);
+  XD3_ASSERT(stream->whole_target.wininfo == NULL);
+  XD3_ASSERT(stream->whole_target.length == 0);
+
+  stream->whole_target.adds_alloc = XD3_ALLOCSIZE;
+  stream->whole_target.inst_alloc = XD3_ALLOCSIZE;
+  stream->whole_target.wininfo_alloc = XD3_ALLOCSIZE;
+
+  if ((stream->whole_target.adds = (uint8_t *)xd3_alloc(
+           stream, stream->whole_target.adds_alloc, 1)) == NULL ||
+      (stream->whole_target.inst = (xd3_winst *)xd3_alloc(
+           stream, stream->whole_target.inst_alloc, 1)) == NULL ||
+      (stream->whole_target.wininfo = (xd3_wininfo *)xd3_alloc(
+           stream, stream->whole_target.wininfo_alloc, 1)) == NULL) {
+    return ENOMEM;
+  }
+  return 0;
+}
+
+static void xd3_swap_whole_state(xd3_whole_state *a, xd3_whole_state *b) {
+  xd3_whole_state tmp;
+  XD3_ASSERT(a->inst != NULL && a->adds != NULL);
+  XD3_ASSERT(b->inst != NULL && b->adds != NULL);
+  XD3_ASSERT(b->wininfo != NULL && b->wininfo != NULL);
+  memcpy(&tmp, a, sizeof(xd3_whole_state));
+  memcpy(a, b, sizeof(xd3_whole_state));
+  memcpy(b, &tmp, sizeof(xd3_whole_state));
+}
+
+static int xd3_realloc_buffer(xd3_stream *stream, usize_t current_units,
+                              usize_t unit_size, usize_t new_units,
+                              usize_t *alloc_size, void **alloc_ptr) {
+  usize_t needed;
+  usize_t new_alloc;
+  usize_t cur_size;
+  uint8_t *new_buf;
+
+  needed = (current_units + new_units) * unit_size;
+
+  if (needed <= *alloc_size) {
+    return 0;
+  }
+
+  cur_size = current_units * unit_size;
+  new_alloc = xd3_round_blksize(needed * 2, XD3_ALLOCSIZE);
+
+  if ((new_buf = (uint8_t *)xd3_alloc(stream, new_alloc, 1)) == NULL) {
+    return ENOMEM;
+  }
+
+  if (cur_size != 0) {
+    memcpy(new_buf, *alloc_ptr, cur_size);
+  }
+
+  if (*alloc_ptr != NULL) {
+    xd3_free(stream, *alloc_ptr);
+  }
+
+  *alloc_size = new_alloc;
+  *alloc_ptr = new_buf;
+
+  return 0;
+}
+
+/* allocate one new output instruction */
+static int xd3_whole_alloc_winst(xd3_stream *stream, xd3_winst **winstp) {
+  int ret;
+
+  if ((ret = xd3_realloc_buffer(stream, stream->whole_target.instlen,
+                                sizeof(xd3_winst), 1,
+                                &stream->whole_target.inst_alloc,
+                                (void **)&stream->whole_target.inst))) {
+    return ret;
+  }
+
+  *winstp = &stream->whole_target.inst[stream->whole_target.instlen++];
+
+  return 0;
+}
+
+static int xd3_whole_alloc_adds(xd3_stream *stream, usize_t count) {
+  return xd3_realloc_buffer(stream, stream->whole_target.addslen, 1, count,
+                            &stream->whole_target.adds_alloc,
+                            (void **)&stream->whole_target.adds);
+}
+
+static int xd3_whole_alloc_wininfo(xd3_stream *stream, xd3_wininfo **wininfop) {
+  int ret;
+
+  if ((ret = xd3_realloc_buffer(stream, stream->whole_target.wininfolen,
+                                sizeof(xd3_wininfo), 1,
+                                &stream->whole_target.wininfo_alloc,
+                                (void **)&stream->whole_target.wininfo))) {
+    return ret;
+  }
+
+  *wininfop = &stream->whole_target.wininfo[stream->whole_target.wininfolen++];
+
+  return 0;
+}
+
+static int xd3_whole_append_inst(xd3_stream *stream, xd3_hinst *inst) {
+  int ret;
+  xd3_winst *winst;
+
+  if ((ret = xd3_whole_alloc_winst(stream, &winst))) {
+    return ret;
+  }
+
+  winst->type = inst->type;
+  winst->mode = 0;
+  winst->size = inst->size;
+  winst->position = stream->whole_target.length;
+  stream->whole_target.length += inst->size;
+
+  if (((inst->type == XD3_ADD) || (inst->type == XD3_RUN)) &&
+      (ret = xd3_whole_alloc_adds(stream,
+                                  (inst->type == XD3_RUN ? 1 : inst->size)))) {
+    return ret;
+  }
+
+  switch (inst->type) {
+  case XD3_RUN:
+    winst->addr = stream->whole_target.addslen;
+    stream->whole_target.adds[stream->whole_target.addslen++] =
+        *stream->data_sect.buf++;
+    break;
+
+  case XD3_ADD:
+    winst->addr = stream->whole_target.addslen;
+    memcpy(stream->whole_target.adds + stream->whole_target.addslen,
+           stream->data_sect.buf, inst->size);
+    stream->data_sect.buf += inst->size;
+    stream->whole_target.addslen += inst->size;
+    break;
+
+  default:
+    if (inst->addr < stream->dec_cpylen) {
+      winst->mode = SRCORTGT(stream->dec_win_ind);
+      winst->addr = stream->dec_cpyoff + inst->addr;
+    } else {
+      winst->addr = (stream->dec_winstart + inst->addr - stream->dec_cpylen);
+    }
+    break;
+  }
+
+  return 0;
+}
+
+int xd3_whole_append_window(xd3_stream *stream) {
+  int ret;
+  xd3_wininfo *wininfo;
+
+  if ((ret = xd3_whole_alloc_wininfo(stream, &wininfo))) {
+    return ret;
+  }
+
+  wininfo->length = stream->dec_tgtlen;
+  wininfo->offset = stream->dec_winstart;
+  wininfo->adler32 = stream->dec_adler32;
+
+  while (stream->inst_sect.buf < stream->inst_sect.buf_max) {
+    if ((ret = xd3_decode_instruction(stream))) {
+      return ret;
+    }
+
+    if ((stream->dec_current1.type != XD3_NOOP) &&
+        (ret = xd3_whole_append_inst(stream, &stream->dec_current1))) {
+      return ret;
+    }
+
+    if ((stream->dec_current2.type != XD3_NOOP) &&
+        (ret = xd3_whole_append_inst(stream, &stream->dec_current2))) {
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+/* xd3_merge_input_output applies *source to *stream, returns the
+ * result in stream. */
+static int xd3_merge_input_output(xd3_stream *stream, xd3_whole_state *source) {
+  int ret;
+  xd3_stream tmp_stream;
+  memset(&tmp_stream, 0, sizeof(tmp_stream));
+  if ((ret = xd3_config_stream(&tmp_stream, NULL)) ||
+      (ret = xd3_whole_state_init(&tmp_stream)) ||
+      (ret = xd3_merge_inputs(&tmp_stream, source, &stream->whole_target))) {
+    XPR(NT XD3_LIB_ERRMSG(&tmp_stream, ret));
+    return ret;
+  }
+
+  /* the output is in tmp_stream.whole_state, swap into input */
+  xd3_swap_whole_state(&stream->whole_target, &tmp_stream.whole_target);
+  /* total allocation counts are preserved */
+  xd3_free_stream(&tmp_stream);
+  return 0;
+}
+
+static int xd3_merge_run(xd3_stream *stream, xd3_whole_state *target,
+                         xd3_winst *iinst) {
+  int ret;
+  xd3_winst *oinst;
+
+  if ((ret = xd3_whole_alloc_winst(stream, &oinst)) ||
+      (ret = xd3_whole_alloc_adds(stream, 1))) {
+    return ret;
+  }
+
+  oinst->type = iinst->type;
+  oinst->mode = iinst->mode;
+  oinst->size = iinst->size;
+  oinst->addr = stream->whole_target.addslen;
+
+  XD3_ASSERT(stream->whole_target.length == iinst->position);
+  oinst->position = stream->whole_target.length;
+  stream->whole_target.length += iinst->size;
+
+  stream->whole_target.adds[stream->whole_target.addslen++] =
+      target->adds[iinst->addr];
+
+  return 0;
+}
+
+static int xd3_merge_add(xd3_stream *stream, xd3_whole_state *target,
+                         xd3_winst *iinst) {
+  int ret;
+  xd3_winst *oinst;
+
+  if ((ret = xd3_whole_alloc_winst(stream, &oinst)) ||
+      (ret = xd3_whole_alloc_adds(stream, iinst->size))) {
+    return ret;
+  }
+
+  oinst->type = iinst->type;
+  oinst->mode = iinst->mode;
+  oinst->size = iinst->size;
+  oinst->addr = stream->whole_target.addslen;
+
+  XD3_ASSERT(stream->whole_target.length == iinst->position);
+  oinst->position = stream->whole_target.length;
+  stream->whole_target.length += iinst->size;
+
+  memcpy(stream->whole_target.adds + stream->whole_target.addslen,
+         target->adds + iinst->addr, iinst->size);
+
+  stream->whole_target.addslen += iinst->size;
+
+  return 0;
+}
+
+static int xd3_merge_target_copy(xd3_stream *stream, xd3_winst *iinst) {
+  int ret;
+  xd3_winst *oinst;
+
+  if ((ret = xd3_whole_alloc_winst(stream, &oinst))) {
+    return ret;
+  }
+
+  XD3_ASSERT(stream->whole_target.length == iinst->position);
+
+  memcpy(oinst, iinst, sizeof(*oinst));
+  return 0;
+}
+
+static int xd3_merge_find_position(xd3_stream *stream, xd3_whole_state *source,
+                                   xoff_t address, usize_t *inst_num) {
+  usize_t low;
+  usize_t high;
+
+  if (address >= source->length) {
+    stream->msg = "Invalid copy offset in merge";
+    return XD3_INVALID_INPUT;
+  }
+
+  low = 0;
+  high = source->instlen;
+
+  while (low != high) {
+    xoff_t mid_lpos;
+    xoff_t mid_hpos;
+    usize_t mid = low + (high - low) / 2;
+    mid_lpos = source->inst[mid].position;
+
+    if (address < mid_lpos) {
+      high = mid;
+      continue;
+    }
+
+    mid_hpos = mid_lpos + source->inst[mid].size;
+
+    if (address >= mid_hpos) {
+      low = mid + 1;
+      continue;
+    }
+
+    *inst_num = mid;
+    return 0;
+  }
+
+  stream->msg = "Internal error in merge";
+  return XD3_INTERNAL;
+}
+
+static int xd3_merge_source_copy(xd3_stream *stream, xd3_whole_state *source,
+                                 const xd3_winst *iinst_orig) {
+  int ret;
+  xd3_winst iinst;
+  usize_t sinst_num;
+
+  memcpy(&iinst, iinst_orig, sizeof(iinst));
+
+  XD3_ASSERT(iinst.mode == VCD_SOURCE);
+
+  if ((ret = xd3_merge_find_position(stream, source, iinst.addr, &sinst_num))) {
+    return ret;
+  }
+
+  while (iinst.size > 0) {
+    xd3_winst *sinst;
+    xd3_winst *minst;
+    usize_t sinst_offset;
+    usize_t sinst_left;
+    usize_t this_take;
+
+    XD3_ASSERT(sinst_num < source->instlen);
+
+    sinst = &source->inst[sinst_num];
+
+    XD3_ASSERT(iinst.addr >= sinst->position);
+
+    sinst_offset = (usize_t)(iinst.addr - sinst->position);
+
+    XD3_ASSERT(sinst->size > sinst_offset);
+
+    sinst_left = sinst->size - sinst_offset;
+    this_take = xd3_min(iinst.size, sinst_left);
+
+    XD3_ASSERT(this_take > 0);
+
+    if ((ret = xd3_whole_alloc_winst(stream, &minst))) {
+      return ret;
+    }
+
+    minst->size = this_take;
+    minst->type = sinst->type;
+    minst->position = iinst.position;
+    minst->mode = 0;
+
+    switch (sinst->type) {
+    case XD3_RUN:
+      if ((ret = xd3_whole_alloc_adds(stream, 1))) {
+        return ret;
+      }
+
+      minst->addr = stream->whole_target.addslen;
+      stream->whole_target.adds[stream->whole_target.addslen++] =
+          source->adds[sinst->addr];
+      break;
+    case XD3_ADD:
+      if ((ret = xd3_whole_alloc_adds(stream, this_take))) {
+        return ret;
+      }
+
+      minst->addr = stream->whole_target.addslen;
+      memcpy(stream->whole_target.adds + stream->whole_target.addslen,
+             source->adds + sinst->addr + sinst_offset, this_take);
+      stream->whole_target.addslen += this_take;
+      break;
+    default:
+      if (sinst->mode != 0) {
+        minst->mode = sinst->mode;
+        minst->addr = sinst->addr + sinst_offset;
+      } else {
+        // Note: A better implementation will construct the
+        // mapping of output ranges, starting from the input
+        // range, applying deltas in forward order, using an
+        // interval tree.  This code uses recursion to construct
+        // each copied range, recursively (using binary search
+        // in xd3_merge_find_position).
+        //
+        // TODO: This code can cause stack overflow. Fix as
+        // described above.
+        xd3_winst tinst;
+        tinst.type = XD3_CPY;
+        tinst.mode = iinst.mode;
+        tinst.addr = sinst->addr + sinst_offset;
+        tinst.size = this_take;
+        tinst.position = iinst.position;
+
+        // The instruction allocated in this frame will not be used.
+        stream->whole_target.instlen -= 1;
+
+        if ((ret = xd3_merge_source_copy(stream, source, &tinst))) {
+          return ret;
+        }
+      }
+      break;
+    }
+
+    iinst.position += this_take;
+    iinst.addr += this_take;
+    iinst.size -= this_take;
+    sinst_num += 1;
+  }
+
+  return 0;
+}
+
+/* xd3_merge_inputs() applies *input to *source, returns its result in
+ * stream. */
+int xd3_merge_inputs(xd3_stream *stream, xd3_whole_state *source,
+                     xd3_whole_state *input) {
+  int ret = 0;
+  usize_t i;
+  size_t input_i;
+
+  for (i = 0; i < input->wininfolen; ++i) {
+    xd3_wininfo *copyinfo;
+
+    if ((ret = xd3_whole_alloc_wininfo(stream, &copyinfo))) {
+      return ret;
+    }
+
+    *copyinfo = input->wininfo[i];
+  }
+
+  /* iterate over each instruction. */
+  for (input_i = 0; ret == 0 && input_i < input->instlen; ++input_i) {
+    xd3_winst *iinst = &input->inst[input_i];
+
+    switch (iinst->type) {
+    case XD3_RUN:
+      ret = xd3_merge_run(stream, input, iinst);
+      break;
+    case XD3_ADD:
+      ret = xd3_merge_add(stream, input, iinst);
+      break;
+    default:
+      if (iinst->mode == 0) {
+        ret = xd3_merge_target_copy(stream, iinst);
+      } else if (iinst->mode == VCD_TARGET) {
+        ret = XD3_INVALID_INPUT;
+      } else {
+        ret = xd3_merge_source_copy(stream, source, iinst);
+      }
+
+      /* The whole_target.length is not updated in the xd3_merge*copy
+       * routine because of recursion in xd3_merge_source_copy. */
+      stream->whole_target.length += iinst->size;
+      break;
+    }
+  }
+
+  return ret;
+}
+
+#endif

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-second.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-second.h
@@ -1,0 +1,274 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#ifndef _XDELTA3_SECOND_H_
+#define _XDELTA3_SECOND_H_
+
+static inline void xd3_bit_state_encode_init(bit_state *bits) {
+  bits->cur_byte = 0;
+  bits->cur_mask = 1;
+}
+
+static inline int xd3_decode_bits(xd3_stream *stream, bit_state *bits,
+                                  const uint8_t **input,
+                                  const uint8_t *input_max, usize_t nbits,
+                                  usize_t *valuep) {
+  usize_t value = 0;
+  usize_t vmask = (usize_t)1 << nbits;
+
+  if (bits->cur_mask == 0x100) {
+    goto next_byte;
+  }
+
+  for (;;) {
+    do {
+      vmask >>= 1;
+
+      if (bits->cur_byte & bits->cur_mask) {
+        value |= vmask;
+      }
+
+      bits->cur_mask <<= 1;
+
+      if (vmask == 1) {
+        goto done;
+      }
+    } while (bits->cur_mask != 0x100);
+
+  next_byte:
+
+    if (*input == input_max) {
+      stream->msg = "secondary decoder end of input";
+      return XD3_INTERNAL;
+    }
+
+    bits->cur_byte = *(*input)++;
+    bits->cur_mask = 1;
+  }
+
+done:
+
+  IF_DEBUG2(DP(RINT "(d) %" XD3_W "u ", value));
+
+  (*valuep) = value;
+  return 0;
+}
+
+#if REGRESSION_TEST
+/* There may be extra bits at the end of secondary decompression, this macro
+ * checks for non-zero bits.  This is overly strict, but helps pass the
+ * single-bit-error regression test. */
+static int xd3_test_clean_bits(xd3_stream *stream, bit_state *bits) {
+  for (; bits->cur_mask != 0x100; bits->cur_mask <<= 1) {
+    if (bits->cur_byte & bits->cur_mask) {
+      stream->msg = "secondary decoder garbage";
+      return XD3_INTERNAL;
+    }
+  }
+
+  return 0;
+}
+#endif
+
+static int xd3_get_secondary(xd3_stream *stream, xd3_sec_stream **sec_streamp,
+                             int is_encode) {
+  if (*sec_streamp == NULL) {
+    int ret;
+
+    if ((*sec_streamp = stream->sec_type->alloc(stream)) == NULL) {
+      stream->msg = "error initializing secondary stream";
+      return XD3_INVALID;
+    }
+
+    if ((ret = stream->sec_type->init(stream, *sec_streamp, is_encode)) != 0) {
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+static int xd3_decode_secondary(xd3_stream *stream, xd3_desect *sect,
+                                xd3_sec_stream **sec_streamp) {
+  usize_t dec_size;
+  uint8_t *out_used;
+  int ret;
+
+  if ((ret = xd3_get_secondary(stream, sec_streamp, 0)) != 0) {
+    return ret;
+  }
+
+  /* Decode the size, allocate the buffer. */
+  if ((ret = xd3_read_size(stream, &sect->buf, sect->buf_max, &dec_size)) ||
+      (ret = xd3_decode_allocate(stream, dec_size, &sect->copied2,
+                                 &sect->alloc2))) {
+    return ret;
+  }
+
+  if (dec_size == 0) {
+    stream->msg = "secondary decoder invalid output size";
+    return XD3_INVALID_INPUT;
+  }
+
+  out_used = sect->copied2;
+
+  if ((ret = stream->sec_type->decode(stream, *sec_streamp, &sect->buf,
+                                      sect->buf_max, &out_used,
+                                      out_used + dec_size))) {
+    return ret;
+  }
+
+  if (sect->buf != sect->buf_max) {
+    stream->msg = "secondary decoder finished with unused input";
+    return XD3_INTERNAL;
+  }
+
+  if (out_used != sect->copied2 + dec_size) {
+    stream->msg = "secondary decoder short output";
+    return XD3_INTERNAL;
+  }
+
+  sect->buf = sect->copied2;
+  sect->buf_max = sect->copied2 + dec_size;
+  sect->size = dec_size;
+
+  return 0;
+}
+
+#if XD3_ENCODER
+static inline int xd3_encode_bit(xd3_stream *stream, xd3_output **output,
+                                 bit_state *bits, usize_t bit) {
+  int ret;
+
+  if (bit) {
+    bits->cur_byte |= bits->cur_mask;
+  }
+
+  /* OPT: Might help to buffer more than 8 bits at once. */
+  if (bits->cur_mask == 0x80) {
+    if ((ret = xd3_emit_byte(stream, output, bits->cur_byte)) != 0) {
+      return ret;
+    }
+
+    bits->cur_mask = 1;
+    bits->cur_byte = 0;
+  } else {
+    bits->cur_mask <<= 1;
+  }
+
+  return 0;
+}
+
+static inline int xd3_flush_bits(xd3_stream *stream, xd3_output **output,
+                                 bit_state *bits) {
+  return (bits->cur_mask == 1) ? 0
+                               : xd3_emit_byte(stream, output, bits->cur_byte);
+}
+
+static inline int xd3_encode_bits(xd3_stream *stream, xd3_output **output,
+                                  bit_state *bits, usize_t nbits,
+                                  usize_t value) {
+  int ret;
+  usize_t mask = (usize_t)1 << nbits;
+
+  XD3_ASSERT(nbits > 0);
+  XD3_ASSERT(nbits < sizeof(usize_t) * 8);
+  XD3_ASSERT(value < mask);
+
+  do {
+    mask >>= 1;
+
+    if ((ret = xd3_encode_bit(stream, output, bits, value & mask))) {
+      return ret;
+    }
+  } while (mask != 1);
+
+  IF_DEBUG2(DP(RINT "(e) %" XD3_W "u ", value));
+
+  return 0;
+}
+
+static int xd3_encode_secondary(xd3_stream *stream, xd3_output **head,
+                                xd3_output **tail, xd3_sec_stream **sec_streamp,
+                                xd3_sec_cfg *cfg, int *did_it) {
+  xd3_output *tmp_head;
+  xd3_output *tmp_tail;
+
+  usize_t comp_size;
+  usize_t orig_size;
+
+  int ret;
+
+  orig_size = xd3_sizeof_output(*head);
+
+  if (orig_size < SECONDARY_MIN_INPUT) {
+    return 0;
+  }
+
+  if ((ret = xd3_get_secondary(stream, sec_streamp, 1)) != 0) {
+    return ret;
+  }
+
+  tmp_head = xd3_alloc_output(stream, NULL);
+
+  /* Encode the size, encode the data.  Encoding the size makes it
+   * simpler, but is a little gross.  Should not need the entire
+   * section in contiguous memory, but it is much easier this way. */
+  if ((ret = xd3_emit_size(stream, &tmp_head, orig_size)) ||
+      (ret = stream->sec_type->encode(stream, *sec_streamp, *head, tmp_head,
+                                      cfg))) {
+    goto getout;
+  }
+
+  /* If the secondary compressor determines it's no good, it returns
+   * XD3_NOSECOND. */
+
+  /* Setup tmp_tail, comp_size */
+  tmp_tail = tmp_head;
+  comp_size = tmp_head->next;
+
+  while (tmp_tail->next_page != NULL) {
+    tmp_tail = tmp_tail->next_page;
+    comp_size += tmp_tail->next;
+  }
+
+  XD3_ASSERT(comp_size == xd3_sizeof_output(tmp_head));
+  XD3_ASSERT(tmp_tail != NULL);
+
+  if (comp_size < (orig_size - SECONDARY_MIN_SAVINGS) || cfg->inefficient) {
+    if (comp_size < orig_size) {
+      IF_DEBUG1(DP(RINT "[encode_secondary] saved %" XD3_W "u bytes: %" XD3_W
+                        "u -> %" XD3_W "u (%0.2f%%)\n",
+                   orig_size - comp_size, orig_size, comp_size,
+                   100.0 * (double)comp_size / (double)orig_size));
+    }
+
+    xd3_free_output(stream, *head);
+
+    *head = tmp_head;
+    *tail = tmp_tail;
+    *did_it = 1;
+  } else {
+  getout:
+    if (ret == XD3_NOSECOND) {
+      ret = 0;
+    }
+    xd3_free_output(stream, tmp_head);
+  }
+
+  return ret;
+}
+#endif /* XD3_ENCODER */
+#endif /* _XDELTA3_SECOND_H_ */

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-test.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3-test.h
@@ -1,0 +1,3502 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+static const uint32_t TEST_SEED1 = 5489UL;
+#define MT_LEN 624
+#define MT_IA 397
+static const uint32_t UPPER_MASK = 0x80000000;
+static const uint32_t LOWER_MASK = 0x7FFFFFFF;
+static const uint32_t MATRIX_A = 0x9908B0DF;
+
+#ifndef SHELL_TESTS
+#define SHELL_TESTS 1
+#endif
+
+typedef struct mtrand mtrand;
+
+struct mtrand {
+  int mt_index_;
+  uint32_t mt_buffer_[MT_LEN];
+};
+
+int test_compare_files(const char *tgt, const char *rec);
+void mt_init(mtrand *mt, uint32_t seed);
+uint32_t mt_random(mtrand *mt);
+int test_setup(void);
+
+/* The Mersenne Twister code used herein is code to Michael Brundage.  Thanks!
+ * http://www.qbrundage.com/michaelb/pubs/essays/random_number_generation.html
+ */
+void mt_init(mtrand *mt, uint32_t seed) {
+  int i;
+  mt->mt_buffer_[0] = seed;
+  mt->mt_index_ = MT_LEN;
+  for (i = 1; i < MT_LEN; i++) {
+    /* See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier. */
+    /* In the previous versions, MSBs of the seed affect   */
+    /* only MSBs of the array mt[].                        */
+    /* 2002/01/09 modified by Makoto Matsumoto             */
+    mt->mt_buffer_[i] = (1812433253UL * (mt->mt_buffer_[i - 1] ^
+                                         (mt->mt_buffer_[i - 1] >> 30)) +
+                         i);
+  }
+}
+
+uint32_t mt_random(mtrand *mt) {
+  uint32_t y;
+  unsigned long mag01[2];
+  mag01[0] = 0;
+  mag01[1] = MATRIX_A;
+
+  if (mt->mt_index_ >= MT_LEN) {
+    int kk;
+
+    for (kk = 0; kk < MT_LEN - MT_IA; kk++) {
+      y = (mt->mt_buffer_[kk] & UPPER_MASK) |
+          (mt->mt_buffer_[kk + 1] & LOWER_MASK);
+      mt->mt_buffer_[kk] =
+          mt->mt_buffer_[kk + MT_IA] ^ (y >> 1) ^ mag01[y & 0x1UL];
+    }
+    for (; kk < MT_LEN - 1; kk++) {
+      y = (mt->mt_buffer_[kk] & UPPER_MASK) |
+          (mt->mt_buffer_[kk + 1] & LOWER_MASK);
+      mt->mt_buffer_[kk] =
+          mt->mt_buffer_[kk + (MT_IA - MT_LEN)] ^ (y >> 1) ^ mag01[y & 0x1UL];
+    }
+    y = (mt->mt_buffer_[MT_LEN - 1] & UPPER_MASK) |
+        (mt->mt_buffer_[0] & LOWER_MASK);
+    mt->mt_buffer_[MT_LEN - 1] =
+        mt->mt_buffer_[MT_IA - 1] ^ (y >> 1) ^ mag01[y & 0x1UL];
+    mt->mt_index_ = 0;
+  }
+
+  y = mt->mt_buffer_[mt->mt_index_++];
+
+  y ^= (y >> 11);
+  y ^= (y << 7) & 0x9d2c5680UL;
+  y ^= (y << 15) & 0xefc60000UL;
+  y ^= (y >> 18);
+
+  return y;
+}
+
+static mtrand static_mtrand;
+
+#include <math.h>
+
+static uint32_t mt_exp_rand(uint32_t mean, uint32_t max_value) {
+  double mean_d = mean;
+  double erand = log(1.0 / (mt_random(&static_mtrand) / (double)UINT32_MAX));
+  uint32_t x = (uint32_t)(mean_d * erand + 0.5);
+
+  return xd3_min(x, max_value);
+}
+
+#if SHELL_TESTS
+#include <sys/wait.h>
+#endif
+
+#if XD3_WIN32
+#include <process.h> /* for _getpid */
+#define xd3_test_getpid _getpid
+#else
+#define xd3_test_getpid getpid
+#endif
+
+/* Directory for the test harness's scratch files.  Honors the platform's
+ * temp-directory environment variables, falling back to /tmp on POSIX and
+ * the current directory on Windows. */
+static const char *test_tmpdir(void) {
+  const char *t;
+#if XD3_WIN32
+  if ((t = getenv("TEMP")) != NULL)
+    return t;
+  if ((t = getenv("TMP")) != NULL)
+    return t;
+  return ".";
+#else
+  if ((t = getenv("TMPDIR")) != NULL)
+    return t;
+  return "/tmp";
+#endif
+}
+
+#define MSG_IS(x) (stream->msg != NULL && strcmp((x), stream->msg) == 0)
+
+static const usize_t TWO_MEGS_AND_DELTA = (3 << 20);
+static const usize_t ADDR_CACHE_ROUNDS = 10000;
+
+static const usize_t TEST_FILE_MEAN = 16384;
+static const double TEST_ADD_MEAN = 128;
+static const double TEST_ADD_MAX = 512;
+static const double TEST_ADD_RATIO = 0.1;
+static const double TEST_EPSILON = 0.25;
+
+#define TESTBUFSIZE (1024 * 16)
+
+#define TESTFILESIZE (1024)
+
+static char TEST_TARGET_FILE[TESTFILESIZE];
+static char TEST_SOURCE_FILE[TESTFILESIZE];
+static char TEST_DELTA_FILE[TESTFILESIZE];
+static char TEST_RECON_FILE[TESTFILESIZE];
+static char TEST_RECON2_FILE[TESTFILESIZE];
+static char TEST_COPY_FILE[TESTFILESIZE];
+static char TEST_NOPERM_FILE[TESTFILESIZE];
+
+#define CHECK(cond)                                                            \
+  if (!(cond)) {                                                               \
+    XPR(NT __FILE__ ":%d: check failure: " #cond, __LINE__);                   \
+    abort();                                                                   \
+  }
+
+#if SHELL_TESTS
+/* Use a fixed soft config so that test values are fixed.  See also
+ * test_compress_text(). */
+static const char *test_softcfg_str = "-C9,3,4,8,2,36,70";
+#endif
+
+/***********************************************************************
+ TEST HELPERS
+ ***********************************************************************/
+
+static void DOT(void) { XPR(NTR "."); }
+static int do_cmd(xd3_stream *stream, const char *buf) {
+  int ret;
+  if ((ret = system(buf)) != 0) {
+    if (WIFEXITED(ret)) {
+      stream->msg = "command exited non-zero";
+      IF_DEBUG1(XPR(NT "command was: %s\n", buf));
+    } else {
+      stream->msg = "abnormal command termination";
+    }
+    return ret;
+  }
+  return 0;
+}
+
+static int do_fail(xd3_stream *stream, const char *buf) {
+  int ret;
+  ret = system(buf);
+  if (!WIFEXITED(ret) || WEXITSTATUS(ret) != 1) {
+    stream->msg = "command should have not succeeded";
+    XPR(NT "command was %s\n", buf);
+    return XD3_INTERNAL;
+  }
+  return 0;
+}
+
+/* Test that the exponential distribution actually produces its mean. */
+static int test_random_numbers(xd3_stream *stream, int ignore) {
+  usize_t i;
+  usize_t sum = 0;
+  usize_t mean = 50;
+  usize_t n_rounds = 1000000;
+  double average, error;
+  double allowed_error = 0.1;
+
+  mt_init(&static_mtrand, 0x9f73f7fe);
+
+  for (i = 0; i < n_rounds; i += 1) {
+    sum += mt_exp_rand((uint32_t)mean, UINT32_MAX);
+  }
+
+  average = (double)sum / (double)n_rounds;
+  error = average - (double)mean;
+
+  if (error < allowed_error && error > -allowed_error) {
+    return 0;
+  }
+
+  /*XPR(NT "error is %f\n", error);*/
+  stream->msg = "random distribution looks broken";
+  return XD3_INTERNAL;
+}
+
+static int test_printf_xoff(xd3_stream *stream, int ignore) {
+  char buf[64];
+  xoff_t x = XOFF_T_MAX;
+  snprintf_func(buf, sizeof(buf), "%" XD3_Q "u", x);
+  const char *expect =
+      XD3_USE_LARGEFILE64 ? "18446744073709551615" : "4294967295";
+  if (strcmp(buf, expect) == 0) {
+    return 0;
+  }
+  return XD3_INTERNAL;
+}
+
+static void test_unlink(char *file) {
+  int ret;
+  if (file != NULL && *file != 0 && (ret = unlink(file)) != 0 &&
+      errno != ENOENT) {
+    XPR(NT "unlink %s failed: %s\n", file, strerror(ret));
+  }
+}
+
+static void test_cleanup(void) {
+#if 1
+  test_unlink(TEST_TARGET_FILE);
+  test_unlink(TEST_SOURCE_FILE);
+  test_unlink(TEST_DELTA_FILE);
+  test_unlink(TEST_RECON_FILE);
+  test_unlink(TEST_RECON2_FILE);
+  test_unlink(TEST_COPY_FILE);
+  test_unlink(TEST_NOPERM_FILE);
+#endif
+}
+
+int test_setup(void) {
+  static int x = 0;
+  int pid = (int)xd3_test_getpid();
+  const char *tmp = test_tmpdir();
+  x++;
+
+  test_cleanup();
+
+  snprintf_func(TEST_TARGET_FILE, TESTFILESIZE, "%s/xdtest.%d.target.%d", tmp,
+                pid, x);
+  snprintf_func(TEST_SOURCE_FILE, TESTFILESIZE, "%s/xdtest.%d.source.%d", tmp,
+                pid, x);
+  snprintf_func(TEST_DELTA_FILE, TESTFILESIZE, "%s/xdtest.%d.delta.%d", tmp,
+                pid, x);
+  snprintf_func(TEST_RECON_FILE, TESTFILESIZE, "%s/xdtest.%d.recon.%d", tmp,
+                pid, x);
+  snprintf_func(TEST_RECON2_FILE, TESTFILESIZE, "%s/xdtest.%d.recon2.%d", tmp,
+                pid, x);
+  snprintf_func(TEST_COPY_FILE, TESTFILESIZE, "%s/xdtest.%d.copy.%d", tmp, pid,
+                x);
+  snprintf_func(TEST_NOPERM_FILE, TESTFILESIZE, "%s/xdtest.%d.noperm.%d", tmp,
+                pid, x);
+
+  test_cleanup();
+  return 0;
+}
+
+static int test_make_inputs(xd3_stream *stream, xoff_t *ss_out,
+                            xoff_t *ts_out) {
+  usize_t ts =
+      (mt_random(&static_mtrand) % TEST_FILE_MEAN) + TEST_FILE_MEAN / 2;
+  usize_t ss =
+      (mt_random(&static_mtrand) % TEST_FILE_MEAN) + TEST_FILE_MEAN / 2;
+  uint8_t *buf = (uint8_t *)malloc(ts + ss), *sbuf = buf, *tbuf = buf + ss;
+  usize_t sadd = 0, sadd_max = (usize_t)(ss * TEST_ADD_RATIO);
+  FILE *tf = NULL, *sf = NULL;
+  usize_t i, j;
+  int ret;
+
+  if (buf == NULL) {
+    return ENOMEM;
+  }
+
+  if ((tf = fopen(TEST_TARGET_FILE, "w")) == NULL ||
+      (ss_out != NULL && (sf = fopen(TEST_SOURCE_FILE, "w")) == NULL)) {
+    stream->msg = "write failed";
+    ret = get_errno();
+    goto failure;
+  }
+
+  if (ss_out != NULL) {
+    for (i = 0; i < ss;) {
+      sbuf[i++] = (uint8_t)mt_random(&static_mtrand);
+    }
+  }
+
+  /* Then modify the data to produce copies, everything not copied is
+   * an add.  The following logic produces the TEST_ADD_RATIO.  The
+   * variable SADD contains the number of adds so far, which should
+   * not exceed SADD_MAX. */
+
+  /* XPR(NT "ss = %u ts = %u\n", ss, ts); */
+  for (i = 0; i < ts;) {
+    usize_t left = ts - i;
+    usize_t next = mt_exp_rand((uint32_t)TEST_ADD_MEAN, (uint32_t)TEST_ADD_MAX);
+    usize_t add_left = sadd_max - sadd;
+    double add_prob = (left == 0) ? 0 : (add_left / (double)left);
+    int do_copy;
+
+    next = xd3_min(left, next);
+    do_copy = (next > add_left ||
+               (mt_random(&static_mtrand) / (double)USIZE_T_MAX) >= add_prob);
+
+    if (ss_out == NULL) {
+      do_copy &= (i > 0);
+    } else {
+      do_copy &= (ss - next) > 0;
+    }
+
+    if (do_copy) {
+      /* Copy */
+      size_t offset =
+          mt_random(&static_mtrand) % ((ss_out == NULL) ? i : (ss - next));
+      /* XPR(NT "[%u] copy %u at %u ", i, next, offset); */
+
+      for (j = 0; j < next; j += 1) {
+        char c = ((ss_out == NULL) ? tbuf : sbuf)[offset + j];
+        /* XPR(NT "%x%x", (c >> 4) & 0xf, c & 0xf); */
+        tbuf[i++] = c;
+      }
+      /* XPR(NT "\n"); */
+    } else {
+      /* Add */
+      /* XPR(NT "[%u] add %u ", i, next); */
+      for (j = 0; j < next; j += 1) {
+        char c = (char)mt_random(&static_mtrand);
+        /* XPR(NT "%x%x", (c >> 4) & 0xf, c & 0xf); */
+        tbuf[i++] = c;
+      }
+      /* XPR(NT "\n"); */
+      sadd += next;
+    }
+  }
+
+  /* XPR(NT "sadd = %u max = %u\n", sadd, sadd_max); */
+
+  if ((fwrite(tbuf, 1, ts, tf) != ts) ||
+      (ss_out != NULL && (fwrite(sbuf, 1, ss, sf) != ss))) {
+    stream->msg = "write failed";
+    ret = get_errno();
+    goto failure;
+  }
+
+  if ((ret = fclose(tf)) || (ss_out != NULL && (ret = fclose(sf)))) {
+    stream->msg = "close failed";
+    ret = get_errno();
+    goto failure;
+  }
+
+  if (ts_out) {
+    (*ts_out) = ts;
+  }
+  if (ss_out) {
+    (*ss_out) = ss;
+  }
+
+failure:
+  free(buf);
+  return ret;
+}
+
+int test_compare_files(const char *tgt, const char *rec) {
+  FILE *orig, *recons;
+  static uint8_t obuf[TESTBUFSIZE], rbuf[TESTBUFSIZE];
+  xoff_t offset = 0;
+  size_t i;
+  size_t oc, rc;
+  xoff_t diffs = 0;
+
+  if ((orig = fopen(tgt, "r")) == NULL) {
+    XPR(NT "open %s failed\n", tgt);
+    return get_errno();
+  }
+
+  if ((recons = fopen(rec, "r")) == NULL) {
+    XPR(NT "open %s failed\n", rec);
+    return get_errno();
+  }
+
+  for (;;) {
+    oc = fread(obuf, 1, TESTBUFSIZE, orig);
+    rc = fread(rbuf, 1, TESTBUFSIZE, recons);
+
+    if (oc != rc) {
+      return XD3_INTERNAL;
+    }
+
+    if (oc == 0) {
+      break;
+    }
+
+    for (i = 0; i < oc; i += 1) {
+      if (obuf[i] != rbuf[i]) {
+        XPR(NT "byte %u (read %u @ %" XD3_Q "u) %d != %d\n", (int)i, (int)oc,
+            offset, obuf[i], rbuf[i]);
+        diffs++;
+        return XD3_INTERNAL;
+      }
+    }
+
+    offset += oc;
+  }
+
+  fclose(orig);
+  fclose(recons);
+  if (diffs != 0) {
+    return XD3_INTERNAL;
+  }
+  return 0;
+}
+
+static int test_copy_to(const char *from, const char *to) {
+  char buf[TESTBUFSIZE];
+  int ret;
+
+  snprintf_func(buf, TESTBUFSIZE, "cp -f %s %s", from, to);
+
+  if ((ret = system(buf)) != 0) {
+    return XD3_INTERNAL;
+  }
+
+  return 0;
+}
+
+static int test_save_copy(const char *origname) {
+  return test_copy_to(origname, TEST_COPY_FILE);
+}
+
+static int test_file_size(const char *file, xoff_t *size) {
+  struct stat sbuf;
+  int ret;
+  (*size) = 0;
+
+  if (stat(file, &sbuf) < 0) {
+    ret = get_errno();
+    XPR(NT "stat failed: %s: %s\n", file, strerror(ret));
+    return ret;
+  }
+
+  if (!S_ISREG(sbuf.st_mode)) {
+    ret = XD3_INTERNAL;
+    XPR(NT "not a regular file: %s: %s\n", file, strerror(ret));
+    return ret;
+  }
+
+  (*size) = sbuf.st_size;
+  return 0;
+}
+
+/***********************************************************************
+ READ OFFSET
+ ***********************************************************************/
+
+/* Common test for read_integer errors: encodes a 64-bit value and
+ * then attempts to read as a 32-bit value.  If TRUNC is non-zero,
+ * attempts to get errors by shortening the input, otherwise it should
+ * overflow.  Expects XD3_INTERNAL and MSG. */
+static int test_read_integer_error(xd3_stream *stream, usize_t trunto,
+                                   const char *msg) {
+  uint64_t eval = 1ULL << 34;
+  uint32_t rval;
+  xd3_output *buf = NULL;
+  const uint8_t *max;
+  const uint8_t *inp;
+  int ret;
+
+  buf = xd3_alloc_output(stream, buf);
+
+  if ((ret = xd3_emit_uint64_t(stream, &buf, eval))) {
+    goto fail;
+  }
+
+again:
+
+  inp = buf->base;
+  max = buf->base + buf->next - trunto;
+
+  if ((ret = xd3_read_uint32_t(stream, &inp, max, &rval)) !=
+          XD3_INVALID_INPUT ||
+      !MSG_IS(msg)) {
+    ret = XD3_INTERNAL;
+  } else if (trunto && trunto < buf->next) {
+    trunto += 1;
+    goto again;
+  } else {
+    ret = 0;
+  }
+
+fail:
+  xd3_free_output(stream, buf);
+  return ret;
+}
+
+/* Test integer overflow using the above routine. */
+static int test_decode_integer_overflow(xd3_stream *stream, int unused) {
+  return test_read_integer_error(stream, 0, "overflow in read_intger");
+}
+
+/* Test integer EOI using the above routine. */
+static int test_decode_integer_end_of_input(xd3_stream *stream, int unused) {
+  return test_read_integer_error(stream, 1, "end-of-input in read_integer");
+}
+
+/* Test that emit_integer/decode_integer/sizeof_integer/read_integer
+ * work on correct inputs.  Tests powers of (2^7), plus or minus, up
+ * to the maximum value. */
+#define TEST_ENCODE_DECODE_INTEGER(TYPE, ONE, MAX)                             \
+  xd3_output *rbuf = NULL;                                                     \
+  xd3_output *dbuf = NULL;                                                     \
+  TYPE values[64];                                                             \
+  usize_t nvalues = 0;                                                         \
+  usize_t i;                                                                   \
+  int ret = 0;                                                                 \
+                                                                               \
+  for (i = 0; i < (sizeof(TYPE) * 8); i += 7) {                                \
+    values[nvalues++] = (ONE << i) - ONE;                                      \
+    values[nvalues++] = (ONE << i);                                            \
+    values[nvalues++] = (ONE << i) + ONE;                                      \
+  }                                                                            \
+                                                                               \
+  values[nvalues++] = MAX - ONE;                                               \
+  values[nvalues++] = MAX;                                                     \
+                                                                               \
+  rbuf = xd3_alloc_output(stream, rbuf);                                       \
+  dbuf = xd3_alloc_output(stream, dbuf);                                       \
+                                                                               \
+  for (i = 0; i < nvalues; i += 1) {                                           \
+    const uint8_t *max;                                                        \
+    const uint8_t *inp;                                                        \
+    TYPE val;                                                                  \
+                                                                               \
+    DOT();                                                                     \
+    rbuf->next = 0;                                                            \
+                                                                               \
+    if ((ret = xd3_emit_##TYPE(stream, &rbuf, values[i])) ||                   \
+        (ret = xd3_emit_##TYPE(stream, &dbuf, values[i]))) {                   \
+      goto fail;                                                               \
+    }                                                                          \
+                                                                               \
+    inp = rbuf->base;                                                          \
+    max = rbuf->base + rbuf->next;                                             \
+                                                                               \
+    if (rbuf->next != xd3_sizeof_##TYPE(values[i])) {                          \
+      ret = XD3_INTERNAL;                                                      \
+      goto fail;                                                               \
+    }                                                                          \
+                                                                               \
+    if ((ret = xd3_read_##TYPE(stream, &inp, max, &val))) {                    \
+      goto fail;                                                               \
+    }                                                                          \
+                                                                               \
+    if (val != values[i]) {                                                    \
+      ret = XD3_INTERNAL;                                                      \
+      goto fail;                                                               \
+    }                                                                          \
+                                                                               \
+    DOT();                                                                     \
+  }                                                                            \
+                                                                               \
+  stream->next_in = dbuf->base;                                                \
+  stream->avail_in = dbuf->next;                                               \
+                                                                               \
+  for (i = 0; i < nvalues; i += 1) {                                           \
+    TYPE val;                                                                  \
+                                                                               \
+    if ((ret = xd3_decode_##TYPE(stream, &val))) {                             \
+      goto fail;                                                               \
+    }                                                                          \
+                                                                               \
+    if (val != values[i]) {                                                    \
+      ret = XD3_INTERNAL;                                                      \
+      goto fail;                                                               \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  if (stream->avail_in != 0) {                                                 \
+    ret = XD3_INTERNAL;                                                        \
+    goto fail;                                                                 \
+  }                                                                            \
+                                                                               \
+  fail:                                                                        \
+  xd3_free_output(stream, rbuf);                                               \
+  xd3_free_output(stream, dbuf);                                               \
+                                                                               \
+  return ret
+
+static int test_encode_decode_uint32_t(xd3_stream *stream, int unused) {
+  TEST_ENCODE_DECODE_INTEGER(uint32_t, 1U, UINT32_MAX);
+}
+
+static int test_encode_decode_uint64_t(xd3_stream *stream, int unused) {
+  TEST_ENCODE_DECODE_INTEGER(uint64_t, 1ULL, UINT64_MAX);
+}
+
+static int test_usize_t_overflow(xd3_stream *stream, int unused) {
+  if (USIZE_T_OVERFLOW(USIZE_T_MAX, 0)) {
+    goto fail;
+  }
+  if (USIZE_T_OVERFLOW(0, USIZE_T_MAX)) {
+    goto fail;
+  }
+  if (USIZE_T_OVERFLOW(USIZE_T_MAX / 2, USIZE_T_MAX / 2)) {
+    goto fail;
+  }
+  if (USIZE_T_OVERFLOW(USIZE_T_MAX / 2, USIZE_T_MAX / 2 + 1)) {
+    goto fail;
+  }
+
+  if (!USIZE_T_OVERFLOW(USIZE_T_MAX, 1)) {
+    goto fail;
+  }
+  if (!USIZE_T_OVERFLOW(1, USIZE_T_MAX)) {
+    goto fail;
+  }
+  if (!USIZE_T_OVERFLOW(USIZE_T_MAX / 2 + 1, USIZE_T_MAX / 2 + 1)) {
+    goto fail;
+  }
+
+  return 0;
+
+fail:
+  stream->msg = "incorrect overflow computation";
+  return XD3_INTERNAL;
+}
+
+static int test_alloc_overflow(xd3_stream *stream, int unused) {
+  void *p;
+  usize_t r;
+
+  /* Macro boundary behavior: a zero operand never overflows, a unit
+   * operand never overflows, and the product is rejected exactly when
+   * it would exceed SIZE_MAX. */
+  if (XD3_MUL_SIZE_OVERFLOW(0, SIZE_MAX)) {
+    goto fail;
+  }
+  if (XD3_MUL_SIZE_OVERFLOW(SIZE_MAX, 0)) {
+    goto fail;
+  }
+  if (XD3_MUL_SIZE_OVERFLOW(1, SIZE_MAX)) {
+    goto fail;
+  }
+  if (XD3_MUL_SIZE_OVERFLOW(SIZE_MAX, 1)) {
+    goto fail;
+  }
+  if (XD3_MUL_SIZE_OVERFLOW(SIZE_MAX / 2, 2)) {
+    goto fail;
+  }
+  if (!XD3_MUL_SIZE_OVERFLOW(SIZE_MAX, 2)) {
+    goto fail;
+  }
+  if (!XD3_MUL_SIZE_OVERFLOW(2, SIZE_MAX)) {
+    goto fail;
+  }
+  if (!XD3_MUL_SIZE_OVERFLOW((SIZE_MAX / 2) + 1, 2)) {
+    goto fail;
+  }
+
+  /* The core allocator must refuse an overflowing request without
+   * calling malloc.  These operands wrap to a small product when the
+   * guard is absent, so an unguarded malloc would succeed and return a
+   * dangerously undersized buffer; the guard must return NULL instead.
+   * A valid request must still be satisfied. */
+  if (__xd3_alloc_func(NULL, (SIZE_MAX / 2) + 2, 2) != NULL) {
+    goto fail;
+  }
+  p = __xd3_alloc_func(NULL, 16, 4);
+  if (p == NULL) {
+    goto fail;
+  }
+  free(p);
+
+#if XD3_MAIN
+  /* The CLI allocator shares the same guard. */
+  if (main_alloc(NULL, (SIZE_MAX / 2) + 2, 2) != NULL) {
+    goto fail;
+  }
+  p = main_alloc(NULL, 16, 4);
+  if (p == NULL) {
+    goto fail;
+  }
+  main_free1(NULL, p);
+#endif
+
+  /* xd3_round_blksize must never return a value smaller than the
+   * requested size, including at the top of the usize_t range where
+   * rounding up would otherwise wrap. */
+  if (xd3_round_blksize(0, XD3_ALLOCSIZE) != 0) {
+    goto fail;
+  }
+  if (xd3_round_blksize(XD3_ALLOCSIZE, XD3_ALLOCSIZE) != XD3_ALLOCSIZE) {
+    goto fail;
+  }
+  if (xd3_round_blksize(1, XD3_ALLOCSIZE) != XD3_ALLOCSIZE) {
+    goto fail;
+  }
+  if (xd3_round_blksize(XD3_ALLOCSIZE + 1, XD3_ALLOCSIZE) !=
+      2 * XD3_ALLOCSIZE) {
+    goto fail;
+  }
+
+  r = xd3_round_blksize(USIZE_T_MAX, XD3_ALLOCSIZE);
+  if (r < USIZE_T_MAX) {
+    goto fail;
+  }
+
+  r = xd3_round_blksize(USIZE_T_MAX - 1, XD3_ALLOCSIZE);
+  if (r < USIZE_T_MAX - 1) {
+    goto fail;
+  }
+
+  /* A zero blocksize must not corrupt the arithmetic. */
+  if (xd3_round_blksize(123, 0) != 123) {
+    goto fail;
+  }
+
+  return 0;
+
+fail:
+  stream->msg = "alloc overflow guard failed";
+  return XD3_INTERNAL;
+}
+
+static int test_forward_match(xd3_stream *stream, int unused) {
+  usize_t i;
+  uint8_t buf1[256], buf2[256];
+
+  memset(buf1, 0, 256);
+  memset(buf2, 0, 256);
+
+  for (i = 0; i < 256; i++) {
+    CHECK(xd3_forward_match(buf1, buf2, i) == i);
+  }
+
+  for (i = 0; i < 255; i++) {
+    buf2[i] = 1;
+    CHECK(xd3_forward_match(buf1, buf2, 256) == i);
+    buf2[i] = 0;
+  }
+
+  return 0;
+}
+
+/***********************************************************************
+ Address cache
+ ***********************************************************************/
+
+static int test_address_cache(xd3_stream *stream, int unused) {
+  int ret;
+  usize_t i;
+  usize_t offset;
+  usize_t *addrs;
+  uint8_t *big_buf, *buf_max;
+  const uint8_t *buf;
+  xd3_output *outp;
+  uint8_t *modes;
+  int mode_counts[16];
+
+  stream->acache.s_near = stream->code_table_desc->near_modes;
+  stream->acache.s_same = stream->code_table_desc->same_modes;
+
+  if ((ret = xd3_encode_init_partial(stream))) {
+    return ret;
+  }
+
+  addrs = (usize_t *)xd3_alloc(stream, sizeof(usize_t), ADDR_CACHE_ROUNDS);
+  modes = (uint8_t *)xd3_alloc(stream, sizeof(uint8_t), ADDR_CACHE_ROUNDS);
+
+  memset(mode_counts, 0, sizeof(mode_counts));
+  memset(modes, 0, ADDR_CACHE_ROUNDS);
+
+  addrs[0] = 0;
+
+  mt_init(&static_mtrand, 0x9f73f7fc);
+
+  /* First pass: encode addresses */
+  xd3_init_cache(&stream->acache);
+
+  for (offset = 1; offset < ADDR_CACHE_ROUNDS; offset += 1) {
+    double p;
+    usize_t addr;
+    usize_t prev_i;
+    usize_t nearby;
+
+    p = (mt_random(&static_mtrand) / (double)UINT32_MAX);
+    prev_i = mt_random(&static_mtrand) % offset;
+    nearby = (mt_random(&static_mtrand) % 256) % offset;
+    nearby = xd3_max(1U, nearby);
+
+    if (p < 0.1) {
+      addr = addrs[offset - nearby];
+    } else if (p < 0.4) {
+      addr = xd3_min(addrs[prev_i] + nearby, offset - 1);
+    } else {
+      addr = prev_i;
+    }
+
+    if ((ret = xd3_encode_address(stream, addr, offset, &modes[offset]))) {
+      return ret;
+    }
+
+    addrs[offset] = addr;
+    mode_counts[modes[offset]] += 1;
+  }
+
+  /* Copy addresses into a contiguous buffer. */
+  big_buf =
+      (uint8_t *)xd3_alloc(stream, xd3_sizeof_output(ADDR_HEAD(stream)), 1);
+
+  for (offset = 0, outp = ADDR_HEAD(stream); outp != NULL;
+       offset += outp->next, outp = outp->next_page) {
+    memcpy(big_buf + offset, outp->base, outp->next);
+  }
+
+  buf_max = big_buf + offset;
+  buf = big_buf;
+
+  /* Second pass: decode addresses */
+  xd3_init_cache(&stream->acache);
+
+  for (offset = 1; offset < ADDR_CACHE_ROUNDS; offset += 1) {
+    usize_t addr;
+
+    if ((ret = xd3_decode_address(stream, offset, modes[offset], &buf, buf_max,
+                                  &addr))) {
+      return ret;
+    }
+
+    if (addr != addrs[offset]) {
+      stream->msg = "incorrect decoded address";
+      return XD3_INTERNAL;
+    }
+  }
+
+  /* Check that every byte, mode was used. */
+  if (buf != buf_max) {
+    stream->msg = "address bytes not used";
+    return XD3_INTERNAL;
+  }
+
+  for (i = 0; i < (2 + stream->acache.s_same + stream->acache.s_near); i += 1) {
+    if (mode_counts[i] == 0) {
+      stream->msg = "address mode not used";
+      return XD3_INTERNAL;
+    }
+  }
+
+  xd3_free(stream, modes);
+  xd3_free(stream, addrs);
+  xd3_free(stream, big_buf);
+
+  return 0;
+}
+
+/***********************************************************************
+ Encode and decode with single bit error
+ ***********************************************************************/
+
+/* It compresses from 256 to around 185 bytes.
+ * Avoids matching addresses that are a single-bit difference.
+ * Avoids matching address 0. */
+static const uint8_t test_text[] = "this is a story\n"
+                                   "abouttttttttttt\n"
+                                   "- his is a stor\n"
+                                   "- about nothing "
+                                   " all. boutique -"
+                                   "his story is a -"
+                                   "about           "
+                                   "what happens all"
+                                   " the time what -"
+                                   "am I ttttttt the"
+                                   " person said, so"
+                                   " what, per son -"
+                                   " gory story is -"
+                                   " about nothing -"
+                                   "tttttt to test -"
+                                   "his sto nothing";
+
+static const uint8_t test_apphead[] = "header test";
+
+static int test_compress_text(xd3_stream *stream, uint8_t *encoded,
+                              usize_t *encoded_size) {
+  int ret;
+  xd3_config cfg;
+  int oflags = stream->flags;
+  int flags = stream->flags | XD3_FLUSH;
+
+  xd3_free_stream(stream);
+  xd3_init_config(&cfg, flags);
+
+  /* This configuration is fixed so that the "expected non-error" the counts in
+   * decompress_single_bit_errors are too.  See test_coftcfg_str. */
+  cfg.smatch_cfg = XD3_SMATCH_SOFT;
+  cfg.smatcher_soft.name = "test";
+  cfg.smatcher_soft.large_look = 64; /* no source, not used */
+  cfg.smatcher_soft.large_step = 64; /* no source, not used */
+  cfg.smatcher_soft.small_look = 4;
+  cfg.smatcher_soft.small_chain = 128;
+  cfg.smatcher_soft.small_lchain = 16;
+  cfg.smatcher_soft.max_lazy = 8;
+  cfg.smatcher_soft.long_enough = 128;
+
+  xd3_config_stream(stream, &cfg);
+
+  (*encoded_size) = 0;
+
+  xd3_set_appheader(stream, test_apphead,
+                    (usize_t)strlen((char *)test_apphead));
+
+  if ((ret = xd3_encode_stream(stream, test_text, sizeof(test_text), encoded,
+                               encoded_size, 4 * sizeof(test_text)))) {
+    goto fail;
+  }
+
+  if ((ret = xd3_close_stream(stream))) {
+    goto fail;
+  }
+
+fail:
+  xd3_free_stream(stream);
+  xd3_init_config(&cfg, oflags);
+  xd3_config_stream(stream, &cfg);
+  return ret;
+}
+
+static int test_decompress_text(xd3_stream *stream, uint8_t *enc,
+                                usize_t enc_size, usize_t test_desize) {
+  xd3_config cfg;
+  char decoded[sizeof(test_text)];
+  uint8_t *apphead;
+  usize_t apphead_size;
+  usize_t decoded_size;
+  const char *msg;
+  int ret;
+  usize_t pos = 0;
+  int flags = stream->flags;
+  usize_t take;
+
+input:
+  /* Test decoding test_desize input bytes at a time */
+  take = xd3_min(enc_size - pos, test_desize);
+  CHECK(take > 0);
+
+  xd3_avail_input(stream, enc + pos, take);
+again:
+  ret = xd3_decode_input(stream);
+
+  pos += take;
+  take = 0;
+
+  switch (ret) {
+  case XD3_OUTPUT:
+    break;
+  case XD3_WINSTART:
+  case XD3_GOTHEADER:
+    goto again;
+  case XD3_INPUT:
+    if (pos < enc_size) {
+      goto input;
+    }
+    /* else fallthrough */
+  case XD3_WINFINISH:
+  default:
+    goto fail;
+  }
+
+  CHECK(ret == XD3_OUTPUT);
+  CHECK(pos == enc_size);
+
+  if (stream->avail_out != sizeof(test_text)) {
+    stream->msg = "incorrect output size";
+    ret = XD3_INTERNAL;
+    goto fail;
+  }
+
+  decoded_size = stream->avail_out;
+  memcpy(decoded, stream->next_out, stream->avail_out);
+
+  xd3_consume_output(stream);
+
+  if ((ret = xd3_get_appheader(stream, &apphead, &apphead_size))) {
+    goto fail;
+  }
+
+  if (apphead_size != strlen((char *)test_apphead) ||
+      memcmp(apphead, test_apphead, strlen((char *)test_apphead)) != 0) {
+    stream->msg = "incorrect appheader";
+    ret = XD3_INTERNAL;
+    goto fail;
+  }
+
+  if ((ret = xd3_decode_input(stream)) != XD3_WINFINISH ||
+      (ret = xd3_close_stream(stream)) != 0) {
+    goto fail;
+  }
+
+  if (decoded_size != sizeof(test_text) ||
+      memcmp(decoded, test_text, sizeof(test_text)) != 0) {
+    stream->msg = "incorrect output text";
+    ret = EIO;
+  }
+
+fail:
+  msg = stream->msg;
+  xd3_free_stream(stream);
+  xd3_init_config(&cfg, flags);
+  xd3_config_stream(stream, &cfg);
+  stream->msg = msg;
+
+  return ret;
+}
+
+static int test_decompress_single_bit_error(xd3_stream *stream,
+                                            int expected_non_failures) {
+  int ret;
+  usize_t i;
+  uint8_t encoded[4 * sizeof(test_text)]; /* make room for alt code table */
+  usize_t encoded_size;
+  int non_failures = 0;
+  int cksum = (stream->flags & XD3_ADLER32) != 0;
+
+// #define DEBUG_TEST_FAILURES
+#ifndef DEBUG_TEST_FAILURES
+#define TEST_FAILURES()
+#else
+  /* For checking non-failure cases by hand, enable this macro and run
+   * xdelta printdelta with print_cpymode disabled.  Every non-failure
+   * should change a copy address mode, which doesn't cause a failure
+   * because the address cache starts out with all zeros.
+
+    ./xdelta3 test
+    for i in test_text.xz.*; do ./xdelta3 printdelta $i > $i.out;
+    diff $i.out test_text.xz.0.out; done
+
+   */
+  system("rm -rf test_text.*");
+  {
+    char buf[TESTBUFSIZE];
+    FILE *f;
+    snprintf_func(buf, TESTBUFSIZE, "test_text");
+    f = fopen(buf, "w");
+    fwrite(test_text, 1, sizeof(test_text), f);
+    fclose(f);
+  }
+#define TEST_FAILURES()                                                        \
+  do {                                                                         \
+    char buf[TESTBUFSIZE];                                                     \
+    FILE *f;                                                                   \
+    snprintf_func(buf, TESTBUFSIZE, "test_text.xz.%d", non_failures);          \
+    f = fopen(buf, "w");                                                       \
+    fwrite(encoded, 1, encoded_size, f);                                       \
+    fclose(f);                                                                 \
+  } while (0)
+#endif
+
+  stream->sec_data.inefficient = 1;
+  stream->sec_inst.inefficient = 1;
+  stream->sec_addr.inefficient = 1;
+
+  /* Encode text, test correct input */
+  if ((ret = test_compress_text(stream, encoded, &encoded_size))) {
+    /*stream->msg = "without error: encode failure";*/
+    return ret;
+  }
+
+  if ((ret = test_decompress_text(stream, encoded, encoded_size,
+                                  sizeof(test_text) / 4))) {
+    /*stream->msg = "without error: decode failure";*/
+    return ret;
+  }
+
+  TEST_FAILURES();
+
+  for (i = 0; i < encoded_size * 8; i += 1) {
+    /* Single bit error. */
+    encoded[i / 8] ^= 1 << (i % 8);
+
+    if ((ret = test_decompress_text(stream, encoded, encoded_size,
+                                    sizeof(test_text))) == 0) {
+      non_failures += 1;
+#ifdef DEBUG_TEST_FAILURES
+      XPR(NT "%u[%u] non-failure %u\n", i / 8, i % 8, non_failures);
+#endif
+      TEST_FAILURES();
+    } else {
+      /*XPR(NT "%u[%u] failure: %s\n", i/8, i%8, stream->msg);*/
+    }
+
+    /* decompress_text returns EIO when the final memcmp() fails, but that
+     * should never happen with checksumming on. */
+    if (cksum && ret == EIO) {
+      /*XPR(NT "%u[%u] cksum mismatch\n", i/8, i%8);*/
+      stream->msg = "checksum mismatch";
+      return XD3_INTERNAL;
+    }
+
+    /* Undo single bit error. */
+    encoded[i / 8] ^= 1 << (i % 8);
+  }
+
+  /* Test correct input again */
+  if ((ret = test_decompress_text(stream, encoded, encoded_size, 1))) {
+    /*stream->msg = "without error: decode failure";*/
+    return ret;
+  }
+
+  /* Check expected non-failures */
+  if (non_failures > expected_non_failures) {
+    XPR(NT "non-failures %u > expected %u", non_failures,
+        expected_non_failures);
+    stream->msg = "incorrect";
+    return XD3_INTERNAL;
+  }
+
+  DOT();
+
+  return 0;
+}
+
+/***********************************************************************
+ Secondary compression tests
+ ***********************************************************************/
+
+#if SECONDARY_ANY
+typedef int (*sec_dist_func)(xd3_stream *stream, xd3_output *data);
+
+static int sec_dist_func1(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func2(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func3(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func4(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func5(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func6(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func7(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func8(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func9(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func10(xd3_stream *stream, xd3_output *data);
+static int sec_dist_func11(xd3_stream *stream, xd3_output *data);
+
+static sec_dist_func sec_dists[] = {
+    sec_dist_func1, sec_dist_func2,  sec_dist_func3,  sec_dist_func4,
+    sec_dist_func5, sec_dist_func6,  sec_dist_func7,  sec_dist_func8,
+    sec_dist_func9, sec_dist_func10, sec_dist_func11,
+};
+
+/* Test ditsribution: 100 bytes of the same character (13). */
+static int sec_dist_func1(xd3_stream *stream, xd3_output *data) {
+  int i, ret;
+  for (i = 0; i < 100; i += 1) {
+    if ((ret = xd3_emit_byte(stream, &data, 13))) {
+      return ret;
+    }
+  }
+  return 0;
+}
+
+/* Test ditsribution: uniform covering half the alphabet. */
+static int sec_dist_func2(xd3_stream *stream, xd3_output *data) {
+  int i, ret;
+  for (i = 0; i < ALPHABET_SIZE; i += 1) {
+    if ((ret = xd3_emit_byte(stream, &data, i % (ALPHABET_SIZE / 2)))) {
+      return ret;
+    }
+  }
+  return 0;
+}
+
+/* Test ditsribution: uniform covering the entire alphabet. */
+static int sec_dist_func3(xd3_stream *stream, xd3_output *data) {
+  int i, ret;
+  for (i = 0; i < ALPHABET_SIZE; i += 1) {
+    if ((ret = xd3_emit_byte(stream, &data, i % ALPHABET_SIZE))) {
+      return ret;
+    }
+  }
+  return 0;
+}
+
+/* Test distribution: An exponential distribution covering half the alphabet */
+static int sec_dist_func4(xd3_stream *stream, xd3_output *data) {
+  int i, ret, x;
+  for (i = 0; i < ALPHABET_SIZE * 20; i += 1) {
+    x = mt_exp_rand(10, ALPHABET_SIZE / 2);
+    if ((ret = xd3_emit_byte(stream, &data, x))) {
+      return ret;
+    }
+  }
+  return 0;
+}
+
+/* Test distribution: An exponential distribution covering the entire alphabet
+ */
+static int sec_dist_func5(xd3_stream *stream, xd3_output *data) {
+  int i, ret, x;
+  for (i = 0; i < ALPHABET_SIZE * 20; i += 1) {
+    x = mt_exp_rand(10, ALPHABET_SIZE - 1);
+    if ((ret = xd3_emit_byte(stream, &data, x))) {
+      return ret;
+    }
+  }
+  return 0;
+}
+
+/* Test distribution: An uniform random distribution covering half the alphabet
+ */
+static int sec_dist_func6(xd3_stream *stream, xd3_output *data) {
+  int i, ret, x;
+  for (i = 0; i < ALPHABET_SIZE * 20; i += 1) {
+    x = mt_random(&static_mtrand) % (ALPHABET_SIZE / 2);
+    if ((ret = xd3_emit_byte(stream, &data, x))) {
+      return ret;
+    }
+  }
+  return 0;
+}
+
+/* Test distribution: An uniform random distribution covering the entire
+ * alphabet */
+static int sec_dist_func7(xd3_stream *stream, xd3_output *data) {
+  int i, ret, x;
+  for (i = 0; i < ALPHABET_SIZE * 200; i += 1) {
+    x = mt_random(&static_mtrand) % ALPHABET_SIZE;
+    if ((ret = xd3_emit_byte(stream, &data, x))) {
+      return ret;
+    }
+  }
+  return 0;
+}
+
+/* Test distribution: A small number of frequent characters, difficult
+ * to divide into many groups */
+static int sec_dist_func8(xd3_stream *stream, xd3_output *data) {
+  int i, ret;
+  for (i = 0; i < ALPHABET_SIZE * 5; i += 1) {
+    if ((ret = xd3_emit_byte(stream, &data, 0))) {
+      return ret;
+    }
+    if ((ret = xd3_emit_byte(stream, &data, 64))) {
+      return ret;
+    }
+    if ((ret = xd3_emit_byte(stream, &data, 128))) {
+      return ret;
+    }
+    if ((ret = xd3_emit_byte(stream, &data, 255))) {
+      return ret;
+    }
+  }
+  return 0;
+}
+
+/* Test distribution: One that causes many FGK block promotions (found a bug)
+ */
+static int sec_dist_func9(xd3_stream *stream, xd3_output *data) {
+  int i, ret;
+
+  int ramp = 0;
+  int rcount = 0;
+  int prom = 0;
+  int pcount = 0;
+
+  /* 200 was long enough to trigger it--only when stricter checking
+   * that counted all blocks was turned on, but it seems I deleted
+   * this code. (missing fgk_free_block on line 398). */
+  for (i = 0; i < ALPHABET_SIZE * 200; i += 1) {
+  repeat:
+    if (ramp < ALPHABET_SIZE) {
+      /* Initially Nth symbol has (N+1) frequency */
+      if (rcount <= ramp) {
+        rcount += 1;
+        if ((ret = xd3_emit_byte(stream, &data, ramp))) {
+          return ret;
+        }
+        continue;
+      }
+
+      ramp += 1;
+      rcount = 0;
+      goto repeat;
+    }
+
+    /* Thereafter, promote least freq to max freq */
+    if (pcount == ALPHABET_SIZE) {
+      pcount = 0;
+      prom = (prom + 1) % ALPHABET_SIZE;
+    }
+
+    pcount += 1;
+    if ((ret = xd3_emit_byte(stream, &data, prom))) {
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+/* Test distribution: freq[i] == i*i, creates a 21-bit code length, fixed
+ * in 3.0r. */
+static int sec_dist_func10(xd3_stream *stream, xd3_output *data) {
+  int i, j, ret;
+  for (i = 0; i < ALPHABET_SIZE; i += 1) {
+    for (j = 0; j <= (i * i); j += 1) {
+      if ((ret = xd3_emit_byte(stream, &data, i))) {
+        return ret;
+      }
+    }
+  }
+  return 0;
+}
+
+/* Test distribution: fibonacci */
+static int sec_dist_func11(xd3_stream *stream, xd3_output *data) {
+  int sum0 = 0;
+  int sum1 = 1;
+  int i, j, ret;
+  for (i = 0; i < 33; ++i) {
+    for (j = 0; j < (sum0 + sum1); ++j) {
+      if ((ret = xd3_emit_byte(stream, &data, i))) {
+        return ret;
+      }
+    }
+    sum0 = sum1;
+    sum1 = j;
+  }
+  return 0;
+}
+
+static int test_secondary_decode(xd3_stream *stream, const xd3_sec_type *sec,
+                                 usize_t input_size, usize_t compress_size,
+                                 const uint8_t *dec_input,
+                                 const uint8_t *dec_correct,
+                                 uint8_t *dec_output) {
+  int ret;
+  xd3_sec_stream *dec_stream;
+  const uint8_t *dec_input_used, *dec_input_end;
+  uint8_t *dec_output_used, *dec_output_end;
+
+  if ((dec_stream = sec->alloc(stream)) == NULL) {
+    return ENOMEM;
+  }
+
+  if ((ret = sec->init(stream, dec_stream, 0)) != 0) {
+    goto fail;
+  }
+
+  dec_input_used = dec_input;
+  dec_input_end = dec_input + compress_size;
+
+  dec_output_used = dec_output;
+  dec_output_end = dec_output + input_size;
+
+  if ((ret = sec->decode(stream, dec_stream, &dec_input_used, dec_input_end,
+                         &dec_output_used, dec_output_end))) {
+    goto fail;
+  }
+
+  if (dec_input_used != dec_input_end) {
+    stream->msg = "unused input";
+    ret = XD3_INTERNAL;
+    goto fail;
+  }
+
+  if (dec_output_used != dec_output_end) {
+    stream->msg = "unfinished output";
+    ret = XD3_INTERNAL;
+    goto fail;
+  }
+
+  if (memcmp(dec_output, dec_correct, input_size) != 0) {
+    stream->msg = "incorrect output";
+    ret = XD3_INTERNAL;
+    goto fail;
+  }
+
+fail:
+  sec->destroy(stream, dec_stream);
+  return ret;
+}
+
+static int test_secondary(xd3_stream *stream, const xd3_sec_type *sec,
+                          usize_t groups) {
+  usize_t test_i;
+  int ret;
+  xd3_output *in_head, *out_head, *p;
+  usize_t p_off, input_size, compress_size;
+  uint8_t *dec_input = NULL, *dec_output = NULL, *dec_correct = NULL;
+  xd3_sec_stream *enc_stream;
+  xd3_sec_cfg cfg;
+
+  memset(&cfg, 0, sizeof(cfg));
+
+  cfg.inefficient = 1;
+
+  for (cfg.ngroups = 1; cfg.ngroups <= groups; cfg.ngroups += 1) {
+    XPR(NTR "\n...");
+    for (test_i = 0; test_i < SIZEOF_ARRAY(sec_dists); test_i += 1) {
+      mt_init(&static_mtrand, 0x9f73f7fc);
+
+      in_head = xd3_alloc_output(stream, NULL);
+      out_head = xd3_alloc_output(stream, NULL);
+      enc_stream = sec->alloc(stream);
+      dec_input = NULL;
+      dec_output = NULL;
+      dec_correct = NULL;
+
+      if (in_head == NULL || out_head == NULL || enc_stream == NULL) {
+        goto nomem;
+      }
+
+      if ((ret = sec_dists[test_i](stream, in_head))) {
+        goto fail;
+      }
+
+      if ((ret = sec->init(stream, enc_stream, 1)) != 0) {
+        goto fail;
+      }
+
+      /* Encode data */
+      if ((ret = sec->encode(stream, enc_stream, in_head, out_head, &cfg))) {
+        XPR(NT "test %" XD3_W "u: encode: %s", test_i, stream->msg);
+        goto fail;
+      }
+
+      /* Calculate sizes, allocate contiguous arrays for decoding */
+      input_size = xd3_sizeof_output(in_head);
+      compress_size = xd3_sizeof_output(out_head);
+
+      XPR(NTR "%.3f", 8.0 * (double)compress_size / (double)input_size);
+
+      if ((dec_input = (uint8_t *)xd3_alloc(stream, compress_size, 1)) ==
+              NULL ||
+          (dec_output = (uint8_t *)xd3_alloc(stream, input_size, 1)) == NULL ||
+          (dec_correct = (uint8_t *)xd3_alloc(stream, input_size, 1)) == NULL) {
+        goto nomem;
+      }
+
+      /* Fill the compressed data array */
+      for (p_off = 0, p = out_head; p != NULL;
+           p_off += p->next, p = p->next_page) {
+        memcpy(dec_input + p_off, p->base, p->next);
+      }
+
+      CHECK(p_off == compress_size);
+
+      /* Fill the input data array */
+      for (p_off = 0, p = in_head; p != NULL;
+           p_off += p->next, p = p->next_page) {
+        memcpy(dec_correct + p_off, p->base, p->next);
+      }
+
+      CHECK(p_off == input_size);
+
+      if ((ret = test_secondary_decode(stream, sec, input_size, compress_size,
+                                       dec_input, dec_correct, dec_output))) {
+        XPR(NT "test %" XD3_W "u: decode: %s", test_i, stream->msg);
+        goto fail;
+      }
+
+      /* Single-bit error test, only cover the first 10 bytes.
+       * Some non-failures are expected in the Huffman case:
+       * Changing the clclen array, for example, may not harm the
+       * decoding.  Really looking for faults here. */
+      {
+        int i;
+        int bytes = (int)xd3_min(compress_size, 10U);
+        for (i = 0; i < bytes * 8; i += 1) {
+          dec_input[i / 8] ^= 1 << (i % 8);
+
+          if ((ret = test_secondary_decode(stream, sec, input_size,
+                                           compress_size, dec_input,
+                                           dec_correct, dec_output)) == 0) {
+            /*XPR(NT "test %u: decode single-bit [%u/%u]
+              error non-failure", test_i, i/8, i%8);*/
+          }
+
+          dec_input[i / 8] ^= 1 << (i % 8);
+
+          if ((i % (2 * bytes)) == (2 * bytes) - 1) {
+            DOT();
+          }
+        }
+        ret = 0;
+      }
+
+      if (0) {
+      nomem:
+        ret = ENOMEM;
+      }
+
+    fail:
+      sec->destroy(stream, enc_stream);
+      xd3_free_output(stream, in_head);
+      xd3_free_output(stream, out_head);
+      xd3_free(stream, dec_input);
+      xd3_free(stream, dec_output);
+      xd3_free(stream, dec_correct);
+
+      if (ret != 0) {
+        return ret;
+      }
+    }
+  }
+
+  return 0;
+}
+
+IF_FGK(static int test_secondary_fgk(xd3_stream *stream, usize_t gp) {
+  return test_secondary(stream, &fgk_sec_type, gp);
+})
+IF_DJW(static int test_secondary_huff(xd3_stream *stream, usize_t gp) {
+  return test_secondary(stream, &djw_sec_type, gp);
+})
+IF_LZMA(static int test_secondary_lzma(xd3_stream *stream, usize_t gp) {
+  return test_secondary(stream, &lzma_sec_type, gp);
+})
+
+#endif /* SECONDARY_ANY */
+
+/***********************************************************************
+ TEST INSTRUCTION TABLE
+ ***********************************************************************/
+
+/* Test that xd3_choose_instruction() does the right thing for its code
+ * table. */
+static int test_choose_instruction(xd3_stream *stream, int ignore) {
+  int i;
+
+  stream->code_table = (*stream->code_table_func)();
+
+  for (i = 0; i < 256; i += 1) {
+    const xd3_dinst *d = stream->code_table + i;
+    xd3_rinst prev, inst;
+
+    CHECK(d->type1 > 0);
+
+    memset(&prev, 0, sizeof(prev));
+    memset(&inst, 0, sizeof(inst));
+
+    if (d->type2 == 0) {
+      inst.type = d->type1;
+
+      if ((inst.size = d->size1) == 0) {
+        inst.size = TESTBUFSIZE;
+      }
+
+      XD3_CHOOSE_INSTRUCTION(stream, NULL, &inst);
+
+      if (inst.code2 != 0 || inst.code1 != i) {
+        stream->msg = "wrong single instruction";
+        return XD3_INTERNAL;
+      }
+    } else {
+      prev.type = d->type1;
+      prev.size = d->size1;
+      inst.type = d->type2;
+      inst.size = d->size2;
+
+      XD3_CHOOSE_INSTRUCTION(stream, &prev, &inst);
+
+      if (prev.code2 != i) {
+        stream->msg = "wrong double instruction";
+        return XD3_INTERNAL;
+      }
+    }
+  }
+
+  return 0;
+}
+
+static int test_checksum_step(xd3_stream *stream, int ignore) {
+  const int bufsize = 128;
+  uint8_t buf[128];
+  for (int i = 0; i < bufsize; i++) {
+    buf[i] = mt_random(&static_mtrand) & 0xff;
+  }
+
+  for (usize_t cksize = 4; cksize <= 32; cksize += 3) {
+    xd3_hash_cfg h1;
+    usize_t x;
+    int ret;
+
+    if ((ret = xd3_size_hashtable(stream, XD3_ALLOCSIZE, cksize, &h1)) != 0) {
+      return ret;
+    }
+
+    x = xd3_large_cksum(&h1, buf, cksize);
+    for (usize_t pos = 0; pos <= (bufsize - cksize); pos++) {
+      usize_t y = xd3_large_cksum(&h1, buf + pos, cksize);
+      if (x != y) {
+        stream->msg = "checksum != incremental checksum";
+        return XD3_INTERNAL;
+      }
+      x = xd3_large_cksum_update(&h1, x, buf + pos, cksize);
+    }
+
+    xd3_free(stream, h1.powers);
+  }
+
+  return 0;
+}
+
+/***********************************************************************
+ 64BIT STREAMING
+ ***********************************************************************/
+
+/* This test encodes and decodes a series of 1 megabyte windows, each
+ * containing a long run of zeros along with a single xoff_t size
+ * record to indicate the sequence. */
+static int test_streaming(xd3_stream *in_stream, uint8_t *encbuf,
+                          uint8_t *decbuf, uint8_t *delbuf, usize_t megs) {
+  xd3_stream estream, dstream;
+  int ret;
+  usize_t i, delsize, decsize;
+  xd3_config cfg;
+  xd3_init_config(&cfg, in_stream->flags);
+  cfg.flags |= XD3_COMPLEVEL_6;
+
+  if ((ret = xd3_config_stream(&estream, &cfg)) ||
+      (ret = xd3_config_stream(&dstream, &cfg))) {
+    goto fail;
+  }
+
+  for (i = 0; i < megs; i += 1) {
+    ((usize_t *)encbuf)[0] = i;
+
+    if ((i % 200) == 199) {
+      DOT();
+    }
+
+    if ((ret = xd3_process_stream(1, &estream, xd3_encode_input, 0, encbuf,
+                                  1 << 20, delbuf, &delsize, 1 << 20))) {
+      in_stream->msg = estream.msg;
+      goto fail;
+    }
+
+    if ((ret = xd3_process_stream(0, &dstream, xd3_decode_input, 0, delbuf,
+                                  delsize, decbuf, &decsize, 1 << 20))) {
+      in_stream->msg = dstream.msg;
+      goto fail;
+    }
+
+    if (decsize != 1 << 20 || memcmp(encbuf, decbuf, 1 << 20) != 0) {
+      in_stream->msg = "wrong result";
+      ret = XD3_INTERNAL;
+      goto fail;
+    }
+  }
+
+  if ((ret = xd3_close_stream(&estream)) ||
+      (ret = xd3_close_stream(&dstream))) {
+    goto fail;
+  }
+
+fail:
+  xd3_free_stream(&estream);
+  xd3_free_stream(&dstream);
+  return ret;
+}
+
+/* Run tests of data streaming of over and around 4GB of data. */
+static int test_compressed_stream_overflow(xd3_stream *stream, int ignore) {
+  int ret;
+  int i;
+  uint8_t *buf;
+
+  if ((buf = (uint8_t *)malloc(TWO_MEGS_AND_DELTA)) == NULL) {
+    return ENOMEM;
+  }
+
+  memset(buf, 0, TWO_MEGS_AND_DELTA);
+  for (i = 0; i < (2 << 20); i += 256) {
+    int j;
+    int off = mt_random(&static_mtrand) % 10;
+    for (j = 0; j < 256; j++) {
+      buf[i + j] = j + off;
+    }
+  }
+
+  /* Test overflow of a 32-bit file offset. */
+  if (SIZEOF_XOFF_T == 4) {
+    ret = test_streaming(stream, buf, buf + (1 << 20), buf + (2 << 20),
+                         (1 << 12) + 1);
+
+    if (ret == XD3_INVALID_INPUT && MSG_IS("decoder file offset overflow")) {
+      ret = 0;
+    } else {
+      XPR(NT XD3_LIB_ERRMSG(stream, ret));
+      stream->msg = "expected overflow condition";
+      ret = XD3_INTERNAL;
+      goto fail;
+    }
+  }
+
+  /* Test transfer of exactly 32bits worth of data. */
+  if ((ret = test_streaming(stream, buf, buf + (1 << 20), buf + (2 << 20),
+                            1 << 12))) {
+    goto fail;
+  }
+fail:
+  free(buf);
+  return ret;
+}
+
+/***********************************************************************
+ COMMAND LINE
+ ***********************************************************************/
+
+#if SHELL_TESTS
+
+/* For each pair of command templates in the array below, test that
+ * encoding and decoding commands work.  Also check for the expected
+ * size delta, which should be approximately TEST_ADD_RATIO times the
+ * file size created by test_make_inputs.  Due to differences in the
+ * application header, it is suppressed (-A) so that all delta files
+ * are the same. */
+static int test_command_line_arguments(xd3_stream *stream, int ignore) {
+  int i, ret;
+
+  static const char *cmdpairs[] = {
+      /* standard input, output */
+      "%s %s -A < %s > %s",
+      "%s -d < %s > %s",
+      "%s %s -A -e < %s > %s",
+      "%s -d < %s > %s",
+      "%s %s -A= encode < %s > %s",
+      "%s decode < %s > %s",
+      "%s %s -A -q encode < %s > %s",
+      "%s -qdq < %s > %s",
+
+      /* file input, standard output */
+      "%s %s -A= %s > %s",
+      "%s -d %s > %s",
+      "%s %s -A -e %s > %s",
+      "%s -d %s > %s",
+      "%s %s encode -A= %s > %s",
+      "%s decode %s > %s",
+
+      /* file input, output */
+      "%s %s -A= %s %s",
+      "%s -d %s %s",
+      "%s %s -A -e %s %s",
+      "%s -d %s %s",
+      "%s %s -A= encode %s %s",
+      "%s decode %s %s",
+
+      /* option placement */
+      "%s %s -A -f %s %s",
+      "%s -f -d %s %s",
+      "%s %s -e -A= %s %s",
+      "%s -d -f %s %s",
+      "%s %s -f encode -A= %s %s",
+      "%s -f decode -f %s %s",
+  };
+
+  char ecmd[TESTBUFSIZE], dcmd[TESTBUFSIZE];
+  int pairs = SIZEOF_ARRAY(cmdpairs) / 2;
+  xoff_t tsize;
+  xoff_t dsize;
+  double ratio;
+
+  mt_init(&static_mtrand, 0x9f73f7fc);
+
+  for (i = 0; i < pairs; i += 1) {
+    test_setup();
+    if ((ret = test_make_inputs(stream, NULL, &tsize))) {
+      return ret;
+    }
+
+    snprintf_func(ecmd, TESTBUFSIZE, cmdpairs[2 * i], program_name,
+                  test_softcfg_str, TEST_TARGET_FILE, TEST_DELTA_FILE);
+    snprintf_func(dcmd, TESTBUFSIZE, cmdpairs[2 * i + 1], program_name,
+                  TEST_DELTA_FILE, TEST_RECON_FILE);
+
+    /* Encode and decode. */
+    if ((ret = system(ecmd)) != 0) {
+      XPR(NT "encode command: %s\n", ecmd);
+      stream->msg = "encode cmd failed";
+      return XD3_INTERNAL;
+    }
+
+    if ((ret = system(dcmd)) != 0) {
+      XPR(NT "decode command: %s\n", dcmd);
+      stream->msg = "decode cmd failed";
+      return XD3_INTERNAL;
+    }
+
+    /* Compare the target file. */
+    if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+      return ret;
+    }
+
+    if ((ret = test_file_size(TEST_DELTA_FILE, &dsize))) {
+      return ret;
+    }
+
+    ratio = (double)dsize / (double)tsize;
+
+    /* Check that it is not too small, not too large. */
+    if (ratio >= TEST_ADD_RATIO + TEST_EPSILON) {
+      XPR(NT "test encode with size ratio %.4f, "
+             "expected < %.4f (%" XD3_Q "u, %" XD3_Q "u)\n",
+          ratio, TEST_ADD_RATIO + TEST_EPSILON, dsize, tsize);
+      stream->msg = "strange encoding";
+      return XD3_INTERNAL;
+    }
+
+    if (ratio <= TEST_ADD_RATIO * (1.0 - 2 * TEST_EPSILON)) {
+      XPR(NT "test encode with size ratio %.4f, "
+             "expected > %.4f\n",
+          ratio, TEST_ADD_RATIO - TEST_EPSILON);
+      stream->msg = "strange encoding";
+      return XD3_INTERNAL;
+    }
+
+    /* Also check that test_compare_files works.  The delta and original
+     * should not be identical. */
+    if ((ret = test_compare_files(TEST_DELTA_FILE, TEST_TARGET_FILE)) == 0) {
+      stream->msg = "broken test_compare_files";
+      return XD3_INTERNAL;
+    }
+
+    test_cleanup();
+    DOT();
+  }
+
+  return 0;
+}
+
+static int check_vcdiff_header(xd3_stream *stream, const char *input,
+                               const char *line_start, const char *matches,
+                               int yes_or_no) {
+  int ret;
+  char vcmd[TESTBUFSIZE], gcmd[TESTBUFSIZE];
+
+  snprintf_func(vcmd, TESTBUFSIZE, "%s printhdr -f %s %s", program_name, input,
+                TEST_RECON2_FILE);
+
+  if ((ret = system(vcmd)) != 0) {
+    XPR(NT "printhdr command: %s\n", vcmd);
+    stream->msg = "printhdr cmd failed";
+    return XD3_INTERNAL;
+  }
+
+  snprintf_func(gcmd, TESTBUFSIZE, "grep \"%s.*%s.*\" %s > /dev/null",
+                line_start, matches, TEST_RECON2_FILE);
+
+  if (yes_or_no) {
+    if ((ret = do_cmd(stream, gcmd))) {
+      XPR(NT "%s\n", gcmd);
+      return ret;
+    }
+  } else {
+    if ((ret = do_fail(stream, gcmd))) {
+      XPR(NT "%s\n", gcmd);
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+static int test_recode_command2(xd3_stream *stream, int has_source, int variant,
+                                int change) {
+  int has_adler32 = (variant & 0x1) != 0;
+  int has_apphead = (variant & 0x2) != 0;
+  int has_secondary = (variant & 0x4) != 0;
+
+  int change_adler32 = (change & 0x1) != 0;
+  int change_apphead = (change & 0x2) != 0;
+  int change_secondary = (change & 0x4) != 0;
+
+  int recoded_adler32 = change_adler32 ? !has_adler32 : has_adler32;
+  int recoded_apphead = change_apphead ? !has_apphead : has_apphead;
+  int recoded_secondary = change_secondary ? !has_secondary : has_secondary;
+
+  char ecmd[TESTBUFSIZE], recmd[TESTBUFSIZE], dcmd[TESTBUFSIZE];
+  xoff_t tsize, ssize;
+  int ret;
+
+  test_setup();
+
+  if ((ret = test_make_inputs(stream, has_source ? &ssize : NULL, &tsize))) {
+    return ret;
+  }
+
+  /* First encode */
+  snprintf_func(ecmd, TESTBUFSIZE, "%s %s -f %s %s %s %s %s %s %s",
+                program_name, test_softcfg_str, has_adler32 ? "" : "-n ",
+                has_apphead ? "-A=encode_apphead " : "-A= ",
+                has_secondary ? "-S djw " : "-S none ", has_source ? "-s " : "",
+                has_source ? TEST_SOURCE_FILE : "", TEST_TARGET_FILE,
+                TEST_DELTA_FILE);
+
+  if ((ret = system(ecmd)) != 0) {
+    XPR(NT "encode command: %s\n", ecmd);
+    stream->msg = "encode cmd failed";
+    return XD3_INTERNAL;
+  }
+
+  /* Now recode */
+  snprintf_func(
+      recmd, TESTBUFSIZE, "%s recode %s -f %s %s %s %s %s", program_name,
+      test_softcfg_str, recoded_adler32 ? "" : "-n ",
+      !change_apphead ? "" : (recoded_apphead ? "-A=recode_apphead " : "-A= "),
+      recoded_secondary ? "-S djw " : "-S= ", TEST_DELTA_FILE, TEST_COPY_FILE);
+
+  if ((ret = system(recmd)) != 0) {
+    XPR(NT "recode command: %s\n", recmd);
+    stream->msg = "recode cmd failed";
+    return XD3_INTERNAL;
+  }
+
+  /* Check recode changes. */
+
+  if ((ret = check_vcdiff_header(stream, TEST_COPY_FILE,
+                                 "VCDIFF window indicator", "VCD_SOURCE",
+                                 has_source))) {
+    return ret;
+  }
+
+  if ((ret = check_vcdiff_header(stream, TEST_COPY_FILE,
+                                 "VCDIFF header indicator", "VCD_SECONDARY",
+                                 recoded_secondary))) {
+    return ret;
+  }
+
+  if ((ret = check_vcdiff_header(stream, TEST_COPY_FILE,
+                                 "VCDIFF window indicator", "VCD_ADLER32",
+                                 /* Recode can't generate an adler32
+                                  * checksum, it can only preserve it or
+                                  * remove it. */
+                                 has_adler32 && recoded_adler32))) {
+    return ret;
+  }
+
+  if (!change_apphead) {
+    if ((ret = check_vcdiff_header(stream, TEST_COPY_FILE,
+                                   "VCDIFF header indicator", "VCD_APPHEADER",
+                                   has_apphead))) {
+      return ret;
+    }
+    if ((ret = check_vcdiff_header(stream, TEST_COPY_FILE,
+                                   "VCDIFF application header",
+                                   "encode_apphead", has_apphead))) {
+      return ret;
+    }
+  } else {
+    if ((ret = check_vcdiff_header(stream, TEST_COPY_FILE,
+                                   "VCDIFF header indicator", "VCD_APPHEADER",
+                                   recoded_apphead))) {
+      return ret;
+    }
+    if (recoded_apphead &&
+        (ret = check_vcdiff_header(stream, TEST_COPY_FILE,
+                                   "VCDIFF application header",
+                                   "recode_apphead", 1))) {
+      return ret;
+    }
+  }
+
+  /* Now decode */
+  snprintf_func(dcmd, TESTBUFSIZE, "%s -fd %s %s %s %s ", program_name,
+                has_source ? "-s " : "", has_source ? TEST_SOURCE_FILE : "",
+                TEST_COPY_FILE, TEST_RECON_FILE);
+
+  if ((ret = system(dcmd)) != 0) {
+    XPR(NT "decode command: %s\n", dcmd);
+    stream->msg = "decode cmd failed";
+    return XD3_INTERNAL;
+  }
+
+  /* Now compare. */
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+  test_cleanup();
+
+  return 0;
+}
+
+static int test_recode_command(xd3_stream *stream, int ignore) {
+  /* Things to test:
+   * - with and without a source file (recode does not change)
+   *
+   * (recode may or may not change -- 8 variations)
+   * - with and without adler32
+   * - with and without app header
+   * - with and without secondary
+   */
+  int has_source;
+  int variant;
+  int change;
+  int ret;
+
+  for (has_source = 0; has_source < 2; has_source++) {
+    for (variant = 0; variant < 8; variant++) {
+      for (change = 0; change < 8; change++) {
+        if ((ret = test_recode_command2(stream, has_source, variant, change))) {
+          return ret;
+        }
+      }
+      DOT();
+    }
+  }
+
+  return 0;
+}
+
+#if SECONDARY_LZMA
+static int test_secondary_lzma_default(xd3_stream *stream, int ignore) {
+  char ecmd[TESTBUFSIZE];
+  int ret;
+
+  test_setup();
+
+  if ((ret = test_make_inputs(stream, NULL, NULL))) {
+    return ret;
+  }
+
+  /* First encode */
+  snprintf_func(ecmd, TESTBUFSIZE, "%s -e %s %s", program_name,
+                TEST_TARGET_FILE, TEST_DELTA_FILE);
+
+  if ((ret = system(ecmd)) != 0) {
+    return XD3_INTERNAL;
+  }
+
+  if ((ret = check_vcdiff_header(stream, TEST_DELTA_FILE,
+                                 "VCDIFF secondary compressor", "lzma", 1))) {
+    return ret;
+  }
+
+  test_cleanup();
+  return 0;
+}
+
+#endif /* SECONDARY_LZMA */
+#endif /* SHELL_TESTS */
+
+/***********************************************************************
+ EXTERNAL I/O DECOMPRESSION/RECOMPRESSION
+ ***********************************************************************/
+
+#if EXTERNAL_COMPRESSION
+/* This performs one step of the test_externally_compressed_io
+ * function described below.  It builds a pipe containing both Xdelta
+ * and external compression/decompression that should not modify the
+ * data passing through. */
+static int test_compressed_pipe(xd3_stream *stream, main_extcomp *ext,
+                                char *buf, const char *comp_options,
+                                const char *decomp_options, int do_ext_recomp,
+                                const char *msg) {
+  int ret;
+  char decomp_buf[TESTBUFSIZE];
+
+  if (do_ext_recomp) {
+    snprintf_func(decomp_buf, TESTBUFSIZE, " | %s %s", ext->decomp_cmdname,
+                  ext->decomp_options);
+  } else {
+    decomp_buf[0] = 0;
+  }
+
+  snprintf_func(buf, TESTBUFSIZE, "%s %s < %s | %s %s | %s %s%s > %s",
+                ext->recomp_cmdname, ext->recomp_options, TEST_TARGET_FILE,
+                program_name, comp_options, program_name, decomp_options,
+                decomp_buf, TEST_RECON_FILE);
+
+  if ((ret = system(buf)) != 0) {
+    stream->msg = msg;
+    return XD3_INTERNAL;
+  }
+
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return XD3_INTERNAL;
+  }
+
+  DOT();
+  return 0;
+}
+
+/* We want to test that a pipe such as:
+ *
+ * --> | gzip -cf | xdelta3 -cf | xdelta3 -dcf | gzip -dcf | -->
+ *
+ * is transparent, i.e., does not modify the stream of data.  However,
+ * we also want to verify that at the center the data is properly
+ * compressed, i.e., that we do not just have a re-compressed gzip
+ * format, that we have an VCDIFF format.  We do this in two steps.
+ * First test the above pipe, then test with suppressed output
+ * recompression (-D).  The result should be the original input:
+ *
+ * --> | gzip -cf | xdelta3 -cf | xdelta3 -Ddcf | -->
+ *
+ * Finally we want to test that -D also disables input decompression:
+ *
+ * --> | gzip -cf | xdelta3 -Dcf | xdelta3 -Ddcf | gzip -dcf | -->
+ */
+static int test_externally_compressed_io(xd3_stream *stream, int ignore) {
+  usize_t i;
+  int ret;
+  char buf[TESTBUFSIZE];
+
+  mt_init(&static_mtrand, 0x9f73f7fc);
+
+  if ((ret = test_make_inputs(stream, NULL, NULL))) {
+    return ret;
+  }
+
+  for (i = 0; i < SIZEOF_ARRAY(extcomp_types); i += 1) {
+    main_extcomp *ext = &extcomp_types[i];
+
+    /* Test for the existence of the external command first, if not skip. */
+    snprintf_func(buf, TESTBUFSIZE, "%s %s < /dev/null > /dev/null",
+                  ext->recomp_cmdname, ext->recomp_options);
+
+    if ((ret = system(buf)) != 0) {
+      XPR(NT "%s=0", ext->recomp_cmdname);
+      continue;
+    }
+
+    if ((ret = test_compressed_pipe(stream, ext, buf, "-cfqa", "-dcfqa", 1,
+                                    "compression failed: identity pipe")) ||
+        (ret = test_compressed_pipe(
+             stream, ext, buf, "-cfqa", "-Rdcfqa", 0,
+             "compression failed: without recompression")) ||
+        (ret = test_compressed_pipe(
+             stream, ext, buf, "-Dcfqa", "-Rdcfqa", 1,
+             "compression failed: without decompression"))) {
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+/* This tests the proper functioning of external decompression for
+ * source files.  The source and target files are identical and
+ * compressed by gzip.  Decoding such a delta with recompression
+ * disbaled (-R) should produce the original, uncompressed
+ * source/target file.  Then it checks with output recompression
+ * enabled--in this case the output should be a compressed copy of the
+ * original source/target file.  Then it checks that encoding with
+ * decompression disabled works--the compressed files are identical
+ * and decoding them should always produce a compressed output,
+ * regardless of -R since the encoded delta file had decompression
+ * disabled..
+ */
+static int test_source_decompression(xd3_stream *stream, int ignore) {
+  int ret;
+  char buf[TESTBUFSIZE];
+  const main_extcomp *ext;
+  xoff_t dsize;
+
+  mt_init(&static_mtrand, 0x9f73f7fc);
+
+  test_setup();
+  if ((ret = test_make_inputs(stream, NULL, NULL))) {
+    return ret;
+  }
+
+  /* Use gzip. */
+  if ((ext = main_get_compressor("G")) == NULL) {
+    XPR(NT "skipped");
+    return 0;
+  }
+
+  /* Save an uncompressed copy. */
+  if ((ret = test_save_copy(TEST_TARGET_FILE))) {
+    return ret;
+  }
+
+  /* Compress the source. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -1 %s < %s > %s", ext->recomp_cmdname,
+                ext->recomp_options, TEST_COPY_FILE, TEST_SOURCE_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  /* Compress the target. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -9 %s < %s > %s", ext->recomp_cmdname,
+                ext->recomp_options, TEST_COPY_FILE, TEST_TARGET_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* Now the two identical files are compressed.  Delta-encode the target,
+   * with decompression. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -e -vfq -s%s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* Check that the compressed file is small (b/c inputs are
+   * identical). */
+  if ((ret = test_file_size(TEST_DELTA_FILE, &dsize))) {
+    return ret;
+  }
+  /* Deltas for identical files should be very small. */
+  if (dsize > 200) {
+    XPR(NT "external compression did not happen\n");
+    stream->msg = "external compression did not happen";
+    return XD3_INTERNAL;
+  }
+
+  /* Decode the delta file with recompression disabled, should get an
+   * uncompressed file out. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -v -dq -R -s%s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_COPY_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  /* Decode the delta file with recompression, should get a compressed file
+   * out.  But we can't compare compressed files directly. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -v -dqf -s%s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s %s < %s > %s", ext->decomp_cmdname,
+                ext->decomp_options, TEST_RECON_FILE, TEST_RECON2_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_COPY_FILE, TEST_RECON2_FILE))) {
+    return ret;
+  }
+
+  /* Encode with decompression disabled */
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -e -D -vfq -s%s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* Decode the delta file with decompression disabled, should get the
+   * identical compressed file out. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -a -d -D -vfq -s%s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  test_cleanup();
+  return 0;
+}
+#endif
+
+/***********************************************************************
+ FORCE, STDOUT
+ ***********************************************************************/
+
+/* This tests that output will not overwrite an existing file unless
+ * -f was specified.  The test is for encoding (the same code handles
+ * it for decoding). */
+static int test_force_behavior(xd3_stream *stream, int ignore) {
+  int ret;
+  char buf[TESTBUFSIZE];
+
+  /* Create empty target file */
+  test_setup();
+  snprintf_func(buf, TESTBUFSIZE, "cp /dev/null %s", TEST_TARGET_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* Encode to delta file */
+  snprintf_func(buf, TESTBUFSIZE, "%s -e %s %s", program_name, TEST_TARGET_FILE,
+                TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* Encode again, should fail. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -e %s %s ", program_name,
+                TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+
+  /* Force it, should succeed. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -f -e %s %s", program_name,
+                TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  test_cleanup();
+  return 0;
+}
+
+/* This checks the proper operation of the -c flag.  When specified
+ * the default output becomes stdout, otherwise the input must be
+ * provided (encode) or it may be defaulted (decode w/ app header). */
+static int test_stdout_behavior(xd3_stream *stream, int ignore) {
+  int ret;
+  char buf[TESTBUFSIZE];
+
+  test_setup();
+  snprintf_func(buf, TESTBUFSIZE, "cp /dev/null %s", TEST_TARGET_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* Without -c, encode writes to delta file */
+  snprintf_func(buf, TESTBUFSIZE, "%s -e %s %s", program_name, TEST_TARGET_FILE,
+                TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* With -c, encode writes to stdout */
+  snprintf_func(buf, TESTBUFSIZE, "%s -e -c %s > %s", program_name,
+                TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* Without -c, decode writes to target file name, but it fails because the
+   * file exists. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -d %s ", program_name,
+                TEST_DELTA_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+
+  /* With -c, decode writes to stdout */
+  snprintf_func(buf, TESTBUFSIZE, "%s -d -c %s > /dev/null", program_name,
+                TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  test_cleanup();
+
+  return 0;
+}
+
+/* This tests that the no-output flag (-J) works. */
+static int test_no_output(xd3_stream *stream, int ignore) {
+  int ret;
+  char buf[TESTBUFSIZE];
+
+  test_setup();
+
+  snprintf_func(buf, TESTBUFSIZE, "touch %s && chmod 0000 %s", TEST_NOPERM_FILE,
+                TEST_NOPERM_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  if ((ret = test_make_inputs(stream, NULL, NULL))) {
+    return ret;
+  }
+
+  /* Try no_output encode w/out unwritable output file */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e %s %s", program_name,
+                TEST_TARGET_FILE, TEST_NOPERM_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -J -e %s %s", program_name,
+                TEST_TARGET_FILE, TEST_NOPERM_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* Now really write the delta to test decode no-output */
+  snprintf_func(buf, TESTBUFSIZE, "%s -e %s %s", program_name, TEST_TARGET_FILE,
+                TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d %s %s", program_name,
+                TEST_DELTA_FILE, TEST_NOPERM_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -J -d %s %s", program_name,
+                TEST_DELTA_FILE, TEST_NOPERM_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  test_cleanup();
+  return 0;
+}
+
+/* This tests that the default appheader works */
+static int test_appheader(xd3_stream *stream, int ignore) {
+  int i;
+  int ret;
+  char buf[TESTBUFSIZE];
+  char bogus[TESTBUFSIZE];
+  xoff_t ssize, tsize;
+  test_setup();
+
+  if ((ret = test_make_inputs(stream, &ssize, &tsize))) {
+    return ret;
+  }
+
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  if ((ret = test_copy_to(program_name, TEST_RECON2_FILE))) {
+    return ret;
+  }
+
+  snprintf_func(buf, TESTBUFSIZE, "chmod 0700 %s", TEST_RECON2_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  if ((ret = test_save_copy(TEST_TARGET_FILE))) {
+    return ret;
+  }
+  if ((ret = test_copy_to(TEST_SOURCE_FILE, TEST_TARGET_FILE))) {
+    return ret;
+  }
+
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_COPY_FILE)) == 0) {
+    return XD3_INVALID; // I.e., files are different!
+  }
+
+  // Test that the target file is restored.
+  snprintf_func(buf, TESTBUFSIZE, "(cd /tmp && %s -q -f -d %s)",
+                TEST_RECON2_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_COPY_FILE)) != 0) {
+    return ret;
+  }
+
+  // Test a malicious string w/ entries > 4 in the appheader by having
+  // the encoder write it:
+  for (i = 0; i < TESTBUFSIZE / 4; ++i) {
+    bogus[2 * i] = 'G';
+    bogus[2 * i + 1] = '/';
+  }
+  bogus[TESTBUFSIZE / 2 - 1] = 0;
+
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -A=%s -e -s %s %s %s", program_name,
+                bogus, TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  // Then read it:
+  snprintf_func(buf, TESTBUFSIZE, "(cd /tmp && %s -q -f -d %s)",
+                TEST_RECON2_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf)) == 0) {
+    return XD3_INVALID; // Impossible
+  }
+  if (!WIFEXITED(ret)) {
+    return XD3_INVALID; // Must have crashed!
+  }
+
+  test_cleanup();
+  return 0;
+}
+
+#if XD3_ARMOR
+/* BLAKE3 known-answer test against the official test vectors (default 32-byte
+ * output).  The input is the repeating byte sequence 0,1,...,250,0,1,...  This
+ * pins the digest values independently of xdelta3's own encode/decode. */
+static int test_armor_blake3_kat(xd3_stream *stream, int ignore) {
+  static const struct {
+    usize_t len;
+    const char *hex;
+  } kats[] = {
+      {0, "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"},
+      {1, "2d3adedff11b61f14c886e35afa036736dcd87a74d27b5c1510225d0f592e213"},
+      {1024,
+       "42214739f095a406f3fc83deb889744ac00df831c10daa55189b5d121c855af7"},
+      {2048,
+       "e776b6028c7cd22a4d0ba182a8bf62205d2ef576467e838ed6f2529b85fba24a"},
+      {3072,
+       "b98cb0ff3623be03326b373de6b9095218513e64f1ee2edd2525c7ad1e5cffd2"},
+  };
+  const usize_t inlen = 3072;
+  uint8_t *inbuf;
+  usize_t i;
+  usize_t k;
+
+  if ((inbuf = (uint8_t *)main_malloc(inlen)) == NULL) {
+    return ENOMEM;
+  }
+  for (i = 0; i < inlen; i += 1) {
+    inbuf[i] = (uint8_t)(i % 251);
+  }
+
+  for (k = 0; k < SIZEOF_ARRAY(kats); k += 1) {
+    blake3_hasher h;
+    uint8_t digest[BLAKE3_OUT_LEN];
+    char got[XD3_BLAKE3_HEXBUF];
+
+    blake3_hasher_init(&h);
+    blake3_hasher_update(&h, inbuf, kats[k].len);
+    blake3_hasher_finalize(&h, digest, sizeof(digest));
+    main_armor_hex(digest, got);
+
+    if (strcmp(got, kats[k].hex) != 0) {
+      XPR(NT "BLAKE3 KAT mismatch at len %u:\n  expected %s\n  actual   %s\n",
+          (unsigned)kats[k].len, kats[k].hex, got);
+      stream->msg = "BLAKE3 known-answer test failed";
+      main_free(inbuf);
+      return XD3_INTERNAL;
+    }
+  }
+
+  main_free(inbuf);
+  return 0;
+}
+
+/* Tests armor mode (BLAKE3 whole-file verification): armored round-trip,
+ * fast failure on a wrong source, the -a opt-out / legacy header, and
+ * armored merge-chain verification including a broken chain. */
+static int test_armor(xd3_stream *stream, int ignore) {
+  int ret;
+  char buf[TESTBUFSIZE];
+  char d1[TESTFILESIZE];
+  char d2[TESTFILESIZE];
+  char v3[TESTFILESIZE];
+  char merged[TESTFILESIZE];
+  char wrong[TESTFILESIZE];
+  char warnf[TESTFILESIZE];
+  char forged[TESTFILESIZE];
+  xoff_t ssize, tsize;
+
+  test_setup();
+  if ((ret = test_make_inputs(stream, &ssize, &tsize))) {
+    return ret;
+  }
+
+  /* Armored encode (default) of SOURCE -> TARGET. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* The armored delta carries '#' digests in its app-header. */
+  snprintf_func(buf, TESTBUFSIZE,
+                "%s printhdr %s | grep -i 'application header' | grep -q '#'",
+                program_name, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    stream->msg = "armor: expected digest in app-header";
+    return ret;
+  }
+
+  /* Decode with the correct source verifies and round-trips. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  /* Decode with an unrelated source must fail the armor pre-check (exit 1). */
+  snprintf_func(wrong, sizeof(wrong), "%s.wrong", TEST_DELTA_FILE);
+  snprintf_func(buf, TESTBUFSIZE, "cat %s %s > %s", TEST_SOURCE_FILE,
+                TEST_TARGET_FILE, wrong);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                wrong, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+
+  /* Decode with the already-patched source (the target itself) reports
+   * "up to date" with the distinct exit code, not a generic failure. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                TEST_TARGET_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  {
+    int st = system(buf);
+    if (!WIFEXITED(st) || WEXITSTATUS(st) != EXIT_ARMOR_UP_TO_DATE) {
+      stream->msg = "armor: expected up-to-date exit code";
+      return XD3_INTERNAL;
+    }
+  }
+
+  /* A streaming (non-seekable) source cannot be verified: armor warns but the
+   * apply still succeeds.  Capture stderr and assert the warning is present. */
+  snprintf_func(warnf, sizeof(warnf), "%s.warn", TEST_DELTA_FILE);
+  snprintf_func(buf, TESTBUFSIZE, "cat %s | %s -f -d -s /dev/stdin %s %s 2>%s",
+                TEST_SOURCE_FILE, program_name, TEST_DELTA_FILE,
+                TEST_RECON_FILE, warnf);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "grep -q 'source is not seekable' %s", warnf);
+  if ((ret = do_cmd(stream, buf))) {
+    stream->msg = "armor: expected streaming-source warning";
+    return ret;
+  }
+  test_unlink(warnf);
+  test_unlink(wrong);
+
+  /* Target verification after apply: forge a delta whose embedded source
+   * digest is correct but whose target digest is wrong, then confirm decode
+   * passes the up-front source check yet fails the after-apply target check
+   * (exit 1).  This exercises the on-the-fly target hasher mismatch path that
+   * the success round-trips above never reach.  The delta is re-armored with
+   * recode -A; the source name and output name are arbitrary because -s and
+   * the explicit output path override them on decode. */
+  {
+    char srchash[XD3_BLAKE3_HEXBUF];
+    char header[TESTBUFSIZE];
+    static const char zeros[XD3_BLAKE3_HEXLEN + 1] =
+        "0000000000000000000000000000000000000000000000000000000000000000";
+
+    if ((ret =
+             main_armor_hash_file(TEST_SOURCE_FILE, "source", srchash, NULL))) {
+      return ret;
+    }
+    snprintf_func(forged, sizeof(forged), "%s.forged", TEST_DELTA_FILE);
+    snprintf_func(header, sizeof(header), "x#%s//x#%s/", zeros, srchash);
+    snprintf_func(buf, TESTBUFSIZE, "%s -f recode -A \"%s\" %s %s",
+                  program_name, header, TEST_DELTA_FILE, forged);
+    if ((ret = do_cmd(stream, buf))) {
+      return ret;
+    }
+    snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                  TEST_SOURCE_FILE, forged, TEST_RECON_FILE);
+    if ((ret = do_fail(stream, buf))) {
+      stream->msg = "armor: expected target mismatch after apply";
+      return ret;
+    }
+    test_unlink(forged);
+  }
+
+  /* -a decode skips armor; with the correct source it still round-trips. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -a -d -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  /* -a must still strip the digest from app-header default filenames: decode
+   * with -a and no -s relies on the embedded source name, which must resolve
+   * to the real file ("source") and not "source#<hash>". */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -a -d %s %s", program_name,
+                TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  /* -a encode produces a legacy app-header with no digest. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -a -e -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_TARGET_FILE, TEST_DELTA_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE,
+                "%s printhdr %s | grep -i 'application header' | grep -q '#'",
+                program_name, TEST_DELTA_FILE);
+  if ((ret = do_fail(stream, buf))) { /* grep finds no '#' -> exit 1 */
+    return ret;
+  }
+
+  /* Armored merge chain: SOURCE(v1) -> TARGET(v2) -> v3. */
+  snprintf_func(d1, sizeof(d1), "%s.d1", TEST_DELTA_FILE);
+  snprintf_func(d2, sizeof(d2), "%s.d2", TEST_DELTA_FILE);
+  snprintf_func(v3, sizeof(v3), "%s.v3", TEST_DELTA_FILE);
+  snprintf_func(merged, sizeof(merged), "%s.merged", TEST_DELTA_FILE);
+
+  snprintf_func(buf, TESTBUFSIZE, "cp %s %s && echo armor-extra-data >> %s",
+                TEST_TARGET_FILE, v3, v3);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_TARGET_FILE, d1);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name,
+                TEST_TARGET_FILE, v3, d2);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -f merge -m %s %s %s", program_name, d1,
+                d2, merged);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, merged, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(v3, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  /* A partially-armored chain (one legacy link) merges successfully but the
+   * merged delta is not re-armored: it carries no digest and applies without
+   * armor verification.  Re-encode the second link with -a so it is legacy. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -a -e -s %s %s %s", program_name,
+                TEST_TARGET_FILE, v3, d2);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -f merge -m %s %s %s", program_name, d1,
+                d2, merged);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  /* The merged delta carries no '#' digest (grep finds none -> exit 1). */
+  snprintf_func(buf, TESTBUFSIZE,
+                "%s printhdr %s | grep -i 'application header' | grep -q '#'",
+                program_name, merged);
+  if ((ret = do_fail(stream, buf))) {
+    stream->msg = "armor: partially-armored merge should not be re-armored";
+    return ret;
+  }
+  /* It still applies and round-trips to v3. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -d -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, merged, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(v3, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  /* A broken chain (replace d2 with v3 -> v1) must be refused. */
+  snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name, v3,
+                TEST_SOURCE_FILE, d2);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "%s -f merge -m %s %s %s", program_name, d1,
+                d2, merged);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+
+  test_unlink(d1);
+  test_unlink(d2);
+  test_unlink(v3);
+  test_unlink(merged);
+
+#if EXTERNAL_COMPRESSION
+  /* Armor verifies the logical (decompressed) content, so it works across
+   * external compression: encode/decode gzip'd inputs and round-trip. */
+  if (main_get_compressor("G") != NULL) {
+    char sgz[TESTFILESIZE];
+    char tgz[TESTFILESIZE];
+    snprintf_func(sgz, sizeof(sgz), "%s.sgz", TEST_DELTA_FILE);
+    snprintf_func(tgz, sizeof(tgz), "%s.tgz", TEST_DELTA_FILE);
+
+    snprintf_func(buf, TESTBUFSIZE, "gzip -1 < %s > %s && gzip -9 < %s > %s",
+                  TEST_SOURCE_FILE, sgz, TEST_TARGET_FILE, tgz);
+    if ((ret = do_cmd(stream, buf))) {
+      return ret;
+    }
+    /* Armored encode auto-decompresses both inputs. */
+    snprintf_func(buf, TESTBUFSIZE, "%s -q -f -e -s %s %s %s", program_name,
+                  sgz, tgz, TEST_DELTA_FILE);
+    if ((ret = do_cmd(stream, buf))) {
+      return ret;
+    }
+    /* Decode with -R (no recompression) yields the logical target content,
+     * which armor also verifies on the fly. */
+    snprintf_func(buf, TESTBUFSIZE, "%s -q -f -R -d -s %s %s %s", program_name,
+                  sgz, TEST_DELTA_FILE, TEST_RECON_FILE);
+    if ((ret = do_cmd(stream, buf))) {
+      return ret;
+    }
+    if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+      return ret;
+    }
+    /* Applying with the already-patched (target) gzip source reports
+     * up-to-date -- the up-to-date detection works across external
+     * compression too. */
+    snprintf_func(buf, TESTBUFSIZE, "%s -q -f -R -d -s %s %s %s", program_name,
+                  tgz, TEST_DELTA_FILE, TEST_RECON_FILE);
+    {
+      int st = system(buf);
+      if (!WIFEXITED(st) || WEXITSTATUS(st) != EXIT_ARMOR_UP_TO_DATE) {
+        stream->msg = "armor: expected up-to-date exit code (gzip)";
+        return XD3_INTERNAL;
+      }
+    }
+
+    test_unlink(sgz);
+    test_unlink(tgz);
+  }
+#endif
+
+  /* Armored encode requires seekable inputs: a streaming (non-seekable) target
+   * or source is rejected.  Both forms feed the streaming input via a pipe (a
+   * "< file" redirect would still be a seekable regular file). */
+  snprintf_func(buf, TESTBUFSIZE, "cat %s | %s -f -e -s %s > %s",
+                TEST_TARGET_FILE, program_name, TEST_SOURCE_FILE,
+                TEST_DELTA_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+  snprintf_func(buf, TESTBUFSIZE, "cat %s | %s -f -e -s /dev/stdin %s %s",
+                TEST_SOURCE_FILE, program_name, TEST_TARGET_FILE,
+                TEST_DELTA_FILE);
+  if ((ret = do_fail(stream, buf))) {
+    return ret;
+  }
+
+  test_cleanup();
+  return 0;
+}
+#endif /* XD3_ARMOR */
+
+#if SHELL_TESTS
+/* Regression test for the source-window (-B) over-allocation behind #273/#251.
+ * A -B much larger than the source must not reserve the full window up front:
+ * encode with a 1 GiB -B over a small (~16 KiB) source, confirm the verbose
+ * source report shows a window clamped to the source size (well under a
+ * gigabyte) rather than the requested 1 GiB, and that the delta still applies
+ * correctly. */
+static int test_srcwin_clamp(xd3_stream *stream, int ignore) {
+  int ret;
+  char buf[TESTBUFSIZE];
+  char vlog[TESTFILESIZE];
+  xoff_t ssize, tsize;
+
+  test_setup();
+  if ((ret = test_make_inputs(stream, &ssize, &tsize))) {
+    return ret;
+  }
+
+  snprintf_func(vlog, sizeof(vlog), "%s.vlog", TEST_DELTA_FILE);
+  snprintf_func(buf, TESTBUFSIZE, "%s -e -v -f -B 1073741824 -s %s %s %s 2>%s",
+                program_name, TEST_SOURCE_FILE, TEST_TARGET_FILE,
+                TEST_DELTA_FILE, vlog);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+
+  /* The window must have been clamped: the verbose report must not claim a
+   * GiB-sized window (pre-fix it printed "window 1.00 GiB"). */
+  snprintf_func(buf, TESTBUFSIZE, "grep -i 'source size' %s | grep -q 'GiB'",
+                vlog);
+  if ((ret = do_fail(stream, buf))) {
+    stream->msg = "srcwin: window not clamped to source size";
+    return ret;
+  }
+
+  snprintf_func(buf, TESTBUFSIZE, "%s -d -f -s %s %s %s", program_name,
+                TEST_SOURCE_FILE, TEST_DELTA_FILE, TEST_RECON_FILE);
+  if ((ret = do_cmd(stream, buf))) {
+    return ret;
+  }
+  if ((ret = test_compare_files(TEST_TARGET_FILE, TEST_RECON_FILE))) {
+    return ret;
+  }
+
+  test_unlink(vlog);
+  test_cleanup();
+  return 0;
+}
+#endif /* SHELL_TESTS */
+
+/***********************************************************************
+ Source identical optimization
+ ***********************************************************************/
+/* Computing a delta should be fastest when the two inputs are
+ * identical, this checks it.  The library is called to compute a
+ * delta between a 10000 byte file, 1000 byte winsize, 500 byte source
+ * blocksize.  The same buffer is used for both source and target. */
+static int test_identical_behavior(xd3_stream *stream, int ignore) {
+#define IDB_TGTSZ                                                              \
+  10000 /* Not a power of two b/c of hard-coded expectations below. */
+#define IDB_BLKSZ 512
+#define IDB_WINSZ 1000
+#define IDB_DELSZ 1000
+#define IDB_WINCNT (IDB_TGTSZ / IDB_WINSZ)
+
+  int ret, i;
+  uint8_t buf[IDB_TGTSZ];
+  uint8_t del[IDB_DELSZ];
+  uint8_t rec[IDB_TGTSZ];
+  xd3_source source;
+  int nextencwin = 0;
+  int winstarts = 0, winfinishes = 0;
+  usize_t delpos = 0, recsize;
+  xd3_config config;
+  memset(&source, 0, sizeof(source));
+
+  for (i = 0; i < IDB_TGTSZ; i += 1) {
+    buf[i] = (uint8_t)mt_random(&static_mtrand);
+  }
+
+  stream->winsize = IDB_WINSZ;
+
+  source.blksize = IDB_BLKSZ;
+  source.name = "";
+  source.curblk = NULL;
+  source.curblkno = 0;
+
+  if ((ret = xd3_set_source(stream, &source))) {
+    goto fail;
+  }
+
+  /* Compute an delta between identical source and targets. */
+  for (;;) {
+    ret = xd3_encode_input(stream);
+
+    if (ret == XD3_INPUT) {
+      xd3_avail_input(stream, buf + (IDB_WINSZ * nextencwin), IDB_WINSZ);
+      nextencwin += 1;
+      continue;
+    }
+
+    if (ret == XD3_GETSRCBLK) {
+      source.curblkno = source.getblkno;
+      source.onblk = IDB_BLKSZ;
+      source.curblk = buf + source.getblkno * IDB_BLKSZ;
+      continue;
+    }
+
+    if (ret == XD3_WINSTART) {
+      winstarts++;
+      continue;
+    }
+    if (ret == XD3_WINFINISH) {
+      winfinishes++;
+      if (winfinishes == IDB_WINCNT) {
+        break;
+      }
+      continue;
+    }
+
+    if (ret != XD3_OUTPUT) {
+      goto fail;
+    }
+
+    CHECK(delpos + stream->avail_out <= IDB_DELSZ);
+
+    memcpy(del + delpos, stream->next_out, stream->avail_out);
+
+    delpos += stream->avail_out;
+
+    xd3_consume_output(stream);
+  }
+
+  CHECK(winfinishes == IDB_WINCNT);
+  CHECK(winstarts == IDB_WINCNT);
+  CHECK(nextencwin == IDB_WINCNT);
+
+  /* Reset. */
+  memset(&source, 0, sizeof(source));
+  source.blksize = IDB_TGTSZ;
+  source.onblk = IDB_TGTSZ;
+  source.curblk = buf;
+  source.curblkno = 0;
+
+  if ((ret = xd3_close_stream(stream))) {
+    goto fail;
+  }
+  xd3_free_stream(stream);
+  xd3_init_config(&config, 0);
+  if ((ret = xd3_config_stream(stream, &config))) {
+    goto fail;
+  }
+  if ((ret = xd3_set_source_and_size(stream, &source, IDB_TGTSZ))) {
+    goto fail;
+  }
+
+  /* Decode. */
+  if ((ret =
+           xd3_decode_stream(stream, del, delpos, rec, &recsize, IDB_TGTSZ))) {
+    goto fail;
+  }
+
+  /* Check result size and data. */
+  if (recsize != IDB_TGTSZ) {
+    stream->msg = "wrong size reconstruction";
+    goto fail;
+  }
+  if (memcmp(rec, buf, IDB_TGTSZ) != 0) {
+    stream->msg = "wrong data reconstruction";
+    goto fail;
+  }
+
+  /* Check that there was one copy per window. */
+  IF_DEBUG(if (stream->n_scpy != IDB_WINCNT || stream->n_add != 0 ||
+               stream->n_run != 0) {
+    stream->msg = "wrong copy count";
+    goto fail;
+  });
+
+  /* Check that no checksums were computed because the initial match
+     was presumed. */
+  IF_DEBUG(if (stream->large_ckcnt != 0) {
+    stream->msg = "wrong checksum behavior";
+    goto fail;
+  });
+
+  ret = 0;
+fail:
+  return ret;
+}
+
+/***********************************************************************
+ String matching test
+ ***********************************************************************/
+
+/* Check particular matching behaviors by calling
+ * xd3_string_match_soft directly with specific arguments. */
+typedef struct _string_match_test string_match_test;
+
+typedef enum {
+  SM_NONE = 0,
+  SM_LAZY = (1 << 1),
+} string_match_flags;
+
+struct _string_match_test {
+  const char *input;
+  int flags;
+  const char *result;
+};
+
+static const string_match_test match_tests[] = {
+    /* nothing */
+    {"1234567890", SM_NONE, ""},
+
+    /* basic run, copy */
+    {"11111111112323232323", SM_NONE, "R0/10 C12/8@10"},
+
+    /* no run smaller than MIN_RUN=8 */
+    {"1111111", SM_NONE, "C1/6@0"},
+    {"11111111", SM_NONE, "R0/8"},
+
+    /* simple promotion: the third copy address depends on promotion */
+    {"ABCDEF_ABCDEF^ABCDEF", SM_NONE, "C7/6@0 C14/6@7"},
+    /* { "ABCDEF_ABCDEF^ABCDEF", SM_PROMOTE, "C7/6@0 C14/6@0" }, forgotten */
+
+    /* simple lazy: there is a better copy starting with "23 X" than "123 " */
+    {"123 23 XYZ 123 XYZ", SM_NONE, "C11/4@0"},
+    {"123 23 XYZ 123 XYZ", SM_LAZY, "C11/4@0 C12/6@4"},
+
+    /* trylazy: no lazy matches unless there are at least two characters beyond
+     * the first match */
+    {"2123_121212", SM_LAZY, "C7/4@5"},
+    {"2123_1212123", SM_LAZY, "C7/4@5"},
+    {"2123_1212123_", SM_LAZY, "C7/4@5 C8/5@0"},
+
+    /* trylazy: no lazy matches if the copy is >= MAXLAZY=10 */
+    {"2123_121212123_", SM_LAZY, "C7/6@5 C10/5@0"},
+    {"2123_12121212123_", SM_LAZY, "C7/8@5 C12/5@0"},
+    {"2123_1212121212123_", SM_LAZY, "C7/10@5"},
+
+    /* lazy run: check a run overlapped by a longer copy */
+    {"11111112 111111112 1", SM_LAZY, "C1/6@0 R9/8 C10/10@0"},
+
+    /* lazy match: match_length,run_l >= min_match tests, shouldn't get any
+     * copies within the run, no run within the copy */
+    {"^________^________  ", SM_LAZY, "R1/8 C9/9@0"},
+
+    /* chain depth: it only goes back 10. this checks that the 10th match hits
+     * and the 11th misses. */
+    {"1234 1234_1234-1234=1234+1234[1234]1234{1234}1234<1234 ", SM_NONE,
+     "C5/4@0 C10/4@5 C15/4@10 C20/4@15 C25/4@20 C30/4@25 C35/4@30 C40/4@35 "
+     "C45/4@40 C50/5@0"},
+    {"1234 1234_1234-1234=1234+1234[1234]1234{1234}1234<1234>1234 ", SM_NONE,
+     "C5/4@0 C10/4@5 C15/4@10 C20/4@15 C25/4@20 C30/4@25 C35/4@30 C40/4@35 "
+     "C45/4@40 C50/4@45 C55/4@50"},
+
+    /* ssmatch test */
+    {"ABCDE___ABCDE*** BCDE***", SM_NONE, "C8/5@0 C17/4@1"},
+    /*{ "ABCDE___ABCDE*** BCDE***", SM_SSMATCH, "C8/5@0 C17/7@9" }, forgotten */
+};
+
+static int test_string_matching(xd3_stream *stream, int ignore) {
+  usize_t i;
+  int ret;
+  xd3_config config;
+  char rbuf[TESTBUFSIZE];
+
+  for (i = 0; i < SIZEOF_ARRAY(match_tests); i += 1) {
+    const string_match_test *test = &match_tests[i];
+    char *rptr = rbuf;
+    usize_t len = (usize_t)strlen(test->input);
+
+    xd3_free_stream(stream);
+    xd3_init_config(&config, 0);
+
+    config.smatch_cfg = XD3_SMATCH_SOFT;
+    config.smatcher_soft.large_look = 4;
+    config.smatcher_soft.large_step = 4;
+    config.smatcher_soft.small_look = 4;
+    config.smatcher_soft.small_chain = 10;
+    config.smatcher_soft.small_lchain = 10;
+    config.smatcher_soft.max_lazy = (test->flags & SM_LAZY) ? 10 : 0;
+    config.smatcher_soft.long_enough = 10;
+
+    if ((ret = xd3_config_stream(stream, &config))) {
+      return ret;
+    }
+    if ((ret = xd3_encode_init_full(stream))) {
+      return ret;
+    }
+
+    xd3_avail_input(stream, (uint8_t *)test->input, len);
+
+    if ((ret = stream->smatcher.string_match(stream))) {
+      return ret;
+    }
+
+    *rptr = 0;
+    while (!xd3_rlist_empty(&stream->iopt_used)) {
+      xd3_rinst *inst = xd3_rlist_pop_front(&stream->iopt_used);
+
+      switch (inst->type) {
+      case XD3_RUN:
+        *rptr++ = 'R';
+        break;
+      case XD3_CPY:
+        *rptr++ = 'C';
+        break;
+      default:
+        CHECK(0);
+      }
+
+      snprintf_func(rptr, rbuf + TESTBUFSIZE - rptr, "%" XD3_W "u/%" XD3_W "u",
+                    inst->pos, inst->size);
+      rptr += strlen(rptr);
+
+      if (inst->type == XD3_CPY) {
+        *rptr++ = '@';
+        snprintf_func(rptr, rbuf + TESTBUFSIZE - rptr, "%" XD3_Q "u",
+                      inst->addr);
+        rptr += strlen(rptr);
+      }
+
+      *rptr++ = ' ';
+
+      xd3_rlist_push_back(&stream->iopt_free, inst);
+    }
+
+    if (rptr != rbuf) {
+      rptr -= 1;
+      *rptr = 0;
+    }
+
+    if (strcmp(rbuf, test->result) != 0) {
+      XPR(NT "test %" XD3_W "u: expected %s: got %s", i, test->result, rbuf);
+      stream->msg = "wrong result";
+      return XD3_INTERNAL;
+    }
+  }
+
+  return 0;
+}
+
+/*
+ * This is a test for many overlapping instructions. It must be a lazy
+ * matcher.
+ */
+static int test_iopt_flush_instructions(xd3_stream *stream, int ignore) {
+  int ret, i;
+  usize_t tpos = 0;
+  usize_t delta_size, recon_size;
+  xd3_config config;
+  uint8_t target[TESTBUFSIZE];
+  uint8_t delta[TESTBUFSIZE];
+  uint8_t recon[TESTBUFSIZE];
+
+  xd3_free_stream(stream);
+  xd3_init_config(&config, 0);
+
+  config.smatch_cfg = XD3_SMATCH_SOFT;
+  config.smatcher_soft.large_look = 16;
+  config.smatcher_soft.large_step = 16;
+  config.smatcher_soft.small_look = 4;
+  config.smatcher_soft.small_chain = 128;
+  config.smatcher_soft.small_lchain = 16;
+  config.smatcher_soft.max_lazy = 8;
+  config.smatcher_soft.long_enough = 128;
+
+  if ((ret = xd3_config_stream(stream, &config))) {
+    return ret;
+  }
+
+  for (i = 1; i < 250; i++) {
+    target[tpos++] = i;
+    target[tpos++] = i + 1;
+    target[tpos++] = i + 2;
+    target[tpos++] = i + 3;
+    target[tpos++] = 0;
+  }
+  for (i = 1; i < 253; i++) {
+    target[tpos++] = i;
+  }
+
+  if ((ret = xd3_encode_stream(stream, target, tpos, delta, &delta_size,
+                               sizeof(delta)))) {
+    return ret;
+  }
+
+  xd3_free_stream(stream);
+  if ((ret = xd3_config_stream(stream, &config))) {
+    return ret;
+  }
+
+  if ((ret = xd3_decode_stream(stream, delta, delta_size, recon, &recon_size,
+                               sizeof(recon)))) {
+    return ret;
+  }
+
+  CHECK(tpos == recon_size);
+  CHECK(memcmp(target, recon, recon_size) == 0);
+
+  return 0;
+}
+
+/*
+ * This tests the 32/64bit ambiguity for source-window matching.
+ */
+#if !XD3_USE_LARGESIZET
+static int test_source_cksum_offset(xd3_stream *stream, int ignore) {
+  xd3_source source;
+
+  // Inputs are:
+  struct {
+    xoff_t cpos; // stream->srcwin_cksum_pos;
+    xoff_t ipos; // stream->total_in;
+    xoff_t size; // stream->src->size;
+
+    usize_t input; // input  32-bit offset
+    xoff_t output; // output 64-bit offset
+
+  } cksum_test[] =
+      {
+          // If cpos is <= 2^32
+          {1, 1, 1, 1, 1},
+
+#if XD3_USE_LARGEFILE64
+          //    cpos            ipos            size            input output
+          //    0x____xxxxxULL, 0x____xxxxxULL, 0x____xxxxxULL, 0x___xxxxxUL,
+          //    0x____xxxxxULL
+          {0x100100000ULL, 0x100000000ULL, 0x100200000ULL, 0x00000000UL,
+           0x100000000ULL},
+          {0x100100000ULL, 0x100000000ULL, 0x100200000ULL, 0xF0000000UL,
+           0x0F0000000ULL},
+
+          {0x100200000ULL, 0x100100000ULL, 0x100200000ULL, 0x00300000UL,
+           0x000300000ULL},
+
+          {25771983104ULL, 25770000000ULL, 26414808769ULL, 2139216707UL,
+           23614053187ULL},
+
+#endif
+
+          {0, 0, 0, 0, 0},
+      },
+    *test_ptr;
+
+  stream->src = &source;
+
+  for (test_ptr = cksum_test; test_ptr->cpos; test_ptr++) {
+    xoff_t r;
+    stream->srcwin_cksum_pos = test_ptr->cpos;
+    stream->total_in = test_ptr->ipos;
+
+    r = xd3_source_cksum_offset(stream, test_ptr->input);
+    CHECK(r == test_ptr->output);
+  }
+  return 0;
+}
+#endif /* !XD3_USE_LARGESIZET */
+
+static int test_in_memory(xd3_stream *stream, int ignore) {
+  // test_text is 256 bytes
+  uint8_t ibuf[sizeof(test_text)];
+  uint8_t dbuf[sizeof(test_text)];
+  uint8_t obuf[sizeof(test_text)];
+  usize_t size = sizeof(test_text);
+  usize_t dsize, osize;
+  int r1, r2;
+  int eflags = SECONDARY_DJW ? XD3_SEC_DJW : 0;
+
+  memcpy(ibuf, test_text, size);
+  memset(ibuf + 128, 0, 16);
+
+  r1 = xd3_encode_memory(ibuf, size, test_text, size, dbuf, &dsize, size,
+                         eflags);
+
+  r2 = xd3_decode_memory(dbuf, dsize, test_text, size, obuf, &osize, size, 0);
+
+  if (r1 != 0 || r2 != 0 || dsize >= (size / 2) || dsize < 1 || osize != size) {
+    stream->msg = "encode/decode size error";
+    return XD3_INTERNAL;
+  }
+
+  if (memcmp(obuf, ibuf, size) != 0) {
+    stream->msg = "encode/decode data error";
+    return XD3_INTERNAL;
+  }
+
+  return 0;
+}
+
+/* Regression for the usize_t / xoff_t mixed-width narrowing.  On the
+ * XD3_USE_LARGESIZET=0 build usize_t is 32-bit while xoff_t stays 64-bit, so
+ * window-relative quantities must be range-checked before they are narrowed.
+ * This verifies the checked-narrowing primitive and the library-level
+ * window-size caps reject out-of-range values with a clean error instead of
+ * silently truncating. */
+static int test_usize_narrowing(xd3_stream *stream, int ignore) {
+  usize_t out = 0;
+  xd3_stream s;
+  xd3_config c;
+  xd3_source src;
+  int ret;
+
+  /* In-range offsets narrow cleanly, including the maximum. */
+  if (xd3_to_usize(0, &out) != 0 || out != 0 ||
+      xd3_to_usize((xoff_t)USIZE_T_MAX, &out) != 0 || out != USIZE_T_MAX) {
+    stream->msg = "xd3_to_usize rejected an in-range value";
+    return XD3_INTERNAL;
+  }
+
+#if SIZEOF_USIZE_T < SIZEOF_XOFF_T
+  /* An offset beyond USIZE_T_MAX is rejected, not truncated. */
+  if (xd3_to_usize((xoff_t)USIZE_T_MAX + 1, &out) != XD3_INVALID_INPUT) {
+    stream->msg = "xd3_to_usize failed to reject an overflowing value";
+    return XD3_INTERNAL;
+  }
+#endif
+
+  /* xd3_config_stream rejects a winsize beyond the source-window cap. */
+  xd3_init_config(&c, 0);
+  c.winsize = (usize_t)(XD3_MAXSRCWINSZ + 1);
+  ret = xd3_config_stream(&s, &c);
+  if (ret != XD3_INVALID) {
+    if (ret == 0) {
+      xd3_free_stream(&s);
+    }
+    stream->msg = "config_stream accepted an oversized winsize";
+    return XD3_INTERNAL;
+  }
+
+  /* xd3_set_source rejects a max_winsize beyond the source-window cap. */
+  xd3_init_config(&c, 0);
+  if ((ret = xd3_config_stream(&s, &c)) != 0) {
+    return ret;
+  }
+  memset(&src, 0, sizeof(src));
+  src.blksize = XD3_ALLOCSIZE;
+  src.max_winsize = (xoff_t)XD3_MAXSRCWINSZ + 1;
+  src.name = "";
+  ret = xd3_set_source(&s, &src);
+  xd3_free_stream(&s);
+  if (ret != XD3_INVALID) {
+    stream->msg = "set_source accepted an oversized max_winsize";
+    return XD3_INTERNAL;
+  }
+
+  return 0;
+}
+
+/***********************************************************************
+ TEST MAIN
+ ***********************************************************************/
+
+int xd3_selftest(void) {
+#define DO_TEST(fn, flags, arg)                                                \
+  do {                                                                         \
+    xd3_stream stream;                                                         \
+    xd3_config config;                                                         \
+    xd3_init_config(&config, flags);                                           \
+    XPR(NT "testing " #fn "%s...", flags ? (" (" #flags ")") : "");            \
+    if ((ret = xd3_config_stream(&stream, &config) == 0) &&                    \
+        (ret = test_##fn(&stream, arg)) == 0) {                                \
+      XPR(NTR " success\n");                                                   \
+    } else {                                                                   \
+      XPR(NTR " failed: %s: %s\n", xd3_errstring(&stream),                     \
+          xd3_mainerror(ret));                                                 \
+    }                                                                          \
+    xd3_free_stream(&stream);                                                  \
+    if (ret != 0) {                                                            \
+      goto failure;                                                            \
+    }                                                                          \
+  } while (0)
+
+  int ret;
+  DO_TEST(random_numbers, 0, 0);
+  DO_TEST(printf_xoff, 0, 0);
+
+  DO_TEST(decode_integer_end_of_input, 0, 0);
+  DO_TEST(decode_integer_overflow, 0, 0);
+  DO_TEST(encode_decode_uint32_t, 0, 0);
+  DO_TEST(encode_decode_uint64_t, 0, 0);
+  DO_TEST(usize_t_overflow, 0, 0);
+  DO_TEST(usize_narrowing, 0, 0);
+  DO_TEST(alloc_overflow, 0, 0);
+  DO_TEST(checksum_step, 0, 0);
+  DO_TEST(forward_match, 0, 0);
+  DO_TEST(address_cache, 0, 0);
+
+  DO_TEST(string_matching, 0, 0);
+  DO_TEST(choose_instruction, 0, 0);
+  DO_TEST(identical_behavior, 0, 0);
+  DO_TEST(in_memory, 0, 0);
+
+  DO_TEST(iopt_flush_instructions, 0, 0);
+#if !XD3_USE_LARGESIZET
+  DO_TEST(source_cksum_offset, 0, 0);
+#endif
+
+  DO_TEST(decompress_single_bit_error, 0, 3);
+  DO_TEST(decompress_single_bit_error, XD3_ADLER32, 3);
+
+  IF_LZMA(DO_TEST(decompress_single_bit_error, XD3_SEC_LZMA, 54));
+  IF_FGK(DO_TEST(decompress_single_bit_error, XD3_SEC_FGK, 3));
+  IF_DJW(DO_TEST(decompress_single_bit_error, XD3_SEC_DJW, 8));
+
+#if XD3_ARMOR
+  DO_TEST(armor_blake3_kat, 0, 0);
+#endif
+
+#if SHELL_TESTS
+  DO_TEST(force_behavior, 0, 0);
+  DO_TEST(stdout_behavior, 0, 0);
+  DO_TEST(no_output, 0, 0);
+  DO_TEST(appheader, 0, 0);
+  DO_TEST(command_line_arguments, 0, 0);
+  DO_TEST(srcwin_clamp, 0, 0);
+#if XD3_ARMOR
+  DO_TEST(armor, 0, 0);
+#endif
+
+#if EXTERNAL_COMPRESSION
+  DO_TEST(source_decompression, 0, 0);
+  DO_TEST(externally_compressed_io, 0, 0);
+#endif
+
+  DO_TEST(recode_command, 0, 0);
+  IF_LZMA(DO_TEST(secondary_lzma_default, 0, 0));
+#endif
+
+  IF_LZMA(DO_TEST(secondary_lzma, 0, 1));
+  IF_DJW(DO_TEST(secondary_huff, 0, DJW_MAX_GROUPS));
+  IF_FGK(DO_TEST(secondary_fgk, 0, 1));
+
+  DO_TEST(compressed_stream_overflow, 0, 0);
+  IF_LZMA(DO_TEST(compressed_stream_overflow, XD3_SEC_LZMA, 0));
+
+failure:
+  test_cleanup();
+  return ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+#undef DO_TEST
+}

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3.c
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3.c
@@ -1,0 +1,4406 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   -------------------------------------------------------------------
+
+                               Xdelta 3
+
+   The goal of this library is to to implement both the (stand-alone)
+   data-compression and delta-compression aspects of VCDIFF encoding, and
+   to support a programming interface that works like Zlib
+   (http://www.gzip.org/zlib.html). See RFC3284: The VCDIFF Generic
+   Differencing and Compression Data Format.
+
+   VCDIFF is a unified encoding that combines data-compression and
+   delta-encoding ("differencing").
+
+   VCDIFF has a detailed byte-code instruction set with many features.
+   The instruction format supports an immediate size operand for small
+   COPYs and ADDs (e.g., under 18 bytes).  There are also instruction
+   "modes", which are used to compress COPY addresses by using two
+   address caches.  An instruction mode refers to slots in the NEAR
+   and SAME caches for recent addresses.  NEAR remembers the
+   previous 4 (by default) COPY addresses, and SAME catches
+   frequent re-uses of the same address using a 3-way (by default)
+   256-entry associative cache of [ADDR mod 256], the encoded byte.
+   A hit in the NEAR/SAME cache requires 0/1 ADDR bytes.
+
+   VCDIFF has a default instruction table, but an alternate
+   instruction tables may themselves be be delta-compressed and
+   included in the encoding header.  This allows even more freedom.
+   There are 9 instruction modes in the default code table, 4 near, 3
+   same, VCD_SELF (absolute encoding) and VCD_HERE (relative to the
+   current position).
+
+   ----------------------------------------------------------------------
+
+                              Algorithms
+
+   Aside from the details of encoding and decoding, there are a bunch
+   of algorithms needed.
+
+   1. STRING-MATCH.  A two-level fingerprinting approach is used.  A
+   single loop computes the two checksums -- small and large -- at
+   successive offsets in the TARGET file.  The large checksum is more
+   accurate and is used to discover SOURCE matches, which are
+   potentially very long.  The small checksum is used to discover
+   copies within the TARGET.  Small matching, which is more expensive,
+   usually dominates the large STRING-MATCH costs in this code - the
+   more exhaustive the search, the better the results.  Either of the
+   two string-matching mechanisms may be disabled.
+
+   2. INSTRUCTION SELECTION.  The IOPT buffer here represents a queue
+   used to store overlapping copy instructions.  There are two possible
+   optimizations that go beyond a greedy search.  Both of these fall
+   into the category of "non-greedy matching" optimizations.
+
+   The first optimization stems from backward SOURCE-COPY matching.
+   When a new SOURCE-COPY instruction covers a previous instruction in
+   the target completely, it is erased from the queue.  Randal Burns
+   originally analyzed these algorithms and did a lot of related work
+   (\cite the 1.5-pass algorithm).
+
+   The second optimization comes by the encoding of common very-small
+   COPY and ADD instructions, for which there are special DOUBLE-code
+   instructions, which code two instructions in a single byte.
+
+   The cost of bad instruction-selection overhead is relatively high
+   for data-compression, relative to delta-compression, so this second
+   optimization is fairly important.  With "lazy" matching (the name
+   used in Zlib for a similar optimization), the string-match
+   algorithm searches after a match for potential overlapping copy
+   instructions.  In Xdelta and by default, VCDIFF, the minimum match
+   size is 4 bytes, whereas Zlib searches with a 3-byte minimum.  This
+   feature, combined with double instructions, provides a nice
+   challenge.  Search in this file for "black magic", a heuristic.
+
+   3. STREAM ALIGNMENT.  Stream alignment is needed to compress large
+   inputs in constant space.  See xd3_srcwin_move_point().
+
+   4. WINDOW SELECTION.  When the IOPT buffer flushes, in the first call
+   to xd3_iopt_finish_encoding containing any kind of copy instruction,
+   the parameters of the source window must be decided: the offset into
+   the source and the length of the window.  Since the IOPT buffer is
+   finite, the program may be forced to fix these values before knowing
+   the best offset/length.
+
+   5. SECONDARY COMPRESSION.  VCDIFF supports a secondary encoding to
+   be applied to the individual sections of the data format, which are
+   ADDRess, INSTruction, and DATA.  Several secondary compressor
+   variations are implemented here, although none is standardized yet.
+
+   One is an adaptive huffman algorithm -- the FGK algorithm (Faller,
+   Gallager, and Knuth, 1985).  This compressor is extremely slow.
+
+   The other is a simple static Huffman routine, which is the base
+   case of a semi-adaptive scheme published by D.J. Wheeler and first
+   widely used in bzip2 (by Julian Seward).  This is a very
+   interesting algorithm, originally published in nearly cryptic form
+   by D.J. Wheeler. !!!NOTE!!! Because these are not standardized,
+   secondary compression remains off by default.
+   ftp://ftp.cl.cam.ac.uk/users/djw3/bred3.{c,ps}
+   --------------------------------------------------------------------
+
+                            Other Features
+
+   1. USER CONVENIENCE
+
+   For user convenience, it is essential to recognize Gzip-compressed
+   files and automatically Gzip-decompress them prior to
+   delta-compression (or else no delta-compression will be achieved
+   unless the user manually decompresses the inputs).  The compressed
+   represention competes with Xdelta, and this must be hidden from the
+   command-line user interface.  The Xdelta-1.x encoding was simple, not
+   compressed itself, so Xdelta-1.x uses Zlib internally to compress the
+   representation.
+
+   This implementation supports external compression, which implements
+   the necessary fork() and pipe() mechanics.  There is a tricky step
+   involved to support automatic detection of a compressed input in a
+   non-seekable input.  First you read a bit of the input to detect
+   magic headers.  When a compressed format is recognized, exec() the
+   external compression program and create a second child process to
+   copy the original input stream. [Footnote: There is a difficulty
+   related to using Gzip externally. It is not possible to decompress
+   and recompress a Gzip file transparently.  If FILE.GZ had a
+   cryptographic signature, then, after: (1) Gzip-decompression, (2)
+   Xdelta-encoding, (3) Gzip-compression the signature could be
+   broken.  The only way to solve this problem is to guess at Gzip's
+   compression level or control it by other means.  I recommend that
+   specific implementations of any compression scheme store
+   information needed to exactly re-compress the input, that way
+   external compression is transparent - however, this won't happen
+   here until it has stabilized.]
+
+   2. APPLICATION-HEADER
+
+   This feature was introduced in RFC3284.  It allows any application
+   to include a header within the VCDIFF file format.  This allows
+   general inter-application data exchange with support for
+   application-specific extensions to communicate metadata.
+
+   3. VCDIFF CHECKSUM
+
+   An optional checksum value is included with each window, which can
+   be used to validate the final result.  This verifies the correct source
+   file was used for decompression as well as the obvious advantage:
+   checking the implementation (and underlying) correctness.
+
+   4. LIGHT WEIGHT
+
+   The code makes efforts to avoid copying data more than necessary.
+   The code delays many initialization tasks until the first use, it
+   optimizes for identical (perfectly matching) inputs.  It does not
+   compute any checksums until the first lookup misses.  Memory usage
+   is reduced.  String-matching is templatized (by slightly gross use
+   of CPP) to hard-code alternative compile-time defaults.  The code
+   has few outside dependencies.
+   ----------------------------------------------------------------------
+
+                The default rfc3284 instruction table:
+                    (see RFC for the explanation)
+
+           TYPE      SIZE     MODE    TYPE     SIZE     MODE     INDEX
+   --------------------------------------------------------------------
+       1.  Run         0        0     Noop       0        0        0
+       2.  Add    0, [1,17]     0     Noop       0        0      [1,18]
+       3.  Copy   0, [4,18]     0     Noop       0        0     [19,34]
+       4.  Copy   0, [4,18]     1     Noop       0        0     [35,50]
+       5.  Copy   0, [4,18]     2     Noop       0        0     [51,66]
+       6.  Copy   0, [4,18]     3     Noop       0        0     [67,82]
+       7.  Copy   0, [4,18]     4     Noop       0        0     [83,98]
+       8.  Copy   0, [4,18]     5     Noop       0        0     [99,114]
+       9.  Copy   0, [4,18]     6     Noop       0        0    [115,130]
+      10.  Copy   0, [4,18]     7     Noop       0        0    [131,146]
+      11.  Copy   0, [4,18]     8     Noop       0        0    [147,162]
+      12.  Add       [1,4]      0     Copy     [4,6]      0    [163,174]
+      13.  Add       [1,4]      0     Copy     [4,6]      1    [175,186]
+      14.  Add       [1,4]      0     Copy     [4,6]      2    [187,198]
+      15.  Add       [1,4]      0     Copy     [4,6]      3    [199,210]
+      16.  Add       [1,4]      0     Copy     [4,6]      4    [211,222]
+      17.  Add       [1,4]      0     Copy     [4,6]      5    [223,234]
+      18.  Add       [1,4]      0     Copy       4        6    [235,238]
+      19.  Add       [1,4]      0     Copy       4        7    [239,242]
+      20.  Add       [1,4]      0     Copy       4        8    [243,246]
+      21.  Copy        4      [0,8]   Add        1        0    [247,255]
+   --------------------------------------------------------------------
+
+                     Reading the source: Overview
+
+   This file includes itself in several passes to macro-expand certain
+   sections with variable forms.  Just read ahead, there's only a
+   little confusion.  I know this sounds ugly, but hard-coding some of
+   the string-matching parameters results in a 10-15% increase in
+   string-match performance.  The only time this hurts is when you have
+   unbalanced #if/endifs.
+
+   A single compilation unit tames the Makefile.  In short, this is to
+   allow the above-described hack without an explodingMakefile.  The
+   single compilation unit includes the core library features,
+   configurable string-match templates, optional main() command-line
+   tool, misc optional features, and a regression test.  Features are
+   controled with CPP #defines, see CMakeLists.txt.
+
+   The initial __XDELTA3_C_HEADER_PASS__ starts first, the _INLINE_ and
+   _TEMPLATE_ sections follow.  Easy stuff first, hard stuff last.
+
+   Optional features include:
+
+     xdelta3-main.h     The command-line interface, external compression
+                        support, POSIX-specific, info & VCDIFF-debug tools.
+     xdelta3-second.h   The common secondary compression routines.
+     xdelta3-decoder.h  All decoding routines.
+     xdelta3-djw.h      The semi-adaptive huffman secondary encoder.
+     xdelta3-fgk.h      The adaptive huffman secondary encoder.
+     xdelta3-test.h     The unit test covers major algorithms,
+                        encoding and decoding.  There are single-bit
+                        error decoding tests.  There are 32/64-bit file size
+                        boundary tests.  There are command-line tests.
+                        There are compression tests.  There are external
+                        compression tests.  There are string-matching tests.
+                        There should be more tests...
+
+   Additional headers include:
+
+     xdelta3.h          The public header file.
+     xdelta3-cfgs.h     The default settings for default, built-in
+                        encoders.  These are hard-coded at
+                        compile-time.  There is also a single
+                        soft-coded string matcher for experimenting
+                        with arbitrary values.
+     xdelta3-list.h     A cyclic list template
+   --------------------------------------------------------------------
+
+   This file itself is unusually large.  I hope to defend this layout
+   with lots of comments.  Everything in this file is related to
+   encoding and decoding.  I like it all together - the template stuff
+   is just a hack. */
+
+#ifndef __XDELTA3_C_HEADER_PASS__
+#define __XDELTA3_C_HEADER_PASS__
+
+#include "xdelta3.h"
+#include "xdelta3-internal.h"
+
+/***********************************************************************
+ STATIC CONFIGURATION
+ ***********************************************************************/
+
+#ifndef XD3_MAIN /* the main application */
+#define XD3_MAIN 0
+#endif
+
+#ifndef VCDIFF_TOOLS
+#define VCDIFF_TOOLS XD3_MAIN
+#endif
+
+#ifndef SECONDARY_FGK   /* one from the algorithm preservation department: */
+#define SECONDARY_FGK 0 /* adaptive Huffman routines */
+#endif
+
+#ifndef SECONDARY_DJW /* semi-adaptive/static Huffman for the eventual */
+#define SECONDARY_DJW                                                          \
+  0 /* standardization, off by default until such time.                        \
+     */
+#endif
+
+#ifndef SECONDARY_LZMA
+#ifdef HAVE_LZMA_H
+#define SECONDARY_LZMA 1
+#else
+#define SECONDARY_LZMA 0
+#endif
+#endif
+
+#if XD3_ENCODER
+#define IF_ENCODER(x) x
+#else
+#define IF_ENCODER(x)
+#endif
+
+/***********************************************************************/
+
+/* header indicator bits */
+#define VCD_SECONDARY (1U << 0) /* uses secondary compressor */
+#define VCD_CODETABLE (1U << 1) /* supplies code table data */
+#define VCD_APPHEADER (1U << 2) /* supplies application data */
+#define VCD_INVHDR (~0x7U)
+
+/* window indicator bits */
+#define VCD_SOURCE (1U << 0)  /* copy window in source file */
+#define VCD_TARGET (1U << 1)  /* copy window in target file */
+#define VCD_ADLER32 (1U << 2) /* has adler32 checksum */
+#define VCD_INVWIN (~0x7U)
+
+#define VCD_SRCORTGT (VCD_SOURCE | VCD_TARGET)
+
+/* delta indicator bits */
+#define VCD_DATACOMP (1U << 0)
+#define VCD_INSTCOMP (1U << 1)
+#define VCD_ADDRCOMP (1U << 2)
+#define VCD_INVDEL (~0x7U)
+
+typedef enum {
+  VCD_DJW_ID = 1,
+  VCD_LZMA_ID = 2,
+  VCD_FGK_ID = 16 /* Note: these are not standard IANA-allocated IDs! */
+} xd3_secondary_ids;
+
+typedef enum {
+  SEC_NOFLAGS = 0,
+
+  /* Note: SEC_COUNT_FREQS Not implemented (to eliminate 1st Huffman pass) */
+  SEC_COUNT_FREQS = (1 << 0)
+} xd3_secondary_flags;
+
+typedef enum {
+  DATA_SECTION, /* These indicate which section to the secondary
+                 * compressor. */
+  INST_SECTION, /* The header section is not compressed, therefore not
+                 * listed here. */
+  ADDR_SECTION
+} xd3_section_type;
+
+typedef unsigned int xd3_rtype;
+
+/***********************************************************************/
+
+#include "xdelta3-list.h"
+
+#if XD3_ENCODER
+XD3_MAKELIST(xd3_rlist, xd3_rinst, link);
+#endif
+
+/***********************************************************************/
+
+#define SECONDARY_MIN_SAVINGS                                                  \
+  2 /* Secondary compression has to save                                       \
+       at least this many bytes. */
+#define SECONDARY_MIN_INPUT                                                    \
+  10 /* Secondary compression needs at                                         \
+        least this many bytes. */
+
+#define VCDIFF_MAGIC1 0xd6  /* 1st file byte */
+#define VCDIFF_MAGIC2 0xc3  /* 2nd file byte */
+#define VCDIFF_MAGIC3 0xc4  /* 3rd file byte */
+#define VCDIFF_VERSION 0x00 /* 4th file byte */
+
+#define VCD_SELF 0 /* 1st address mode */
+#define VCD_HERE 1 /* 2nd address mode */
+
+#define SECONDARY_ANY (SECONDARY_DJW || SECONDARY_FGK || SECONDARY_LZMA)
+
+#define ALPHABET_SIZE                                                          \
+  256 /* Used in test code--size of the secondary                              \
+       * compressor alphabet. */
+
+#define HASH_CKOFFSET                                                          \
+  1U /* Table entries distinguish "no-entry" from                              \
+      * offset 0 using this offset. */
+
+#define MAX_MATCH_SPLIT                                                        \
+  18U /* VCDIFF code table: 18 is the default limit                            \
+       * for direct-coded ADD sizes */
+
+#define LEAST_MATCH_INCR                                                       \
+  0 /* The least number of bytes an overlapping                                \
+     * match must beat the preceding match by.  This                           \
+     * is a bias for the lazy match optimization.  A                           \
+     * non-zero value means that an adjacent match                             \
+     * has to be better by more than the step                                  \
+     * between them.  0. */
+
+#define MIN_MATCH 4U /* VCDIFF code table: MIN_MATCH=4 */
+#define MIN_RUN                                                                \
+  8U /* The shortest run, if it is shorter than this                           \
+      * an immediate add/copy will be just as good.                            \
+      * ADD1/COPY6 = 1I+1D+1A bytes, RUN18 =                                   \
+      * 1I+1D+1A. */
+
+#define MAX_MODES                                                              \
+  9 /* Maximum number of nodes used for                                        \
+     * compression--does not limit decompression. */
+
+#define ENC_SECTS 4 /* Number of separate output sections. */
+
+#define HDR_TAIL(s) ((s)->enc_tails[0])
+#define DATA_TAIL(s) ((s)->enc_tails[1])
+#define INST_TAIL(s) ((s)->enc_tails[2])
+#define ADDR_TAIL(s) ((s)->enc_tails[3])
+
+#define HDR_HEAD(s) ((s)->enc_heads[0])
+#define DATA_HEAD(s) ((s)->enc_heads[1])
+#define INST_HEAD(s) ((s)->enc_heads[2])
+#define ADDR_HEAD(s) ((s)->enc_heads[3])
+
+/* Template instances. */
+#if XD3_BUILD_SLOW
+#define IF_BUILD_SLOW(x) x
+#else
+#define IF_BUILD_SLOW(x)
+#endif
+#if XD3_BUILD_FAST
+#define IF_BUILD_FAST(x) x
+#else
+#define IF_BUILD_FAST(x)
+#endif
+#if XD3_BUILD_FASTER
+#define IF_BUILD_FASTER(x) x
+#else
+#define IF_BUILD_FASTER(x)
+#endif
+#if XD3_BUILD_FASTEST
+#define IF_BUILD_FASTEST(x) x
+#else
+#define IF_BUILD_FASTEST(x)
+#endif
+#if XD3_BUILD_SOFT
+#define IF_BUILD_SOFT(x) x
+#else
+#define IF_BUILD_SOFT(x)
+#endif
+#if XD3_BUILD_DEFAULT
+#define IF_BUILD_DEFAULT(x) x
+#else
+#define IF_BUILD_DEFAULT(x)
+#endif
+
+/* Update the run-length state */
+#define NEXTRUN(c)                                                             \
+  do {                                                                         \
+    if ((c) == run_c) {                                                        \
+      run_l += 1;                                                              \
+    } else {                                                                   \
+      run_c = (c);                                                             \
+      run_l = 1;                                                               \
+    }                                                                          \
+  } while (0)
+
+/* This CPP-conditional stuff can be cleaned up... */
+#if REGRESSION_TEST
+#define IF_REGRESSION(x) x
+#else
+#define IF_REGRESSION(x)
+#endif
+
+/***********************************************************************/
+
+#if XD3_ENCODER
+static void *xd3_alloc0(xd3_stream *stream, usize_t elts, usize_t size);
+
+static int xd3_alloc_iopt(xd3_stream *stream, usize_t elts);
+
+static void xd3_free_output(xd3_stream *stream, xd3_output *output);
+
+static int xd3_emit_double(xd3_stream *stream, xd3_rinst *first,
+                           xd3_rinst *second, uint8_t code);
+static int xd3_emit_single(xd3_stream *stream, xd3_rinst *single, uint8_t code);
+
+static usize_t xd3_sizeof_output(xd3_output *output);
+static void xd3_encode_reset(xd3_stream *stream);
+
+static int xd3_source_match_setup(xd3_stream *stream, xoff_t srcpos);
+static int xd3_source_extend_match(xd3_stream *stream);
+static int xd3_srcwin_setup(xd3_stream *stream);
+static usize_t xd3_iopt_last_matched(xd3_stream *stream);
+static int xd3_emit_uint32_t(xd3_stream *stream, xd3_output **output,
+                             uint32_t num);
+
+static usize_t xd3_smatch(xd3_stream *stream, usize_t base, usize_t scksum,
+                          usize_t *match_offset);
+static int xd3_string_match_init(xd3_stream *stream);
+static uint32_t xd3_scksum(uint32_t *state, const uint8_t *seg,
+                           const usize_t ln);
+static usize_t xd3_comprun(const uint8_t *seg, usize_t slook, uint8_t *run_cp);
+static int xd3_srcwin_move_point(xd3_stream *stream, usize_t *next_move_point);
+
+static int xd3_emit_run(xd3_stream *stream, usize_t pos, usize_t size,
+                        uint8_t *run_c);
+static xoff_t xd3_source_cksum_offset(xd3_stream *stream, usize_t low);
+static void xd3_scksum_insert(xd3_stream *stream, usize_t inx, usize_t scksum,
+                              usize_t pos);
+
+#if XD3_DEBUG
+static void xd3_verify_run_state(xd3_stream *stream, const uint8_t *inp,
+                                 usize_t x_run_l, uint8_t *x_run_c);
+static void xd3_verify_large_state(xd3_stream *stream, const uint8_t *inp,
+                                   usize_t x_cksum);
+static void xd3_verify_small_state(xd3_stream *stream, const uint8_t *inp,
+                                   uint32_t x_cksum);
+
+#endif /* XD3_DEBUG */
+#endif /* XD3_ENCODER */
+
+static int xd3_decode_allocate(xd3_stream *stream, usize_t size,
+                               uint8_t **copied1, usize_t *alloc1);
+
+static void *xd3_alloc(xd3_stream *stream, usize_t elts, usize_t size);
+static void xd3_free(xd3_stream *stream, void *ptr);
+
+const char *xd3_strerror(int ret) {
+  switch (ret) {
+  case XD3_INPUT:
+    return "XD3_INPUT";
+  case XD3_OUTPUT:
+    return "XD3_OUTPUT";
+  case XD3_GETSRCBLK:
+    return "XD3_GETSRCBLK";
+  case XD3_GOTHEADER:
+    return "XD3_GOTHEADER";
+  case XD3_WINSTART:
+    return "XD3_WINSTART";
+  case XD3_WINFINISH:
+    return "XD3_WINFINISH";
+  case XD3_TOOFARBACK:
+    return "XD3_TOOFARBACK";
+  case XD3_INTERNAL:
+    return "XD3_INTERNAL";
+  case XD3_INVALID:
+    return "XD3_INVALID";
+  case XD3_INVALID_INPUT:
+    return "XD3_INVALID_INPUT";
+  case XD3_NOSECOND:
+    return "XD3_NOSECOND";
+  case XD3_UNIMPLEMENTED:
+    return "XD3_UNIMPLEMENTED";
+  }
+  return NULL;
+}
+
+/***********************************************************************/
+
+#define xd3_sec_data(s) ((s)->sec_stream_d)
+#define xd3_sec_inst(s) ((s)->sec_stream_i)
+#define xd3_sec_addr(s) ((s)->sec_stream_a)
+
+struct _xd3_sec_type {
+  uint8_t id;
+  const char *name;
+  xd3_secondary_flags flags;
+
+  /* xd3_sec_stream is opaque to the generic code */
+  xd3_sec_stream *(*alloc)(xd3_stream *stream);
+  void (*destroy)(xd3_stream *stream, xd3_sec_stream *sec);
+  int (*init)(xd3_stream *stream, xd3_sec_stream *sec_stream, int is_encode);
+  int (*decode)(xd3_stream *stream, xd3_sec_stream *sec_stream,
+                const uint8_t **input, const uint8_t *input_end,
+                uint8_t **output, const uint8_t *output_end);
+#if XD3_ENCODER
+  int (*encode)(xd3_stream *stream, xd3_sec_stream *sec_stream,
+                xd3_output *input, xd3_output *output, xd3_sec_cfg *cfg);
+#endif
+};
+
+#define BIT_STATE_ENCODE_INIT {0, 1}
+#define BIT_STATE_DECODE_INIT {0, 0x100}
+
+typedef struct _bit_state bit_state;
+struct _bit_state {
+  uint8_t cur_byte;
+  usize_t cur_mask;
+};
+
+#if SECONDARY_ANY == 0
+#define IF_SEC(x)
+#define IF_NSEC(x) x
+#else /* yuck */
+#define IF_SEC(x) x
+#define IF_NSEC(x)
+static int xd3_decode_secondary(xd3_stream *stream, xd3_desect *sect,
+                                xd3_sec_stream **sec_streamp);
+#if XD3_ENCODER
+static int xd3_encode_secondary(xd3_stream *stream, xd3_output **head,
+                                xd3_output **tail, xd3_sec_stream **sec_streamp,
+                                xd3_sec_cfg *cfg, int *did_it);
+#endif
+#endif /* SECONDARY_ANY */
+
+#if SECONDARY_FGK
+extern const xd3_sec_type fgk_sec_type;
+#define IF_FGK(x) x
+#define FGK_CASE(s)                                                            \
+  s->sec_type = &fgk_sec_type;                                                 \
+  break;
+#else
+#define IF_FGK(x)
+#define FGK_CASE(s)                                                            \
+  s->msg = "unavailable secondary compressor: FGK Adaptive Huffman";           \
+  return XD3_INTERNAL;
+#endif
+
+#if SECONDARY_DJW
+extern const xd3_sec_type djw_sec_type;
+#define IF_DJW(x) x
+#define DJW_CASE(s)                                                            \
+  s->sec_type = &djw_sec_type;                                                 \
+  break;
+#else
+#define IF_DJW(x)
+#define DJW_CASE(s)                                                            \
+  s->msg = "unavailable secondary compressor: DJW Static Huffman";             \
+  return XD3_INTERNAL;
+#endif
+
+#if SECONDARY_LZMA
+extern const xd3_sec_type lzma_sec_type;
+#define IF_LZMA(x) x
+#define LZMA_CASE(s)                                                           \
+  s->sec_type = &lzma_sec_type;                                                \
+  break;
+#else
+#define IF_LZMA(x)
+#define LZMA_CASE(s)                                                           \
+  s->msg = "unavailable secondary compressor: LZMA";                           \
+  return XD3_INTERNAL;
+#endif
+
+/***********************************************************************/
+
+#include "xdelta3-hash.h"
+
+/* Process template passes - this includes xdelta3.c several times. */
+#define __XDELTA3_C_TEMPLATE_PASS__
+#include "xdelta3-cfgs.h"
+#undef __XDELTA3_C_TEMPLATE_PASS__
+
+/* Process the inline pass. */
+#define __XDELTA3_C_INLINE_PASS__
+#include "xdelta3.c"
+#undef __XDELTA3_C_INLINE_PASS__
+
+/* Secondary compression */
+#if SECONDARY_ANY
+#include "xdelta3-second.h"
+#endif
+
+#if SECONDARY_FGK
+#include "xdelta3-fgk.h"
+const xd3_sec_type fgk_sec_type = {
+    VCD_FGK_ID,
+    "FGK Adaptive Huffman",
+    SEC_NOFLAGS,
+    (xd3_sec_stream * (*)(xd3_stream *)) fgk_alloc,
+    (void (*)(xd3_stream *, xd3_sec_stream *))fgk_destroy,
+    (int (*)(xd3_stream *, xd3_sec_stream *, int))fgk_init,
+    (int (*)(xd3_stream *, xd3_sec_stream *, const uint8_t **, const uint8_t *,
+             uint8_t **, const uint8_t *))xd3_decode_fgk,
+    IF_ENCODER((int (*)(xd3_stream *, xd3_sec_stream *, xd3_output *,
+                        xd3_output *, xd3_sec_cfg *))xd3_encode_fgk)};
+#endif
+
+#if SECONDARY_DJW
+#include "xdelta3-djw.h"
+const xd3_sec_type djw_sec_type = {
+    VCD_DJW_ID,
+    "Static Huffman",
+    SEC_COUNT_FREQS,
+    (xd3_sec_stream * (*)(xd3_stream *)) djw_alloc,
+    (void (*)(xd3_stream *, xd3_sec_stream *))djw_destroy,
+    (int (*)(xd3_stream *, xd3_sec_stream *, int))djw_init,
+    (int (*)(xd3_stream *, xd3_sec_stream *, const uint8_t **, const uint8_t *,
+             uint8_t **, const uint8_t *))xd3_decode_huff,
+    IF_ENCODER((int (*)(xd3_stream *, xd3_sec_stream *, xd3_output *,
+                        xd3_output *, xd3_sec_cfg *))xd3_encode_huff)};
+#endif
+
+#if SECONDARY_LZMA
+#include "xdelta3-lzma.h"
+const xd3_sec_type lzma_sec_type = {
+    VCD_LZMA_ID,
+    "lzma",
+    SEC_NOFLAGS,
+    (xd3_sec_stream * (*)(xd3_stream *)) xd3_lzma_alloc,
+    (void (*)(xd3_stream *, xd3_sec_stream *))xd3_lzma_destroy,
+    (int (*)(xd3_stream *, xd3_sec_stream *, int))xd3_lzma_init,
+    (int (*)(xd3_stream *, xd3_sec_stream *, const uint8_t **, const uint8_t *,
+             uint8_t **, const uint8_t *))xd3_decode_lzma,
+    IF_ENCODER((int (*)(xd3_stream *, xd3_sec_stream *, xd3_output *,
+                        xd3_output *, xd3_sec_cfg *))xd3_encode_lzma)};
+#endif
+
+#if XD3_MAIN || PYTHON_MODULE || SWIG_MODULE || NOT_MAIN
+#include "xdelta3-main.h"
+#endif
+
+#if REGRESSION_TEST
+#include "xdelta3-test.h"
+#endif
+
+#endif /* __XDELTA3_C_HEADER_PASS__ */
+#ifdef __XDELTA3_C_INLINE_PASS__
+
+/****************************************************************
+ Instruction tables
+ *****************************************************************/
+
+/* The following code implements a parametrized description of the
+ * code table given above for a few reasons.  It is not necessary for
+ * implementing the standard, to support compression with variable
+ * tables, so an implementation is only required to know the default
+ * code table to begin decompression.  (If the encoder uses an
+ * alternate table, the table is included in compressed form inside
+ * the VCDIFF file.)
+ *
+ * Before adding variable-table support there were two functions which
+ * were hard-coded to the default table above.
+ * xd3_compute_default_table() would create the default table by
+ * filling a 256-elt array of xd3_dinst values.  The corresponding
+ * function, xd3_choose_instruction(), would choose an instruction
+ * based on the hard-coded parameters of the default code table.
+ *
+ * Notes: The parametrized code table description here only generates
+ * tables of a certain regularity similar to the default table by
+ * allowing to vary the distribution of single- and
+ * double-instructions and change the number of near and same copy
+ * modes.  More exotic tables are only possible by extending this
+ * code.
+ *
+ * For performance reasons, both the parametrized and non-parametrized
+ * versions of xd3_choose_instruction remain.  The parametrized
+ * version is only needed for testing multi-table decoding support.
+ * If ever multi-table encoding is required, this can be optimized by
+ * compiling static functions for each table.
+ */
+
+/* The XD3_CHOOSE_INSTRUCTION calls xd3_choose_instruction with the
+ * table description when GENERIC_ENCODE_TABLES are in use.  The
+ * IF_GENCODETBL macro enables generic-code-table specific code
+ * (removed 10/2014). */
+#define XD3_CHOOSE_INSTRUCTION(stream, prev, inst)                             \
+  xd3_choose_instruction(prev, inst)
+
+/* This structure maintains information needed by
+ * xd3_choose_instruction to compute the code for a double instruction
+ * by first indexing an array of code_table_sizes by copy mode, then
+ * using (offset + (muliplier * X)) */
+struct _xd3_code_table_sizes {
+  uint8_t cpy_max;
+  uint8_t offset;
+  uint8_t mult;
+};
+
+/* This contains a complete description of a code table. */
+struct _xd3_code_table_desc {
+  /* Assumes a single RUN instruction */
+  /* Assumes that MIN_MATCH is 4 */
+
+  uint8_t add_sizes;  /* Number of immediate-size single
+                         adds (default 17) */
+  uint8_t near_modes; /* Number of near copy modes (default 4) */
+  uint8_t same_modes; /* Number of same copy modes (default 3) */
+  uint8_t cpy_sizes;  /* Number of immediate-size single
+                         copies (default 15) */
+
+  uint8_t addcopy_add_max;      /* Maximum add size for an add-copy
+                                   double instruction, all modes
+                                   (default 4) */
+  uint8_t addcopy_near_cpy_max; /* Maximum cpy size for an add-copy
+                                   double instruction, up through
+                                   VCD_NEAR modes (default 6) */
+  uint8_t addcopy_same_cpy_max; /* Maximum cpy size for an add-copy
+                                   double instruction, VCD_SAME modes
+                                   (default 4) */
+
+  uint8_t copyadd_add_max;      /* Maximum add size for a copy-add
+                                   double instruction, all modes
+                                   (default 1) */
+  uint8_t copyadd_near_cpy_max; /* Maximum cpy size for a copy-add
+                                   double instruction, up through
+                                   VCD_NEAR modes (default 4) */
+  uint8_t copyadd_same_cpy_max; /* Maximum cpy size for a copy-add
+                                   double instruction, VCD_SAME modes
+                                   (default 4) */
+
+  xd3_code_table_sizes addcopy_max_sizes[MAX_MODES];
+  xd3_code_table_sizes copyadd_max_sizes[MAX_MODES];
+};
+
+/* The rfc3284 code table is represented: */
+static const xd3_code_table_desc __rfc3284_code_table_desc = {
+    17, /* add sizes */
+    4,  /* near modes */
+    3,  /* same modes */
+    15, /* copy sizes */
+
+    4, /* add-copy max add */
+    6, /* add-copy max cpy, near */
+    4, /* add-copy max cpy, same */
+
+    1, /* copy-add max add */
+    4, /* copy-add max cpy, near */
+    4, /* copy-add max cpy, same */
+
+    /* addcopy */
+    {{6, 163, 3},
+     {6, 175, 3},
+     {6, 187, 3},
+     {6, 199, 3},
+     {6, 211, 3},
+     {6, 223, 3},
+     {4, 235, 1},
+     {4, 239, 1},
+     {4, 243, 1}},
+    /* copyadd */
+    {{4, 247, 1},
+     {4, 248, 1},
+     {4, 249, 1},
+     {4, 250, 1},
+     {4, 251, 1},
+     {4, 252, 1},
+     {4, 253, 1},
+     {4, 254, 1},
+     {4, 255, 1}},
+};
+
+/* Computes code table entries of TBL using the specified description. */
+static void xd3_build_code_table(const xd3_code_table_desc *desc,
+                                 xd3_dinst *tbl) {
+  uint8_t size1, size2;
+  uint8_t mode;
+  usize_t cpy_modes = 2U + desc->near_modes + desc->same_modes;
+  xd3_dinst *d = tbl;
+
+  (d++)->type1 = XD3_RUN;
+  (d++)->type1 = XD3_ADD;
+
+  for (size1 = 1; size1 <= desc->add_sizes; size1 += 1, d += 1) {
+    d->type1 = XD3_ADD;
+    d->size1 = size1;
+  }
+
+  for (mode = 0; mode < cpy_modes; mode += 1) {
+    (d++)->type1 = XD3_CPY + mode;
+
+    for (size1 = MIN_MATCH; size1 < MIN_MATCH + desc->cpy_sizes;
+         size1 += 1, d += 1) {
+      d->type1 = XD3_CPY + mode;
+      d->size1 = size1;
+    }
+  }
+
+  for (mode = 0; mode < cpy_modes; mode += 1) {
+    for (size1 = 1; size1 <= desc->addcopy_add_max; size1 += 1) {
+      usize_t max = (mode < 2U + desc->near_modes) ? desc->addcopy_near_cpy_max
+                                                   : desc->addcopy_same_cpy_max;
+
+      for (size2 = MIN_MATCH; size2 <= max; size2 += 1, d += 1) {
+        d->type1 = XD3_ADD;
+        d->size1 = size1;
+        d->type2 = XD3_CPY + mode;
+        d->size2 = size2;
+      }
+    }
+  }
+
+  for (mode = 0; mode < cpy_modes; mode += 1) {
+    usize_t max = (mode < 2U + desc->near_modes) ? desc->copyadd_near_cpy_max
+                                                 : desc->copyadd_same_cpy_max;
+
+    for (size1 = MIN_MATCH; size1 <= max; size1 += 1) {
+      for (size2 = 1; size2 <= desc->copyadd_add_max; size2 += 1, d += 1) {
+        d->type1 = XD3_CPY + mode;
+        d->size1 = size1;
+        d->type2 = XD3_ADD;
+        d->size2 = size2;
+      }
+    }
+  }
+
+  XD3_ASSERT(d - tbl == 256);
+}
+
+/* The default RFC 3284 code table, expanded at compile time from
+   __rfc3284_code_table_desc by xd3_build_code_table.  It is fully constant so
+   it needs no lazy initialization and is safe to share across threads/streams.
+   xd3_verify_rfc3284_code_table (debug builds only) checks it still matches
+   xd3_build_code_table, guarding against drift in the table description. */
+static const xd3_dinst __rfc3284_code_table[256] = {
+    {2, 0, 0, 0},   {1, 0, 0, 0},   {1, 1, 0, 0},   {1, 2, 0, 0},
+    {1, 3, 0, 0},   {1, 4, 0, 0},   {1, 5, 0, 0},   {1, 6, 0, 0},
+    {1, 7, 0, 0},   {1, 8, 0, 0},   {1, 9, 0, 0},   {1, 10, 0, 0},
+    {1, 11, 0, 0},  {1, 12, 0, 0},  {1, 13, 0, 0},  {1, 14, 0, 0},
+    {1, 15, 0, 0},  {1, 16, 0, 0},  {1, 17, 0, 0},  {3, 0, 0, 0},
+    {3, 4, 0, 0},   {3, 5, 0, 0},   {3, 6, 0, 0},   {3, 7, 0, 0},
+    {3, 8, 0, 0},   {3, 9, 0, 0},   {3, 10, 0, 0},  {3, 11, 0, 0},
+    {3, 12, 0, 0},  {3, 13, 0, 0},  {3, 14, 0, 0},  {3, 15, 0, 0},
+    {3, 16, 0, 0},  {3, 17, 0, 0},  {3, 18, 0, 0},  {4, 0, 0, 0},
+    {4, 4, 0, 0},   {4, 5, 0, 0},   {4, 6, 0, 0},   {4, 7, 0, 0},
+    {4, 8, 0, 0},   {4, 9, 0, 0},   {4, 10, 0, 0},  {4, 11, 0, 0},
+    {4, 12, 0, 0},  {4, 13, 0, 0},  {4, 14, 0, 0},  {4, 15, 0, 0},
+    {4, 16, 0, 0},  {4, 17, 0, 0},  {4, 18, 0, 0},  {5, 0, 0, 0},
+    {5, 4, 0, 0},   {5, 5, 0, 0},   {5, 6, 0, 0},   {5, 7, 0, 0},
+    {5, 8, 0, 0},   {5, 9, 0, 0},   {5, 10, 0, 0},  {5, 11, 0, 0},
+    {5, 12, 0, 0},  {5, 13, 0, 0},  {5, 14, 0, 0},  {5, 15, 0, 0},
+    {5, 16, 0, 0},  {5, 17, 0, 0},  {5, 18, 0, 0},  {6, 0, 0, 0},
+    {6, 4, 0, 0},   {6, 5, 0, 0},   {6, 6, 0, 0},   {6, 7, 0, 0},
+    {6, 8, 0, 0},   {6, 9, 0, 0},   {6, 10, 0, 0},  {6, 11, 0, 0},
+    {6, 12, 0, 0},  {6, 13, 0, 0},  {6, 14, 0, 0},  {6, 15, 0, 0},
+    {6, 16, 0, 0},  {6, 17, 0, 0},  {6, 18, 0, 0},  {7, 0, 0, 0},
+    {7, 4, 0, 0},   {7, 5, 0, 0},   {7, 6, 0, 0},   {7, 7, 0, 0},
+    {7, 8, 0, 0},   {7, 9, 0, 0},   {7, 10, 0, 0},  {7, 11, 0, 0},
+    {7, 12, 0, 0},  {7, 13, 0, 0},  {7, 14, 0, 0},  {7, 15, 0, 0},
+    {7, 16, 0, 0},  {7, 17, 0, 0},  {7, 18, 0, 0},  {8, 0, 0, 0},
+    {8, 4, 0, 0},   {8, 5, 0, 0},   {8, 6, 0, 0},   {8, 7, 0, 0},
+    {8, 8, 0, 0},   {8, 9, 0, 0},   {8, 10, 0, 0},  {8, 11, 0, 0},
+    {8, 12, 0, 0},  {8, 13, 0, 0},  {8, 14, 0, 0},  {8, 15, 0, 0},
+    {8, 16, 0, 0},  {8, 17, 0, 0},  {8, 18, 0, 0},  {9, 0, 0, 0},
+    {9, 4, 0, 0},   {9, 5, 0, 0},   {9, 6, 0, 0},   {9, 7, 0, 0},
+    {9, 8, 0, 0},   {9, 9, 0, 0},   {9, 10, 0, 0},  {9, 11, 0, 0},
+    {9, 12, 0, 0},  {9, 13, 0, 0},  {9, 14, 0, 0},  {9, 15, 0, 0},
+    {9, 16, 0, 0},  {9, 17, 0, 0},  {9, 18, 0, 0},  {10, 0, 0, 0},
+    {10, 4, 0, 0},  {10, 5, 0, 0},  {10, 6, 0, 0},  {10, 7, 0, 0},
+    {10, 8, 0, 0},  {10, 9, 0, 0},  {10, 10, 0, 0}, {10, 11, 0, 0},
+    {10, 12, 0, 0}, {10, 13, 0, 0}, {10, 14, 0, 0}, {10, 15, 0, 0},
+    {10, 16, 0, 0}, {10, 17, 0, 0}, {10, 18, 0, 0}, {11, 0, 0, 0},
+    {11, 4, 0, 0},  {11, 5, 0, 0},  {11, 6, 0, 0},  {11, 7, 0, 0},
+    {11, 8, 0, 0},  {11, 9, 0, 0},  {11, 10, 0, 0}, {11, 11, 0, 0},
+    {11, 12, 0, 0}, {11, 13, 0, 0}, {11, 14, 0, 0}, {11, 15, 0, 0},
+    {11, 16, 0, 0}, {11, 17, 0, 0}, {11, 18, 0, 0}, {1, 1, 3, 4},
+    {1, 1, 3, 5},   {1, 1, 3, 6},   {1, 2, 3, 4},   {1, 2, 3, 5},
+    {1, 2, 3, 6},   {1, 3, 3, 4},   {1, 3, 3, 5},   {1, 3, 3, 6},
+    {1, 4, 3, 4},   {1, 4, 3, 5},   {1, 4, 3, 6},   {1, 1, 4, 4},
+    {1, 1, 4, 5},   {1, 1, 4, 6},   {1, 2, 4, 4},   {1, 2, 4, 5},
+    {1, 2, 4, 6},   {1, 3, 4, 4},   {1, 3, 4, 5},   {1, 3, 4, 6},
+    {1, 4, 4, 4},   {1, 4, 4, 5},   {1, 4, 4, 6},   {1, 1, 5, 4},
+    {1, 1, 5, 5},   {1, 1, 5, 6},   {1, 2, 5, 4},   {1, 2, 5, 5},
+    {1, 2, 5, 6},   {1, 3, 5, 4},   {1, 3, 5, 5},   {1, 3, 5, 6},
+    {1, 4, 5, 4},   {1, 4, 5, 5},   {1, 4, 5, 6},   {1, 1, 6, 4},
+    {1, 1, 6, 5},   {1, 1, 6, 6},   {1, 2, 6, 4},   {1, 2, 6, 5},
+    {1, 2, 6, 6},   {1, 3, 6, 4},   {1, 3, 6, 5},   {1, 3, 6, 6},
+    {1, 4, 6, 4},   {1, 4, 6, 5},   {1, 4, 6, 6},   {1, 1, 7, 4},
+    {1, 1, 7, 5},   {1, 1, 7, 6},   {1, 2, 7, 4},   {1, 2, 7, 5},
+    {1, 2, 7, 6},   {1, 3, 7, 4},   {1, 3, 7, 5},   {1, 3, 7, 6},
+    {1, 4, 7, 4},   {1, 4, 7, 5},   {1, 4, 7, 6},   {1, 1, 8, 4},
+    {1, 1, 8, 5},   {1, 1, 8, 6},   {1, 2, 8, 4},   {1, 2, 8, 5},
+    {1, 2, 8, 6},   {1, 3, 8, 4},   {1, 3, 8, 5},   {1, 3, 8, 6},
+    {1, 4, 8, 4},   {1, 4, 8, 5},   {1, 4, 8, 6},   {1, 1, 9, 4},
+    {1, 2, 9, 4},   {1, 3, 9, 4},   {1, 4, 9, 4},   {1, 1, 10, 4},
+    {1, 2, 10, 4},  {1, 3, 10, 4},  {1, 4, 10, 4},  {1, 1, 11, 4},
+    {1, 2, 11, 4},  {1, 3, 11, 4},  {1, 4, 11, 4},  {3, 4, 1, 1},
+    {4, 4, 1, 1},   {5, 4, 1, 1},   {6, 4, 1, 1},   {7, 4, 1, 1},
+    {8, 4, 1, 1},   {9, 4, 1, 1},   {10, 4, 1, 1},  {11, 4, 1, 1},
+};
+
+#if XD3_DEBUG
+static void xd3_verify_rfc3284_code_table(void) {
+  xd3_dinst built[256];
+  memset(built, 0, sizeof(built));
+  xd3_build_code_table(&__rfc3284_code_table_desc, built);
+  XD3_ASSERT(memcmp(built, __rfc3284_code_table, sizeof(built)) == 0);
+}
+#endif
+
+/* Returns the static default code table. */
+static const xd3_dinst *xd3_rfc3284_code_table(void) {
+  IF_DEBUG(xd3_verify_rfc3284_code_table());
+  return __rfc3284_code_table;
+}
+
+#if XD3_ENCODER
+/* This version of xd3_choose_instruction is hard-coded for the default
+   table. */
+static void xd3_choose_instruction(xd3_rinst *prev, xd3_rinst *inst) {
+  switch (inst->type) {
+  case XD3_RUN:
+    inst->code1 = 0;
+    break;
+
+  case XD3_ADD:
+    inst->code1 = 1;
+
+    if (inst->size <= 17) {
+      inst->code1 += (uint8_t)inst->size;
+
+      if ((inst->size == 1) && (prev != NULL) && (prev->size == 4) &&
+          (prev->type >= XD3_CPY)) {
+        prev->code2 = 247 + (prev->type - XD3_CPY);
+      }
+    }
+
+    break;
+
+  default: {
+    uint8_t mode = inst->type - XD3_CPY;
+
+    XD3_ASSERT(inst->type >= XD3_CPY && inst->type < 12);
+
+    inst->code1 = 19 + 16 * mode;
+
+    if (inst->size <= 18 && inst->size >= 4) {
+      inst->code1 += (uint8_t)(inst->size - 3);
+
+      if ((prev != NULL) && (prev->type == XD3_ADD) && (prev->size <= 4)) {
+        if ((inst->size <= 6) && (mode <= 5)) {
+          prev->code2 = (uint8_t)(163 + (mode * 12) + (3 * (prev->size - 1)) +
+                                  (inst->size - 4));
+          XD3_ASSERT(prev->code2 <= 234);
+        } else if ((inst->size == 4) && (mode >= 6)) {
+          prev->code2 = (uint8_t)(235 + ((mode - 6) * 4) + (prev->size - 1));
+
+          XD3_ASSERT(prev->code2 <= 246);
+        }
+      }
+    }
+
+    XD3_ASSERT(inst->code1 <= 162);
+  } break;
+  }
+}
+#endif /* XD3_ENCODER */
+
+/***********************************************************************/
+
+static inline void xd3_swap_uint8p(uint8_t **p1, uint8_t **p2) {
+  uint8_t *t = (*p1);
+  (*p1) = (*p2);
+  (*p2) = t;
+}
+
+static inline void xd3_swap_usize_t(usize_t *p1, usize_t *p2) {
+  usize_t t = (*p1);
+  (*p1) = (*p2);
+  (*p2) = t;
+}
+
+/* It's not constant time, but it computes the log. */
+static int xd3_check_pow2(xoff_t value, usize_t *logof) {
+  xoff_t x = 1;
+  usize_t nolog;
+  if (logof == NULL) {
+    logof = &nolog;
+  }
+
+  *logof = 0;
+
+  for (; x != 0; x <<= 1, *logof += 1) {
+    if (x == value) {
+      return 0;
+    }
+  }
+
+  return XD3_INTERNAL;
+}
+
+usize_t xd3_pow2_roundup(usize_t x) {
+  usize_t i = 1;
+  while (x > i) {
+    i <<= 1U;
+  }
+  return i;
+}
+
+static xoff_t xd3_xoff_roundup(xoff_t x) {
+  xoff_t i = 1;
+  while (x > i) {
+    i <<= 1U;
+  }
+  return i;
+}
+
+static usize_t xd3_round_blksize(usize_t sz, usize_t blksz) {
+  usize_t mod;
+  usize_t add;
+
+  XD3_ASSERT(xd3_check_pow2(blksz, NULL) == 0);
+
+  /* A zero blocksize would underflow the mask below; leave sz
+   * unchanged rather than corrupt the arithmetic. */
+  if (blksz == 0) {
+    return sz;
+  }
+
+  mod = sz & (blksz - 1);
+
+  if (mod == 0) {
+    return sz;
+  }
+
+  add = blksz - mod;
+
+  /* Rounding up must never wrap past USIZE_T_MAX.  A wrapped result
+   * would be smaller than sz and cause the caller to under-allocate.
+   * When the rounded value would overflow, return sz, which is itself
+   * a valid size and the largest we can guarantee is not smaller than
+   * requested. */
+  if (USIZE_T_OVERFLOW(sz, add)) {
+    return sz;
+  }
+
+  return sz + add;
+}
+
+/***********************************************************************
+ Adler32 stream function: code copied from Zlib, defined in RFC1950
+ ***********************************************************************/
+
+#define A32_BASE 65521L /* Largest prime smaller than 2^16 */
+#define A32_NMAX                                                               \
+  5552 /* NMAX is the largest n such that 255n(n+1)/2                          \
+          + (n+1)(BASE-1) <= 2^32-1 */
+
+#define A32_DO1(buf, i)                                                        \
+  {                                                                            \
+    s1 += buf[i];                                                              \
+    s2 += s1;                                                                  \
+  }
+#define A32_DO2(buf, i)                                                        \
+  A32_DO1(buf, i);                                                             \
+  A32_DO1(buf, i + 1);
+#define A32_DO4(buf, i)                                                        \
+  A32_DO2(buf, i);                                                             \
+  A32_DO2(buf, i + 2);
+#define A32_DO8(buf, i)                                                        \
+  A32_DO4(buf, i);                                                             \
+  A32_DO4(buf, i + 4);
+#define A32_DO16(buf)                                                          \
+  A32_DO8(buf, 0);                                                             \
+  A32_DO8(buf, 8);
+
+static uint32_t adler32(uint32_t adler, const uint8_t *buf, usize_t len) {
+  uint32_t s1 = adler & 0xffffU;
+  uint32_t s2 = (adler >> 16) & 0xffffU;
+  int k;
+
+  while (len > 0) {
+    k = (int)((len < A32_NMAX) ? len : A32_NMAX);
+    len -= k;
+
+    while (k >= 16) {
+      A32_DO16(buf);
+      buf += 16;
+      k -= 16;
+    }
+
+    if (k != 0) {
+      do {
+        s1 += *buf++;
+        s2 += s1;
+      } while (--k);
+    }
+
+    s1 %= A32_BASE;
+    s2 %= A32_BASE;
+  }
+
+  return (s2 << 16) | s1;
+}
+
+/***********************************************************************
+ Run-length function
+ ***********************************************************************/
+
+#if XD3_ENCODER
+static usize_t xd3_comprun(const uint8_t *seg, usize_t slook, uint8_t *run_cp) {
+  usize_t i;
+  usize_t run_l = 0;
+  uint8_t run_c = 0;
+
+  for (i = 0; i < slook; i += 1) {
+    NEXTRUN(seg[i]);
+  }
+
+  (*run_cp) = run_c;
+
+  return run_l;
+}
+#endif
+
+/***********************************************************************
+ Basic encoder/decoder functions
+ ***********************************************************************/
+
+#if XD3_ENCODER
+inline int xd3_emit_byte(xd3_stream *stream, xd3_output **outputp,
+                         uint8_t code) {
+  xd3_output *output = (*outputp);
+
+  if (output->next == output->avail) {
+    xd3_output *aoutput;
+
+    if ((aoutput = xd3_alloc_output(stream, output)) == NULL) {
+      return ENOMEM;
+    }
+
+    output = (*outputp) = aoutput;
+  }
+
+  output->base[output->next++] = code;
+
+  return 0;
+}
+
+inline int xd3_emit_bytes(xd3_stream *stream, xd3_output **outputp,
+                          const uint8_t *base, usize_t size) {
+  xd3_output *output = (*outputp);
+
+  do {
+    usize_t take;
+
+    if (output->next == output->avail) {
+      xd3_output *aoutput;
+
+      if ((aoutput = xd3_alloc_output(stream, output)) == NULL) {
+        return ENOMEM;
+      }
+
+      output = (*outputp) = aoutput;
+    }
+
+    take = xd3_min(output->avail - output->next, size);
+
+    memcpy(output->base + output->next, base, (size_t)take);
+
+    output->next += take;
+    size -= take;
+    base += take;
+  } while (size > 0);
+
+  return 0;
+}
+#endif /* XD3_ENCODER */
+
+/***********************************************************************
+ Address cache stuff
+ ***********************************************************************/
+
+static int xd3_alloc_cache(xd3_stream *stream) {
+  if (stream->acache.near_array != NULL) {
+    xd3_free(stream, stream->acache.near_array);
+  }
+
+  if (stream->acache.same_array != NULL) {
+    xd3_free(stream, stream->acache.same_array);
+  }
+
+  if (((stream->acache.s_near > 0) &&
+       (stream->acache.near_array =
+            (usize_t *)xd3_alloc(stream, stream->acache.s_near,
+                                 (usize_t)sizeof(usize_t))) == NULL) ||
+      ((stream->acache.s_same > 0) &&
+       (stream->acache.same_array =
+            (usize_t *)xd3_alloc(stream, stream->acache.s_same * 256,
+                                 (usize_t)sizeof(usize_t))) == NULL)) {
+    return ENOMEM;
+  }
+
+  return 0;
+}
+
+void xd3_init_cache(xd3_addr_cache *acache) {
+  if (acache->s_near > 0) {
+    memset(acache->near_array, 0, acache->s_near * sizeof(usize_t));
+    acache->next_slot = 0;
+  }
+
+  if (acache->s_same > 0) {
+    memset(acache->same_array, 0, acache->s_same * 256 * sizeof(usize_t));
+  }
+}
+
+static void xd3_update_cache(xd3_addr_cache *acache, usize_t addr) {
+  if (acache->s_near > 0) {
+    acache->near_array[acache->next_slot] = addr;
+    acache->next_slot = (acache->next_slot + 1) % acache->s_near;
+  }
+
+  if (acache->s_same > 0) {
+    acache->same_array[addr % (acache->s_same * 256)] = addr;
+  }
+}
+
+#if XD3_ENCODER
+/* OPT: this gets called a lot, can it be optimized? */
+static int xd3_encode_address(xd3_stream *stream, usize_t addr, usize_t here,
+                              uint8_t *mode) {
+  usize_t d, bestd;
+  usize_t i, bestm;
+  int ret;
+  xd3_addr_cache *acache = &stream->acache;
+
+#define SMALLEST_INT(x)                                                        \
+  do {                                                                         \
+    if (((x) & ~127U) == 0) {                                                  \
+      goto good;                                                               \
+    }                                                                          \
+  } while (0)
+
+  /* Attempt to find the address mode that yields the smallest integer value
+   * for "d", the encoded address value, thereby minimizing the encoded size
+   * of the address. */
+  bestd = addr;
+  bestm = VCD_SELF;
+
+  XD3_ASSERT(addr < here);
+
+  SMALLEST_INT(bestd);
+
+  if ((d = here - addr) < bestd) {
+    bestd = d;
+    bestm = VCD_HERE;
+
+    SMALLEST_INT(bestd);
+  }
+
+  for (i = 0; i < acache->s_near; i += 1) {
+    /* Note: If we used signed computation here, we'd could compte d
+     * and then check (d >= 0 && d < bestd). */
+    if (addr >= acache->near_array[i]) {
+      d = addr - acache->near_array[i];
+
+      if (d < bestd) {
+        bestd = d;
+        bestm = i + 2; /* 2 counts the VCD_SELF, VCD_HERE modes */
+
+        SMALLEST_INT(bestd);
+      }
+    }
+  }
+
+  if (acache->s_same > 0 &&
+      acache->same_array[d = addr % (acache->s_same * 256)] == addr) {
+    bestd = d % 256;
+    /* 2 + s_near offsets past the VCD_NEAR modes */
+    bestm = acache->s_near + 2 + d / 256;
+
+    if ((ret = xd3_emit_byte(stream, &ADDR_TAIL(stream), (uint8_t)bestd))) {
+      return ret;
+    }
+  } else {
+  good:
+
+    if ((ret = xd3_emit_size(stream, &ADDR_TAIL(stream), bestd))) {
+      return ret;
+    }
+  }
+
+  xd3_update_cache(acache, addr);
+
+  (*mode) += (uint8_t)bestm;
+
+  return 0;
+}
+#endif
+
+static int xd3_decode_address(xd3_stream *stream, usize_t here, usize_t mode,
+                              const uint8_t **inpp, const uint8_t *max,
+                              usize_t *valp) {
+  int ret;
+  usize_t same_start = 2 + stream->acache.s_near;
+
+  if (mode < same_start) {
+    if ((ret = xd3_read_size(stream, inpp, max, valp))) {
+      return ret;
+    }
+
+    switch (mode) {
+    case VCD_SELF:
+      break;
+    case VCD_HERE:
+      (*valp) = here - (*valp);
+      break;
+    default:
+      (*valp) += stream->acache.near_array[mode - 2];
+      break;
+    }
+  } else {
+    if (*inpp == max) {
+      stream->msg = "address underflow";
+      return XD3_INVALID_INPUT;
+    }
+
+    mode -= same_start;
+
+    (*valp) = stream->acache.same_array[mode * 256 + (**inpp)];
+
+    (*inpp) += 1;
+  }
+
+  xd3_update_cache(&stream->acache, *valp);
+
+  return 0;
+}
+
+/***********************************************************************
+ Alloc/free
+***********************************************************************/
+
+static void *__xd3_alloc_func(void *opaque, size_t items, usize_t size) {
+  if (XD3_MUL_SIZE_OVERFLOW(items, size)) {
+    return NULL;
+  }
+  return malloc(items * (size_t)size);
+}
+
+static void __xd3_free_func(void *opaque, void *address) { free(address); }
+
+static void *xd3_alloc(xd3_stream *stream, usize_t elts, usize_t size) {
+  void *a = stream->alloc(stream->opaque, elts, size);
+
+  if (a != NULL) {
+    IF_DEBUG(stream->alloc_cnt += 1);
+    IF_DEBUG2(DP(RINT "[stream %p malloc] size %" XD3_W "u ptr %p\n",
+                 (void *)stream, elts * size, a));
+  } else {
+    stream->msg = "out of memory";
+  }
+
+  return a;
+}
+
+static void xd3_free(xd3_stream *stream, void *ptr) {
+  if (ptr != NULL) {
+    IF_DEBUG(stream->free_cnt += 1);
+    XD3_ASSERT(stream->free_cnt <= stream->alloc_cnt);
+    IF_DEBUG2(DP(RINT "[stream %p free] %p\n", (void *)stream, ptr));
+    stream->free(stream->opaque, ptr);
+  }
+}
+
+#if XD3_ENCODER
+static void *xd3_alloc0(xd3_stream *stream, usize_t elts, usize_t size) {
+  void *a = xd3_alloc(stream, elts, size);
+
+  if (a != NULL) {
+    memset(a, 0, (size_t)(elts * size));
+  }
+
+  return a;
+}
+
+xd3_output *xd3_alloc_output(xd3_stream *stream, xd3_output *old_output) {
+  xd3_output *output;
+  uint8_t *base;
+
+  if (stream->enc_free != NULL) {
+    output = stream->enc_free;
+    stream->enc_free = output->next_page;
+  } else {
+    if ((output = (xd3_output *)xd3_alloc(
+             stream, 1, (usize_t)sizeof(xd3_output))) == NULL) {
+      return NULL;
+    }
+
+    if ((base = (uint8_t *)xd3_alloc(stream, XD3_ALLOCSIZE, sizeof(uint8_t))) ==
+        NULL) {
+      xd3_free(stream, output);
+      return NULL;
+    }
+
+    output->base = base;
+    output->avail = XD3_ALLOCSIZE;
+  }
+
+  output->next = 0;
+
+  if (old_output) {
+    old_output->next_page = output;
+  }
+
+  output->next_page = NULL;
+
+  return output;
+}
+
+static usize_t xd3_sizeof_output(xd3_output *output) {
+  usize_t s = 0;
+
+  for (; output; output = output->next_page) {
+    s += output->next;
+  }
+
+  return s;
+}
+
+static void xd3_freelist_output(xd3_stream *stream, xd3_output *output) {
+  xd3_output *tmp;
+
+  while (output) {
+    tmp = output;
+    output = output->next_page;
+
+    tmp->next = 0;
+    tmp->next_page = stream->enc_free;
+    stream->enc_free = tmp;
+  }
+}
+
+static void xd3_free_output(xd3_stream *stream, xd3_output *output) {
+  xd3_output *next;
+
+again:
+  if (output == NULL) {
+    return;
+  }
+
+  next = output->next_page;
+
+  xd3_free(stream, output->base);
+  xd3_free(stream, output);
+
+  output = next;
+  goto again;
+}
+#endif /* XD3_ENCODER */
+
+void xd3_free_stream(xd3_stream *stream) {
+  xd3_iopt_buflist *blist = stream->iopt_alloc;
+
+  while (blist != NULL) {
+    xd3_iopt_buflist *tmp = blist;
+    blist = blist->next;
+    xd3_free(stream, tmp->buffer);
+    xd3_free(stream, tmp);
+  }
+
+#if XD3_ENCODER
+  xd3_free(stream, stream->large_table);
+  xd3_free(stream, stream->small_table);
+  xd3_free(stream, stream->large_hash.powers);
+  xd3_free(stream, stream->small_hash.powers);
+  xd3_free(stream, stream->small_prev);
+
+  {
+    int i;
+    for (i = 0; i < ENC_SECTS; i += 1) {
+      xd3_free_output(stream, stream->enc_heads[i]);
+    }
+    xd3_free_output(stream, stream->enc_free);
+  }
+#endif
+
+  xd3_free(stream, stream->acache.near_array);
+  xd3_free(stream, stream->acache.same_array);
+
+  xd3_free(stream, stream->inst_sect.copied1);
+  xd3_free(stream, stream->addr_sect.copied1);
+  xd3_free(stream, stream->data_sect.copied1);
+
+  if (stream->dec_lastwin != stream->dec_buffer) {
+    xd3_free(stream, (uint8_t *)stream->dec_lastwin);
+  }
+  xd3_free(stream, stream->dec_buffer);
+
+  xd3_free(stream, stream->buf_in);
+  xd3_free(stream, stream->dec_appheader);
+  xd3_free(stream, stream->dec_codetbl);
+  xd3_free(stream, stream->code_table_alloc);
+
+#if SECONDARY_ANY
+  xd3_free(stream, stream->inst_sect.copied2);
+  xd3_free(stream, stream->addr_sect.copied2);
+  xd3_free(stream, stream->data_sect.copied2);
+
+  if (stream->sec_type != NULL) {
+    stream->sec_type->destroy(stream, stream->sec_stream_d);
+    stream->sec_type->destroy(stream, stream->sec_stream_i);
+    stream->sec_type->destroy(stream, stream->sec_stream_a);
+  }
+#endif
+
+  xd3_free(stream, stream->whole_target.adds);
+  xd3_free(stream, stream->whole_target.inst);
+  xd3_free(stream, stream->whole_target.wininfo);
+
+  XD3_ASSERT(stream->alloc_cnt == stream->free_cnt);
+
+  memset(stream, 0, sizeof(xd3_stream));
+}
+
+#if (XD3_DEBUG > 1 || VCDIFF_TOOLS)
+static const char *xd3_rtype_to_string(xd3_rtype type, int print_mode) {
+  switch (type) {
+  case XD3_NOOP:
+    return "NOOP ";
+  case XD3_RUN:
+    return "RUN  ";
+  case XD3_ADD:
+    return "ADD  ";
+  default:
+    break;
+  }
+  if (!print_mode) {
+    return "CPY  ";
+  }
+  switch (type) {
+  case XD3_CPY + 0:
+    return "CPY_0";
+  case XD3_CPY + 1:
+    return "CPY_1";
+  case XD3_CPY + 2:
+    return "CPY_2";
+  case XD3_CPY + 3:
+    return "CPY_3";
+  case XD3_CPY + 4:
+    return "CPY_4";
+  case XD3_CPY + 5:
+    return "CPY_5";
+  case XD3_CPY + 6:
+    return "CPY_6";
+  case XD3_CPY + 7:
+    return "CPY_7";
+  case XD3_CPY + 8:
+    return "CPY_8";
+  case XD3_CPY + 9:
+    return "CPY_9";
+  default:
+    return "CPY>9";
+  }
+}
+#endif
+
+/****************************************************************
+ Stream configuration
+ ******************************************************************/
+
+int xd3_config_stream(xd3_stream *stream, xd3_config *config) {
+  int ret;
+  xd3_config defcfg;
+  xd3_smatcher *smatcher = &stream->smatcher;
+
+  if (config == NULL) {
+    config = &defcfg;
+    memset(config, 0, sizeof(*config));
+  }
+
+  /* Initial setup: no error checks yet */
+  memset(stream, 0, sizeof(*stream));
+
+  stream->winsize = config->winsize ? config->winsize : XD3_DEFAULT_WINSIZE;
+  stream->sprevsz = config->sprevsz ? config->sprevsz : XD3_DEFAULT_SPREVSZ;
+
+  /* Enforce the window-size cap in the library, not just the CLI arg
+   * parser.  Window-relative copy addresses are narrowed to usize_t, so a
+   * winsize beyond XD3_MAXSRCWINSZ could overflow on a 32-bit-usize_t build
+   * regardless of how the caller reached this point. */
+  if (stream->winsize > XD3_MAXSRCWINSZ) {
+    stream->msg = "winsize exceeds the maximum source window size";
+    return XD3_INVALID;
+  }
+
+  if (config->iopt_size == 0) {
+    stream->iopt_size = XD3_ALLOCSIZE / sizeof(xd3_rinst);
+    stream->iopt_unlimited = 1;
+  } else {
+    stream->iopt_size = config->iopt_size;
+  }
+
+  stream->getblk = config->getblk;
+  stream->alloc = config->alloc ? config->alloc : __xd3_alloc_func;
+  stream->free = config->freef ? config->freef : __xd3_free_func;
+  stream->opaque = config->opaque;
+  stream->flags = config->flags;
+
+  /* Secondary setup. */
+  stream->sec_data = config->sec_data;
+  stream->sec_inst = config->sec_inst;
+  stream->sec_addr = config->sec_addr;
+
+  stream->sec_data.data_type = DATA_SECTION;
+  stream->sec_inst.data_type = INST_SECTION;
+  stream->sec_addr.data_type = ADDR_SECTION;
+
+  /* Check static sizes. */
+  if (sizeof(usize_t) != SIZEOF_USIZE_T || sizeof(xoff_t) != SIZEOF_XOFF_T ||
+      (ret = xd3_check_pow2(XD3_ALLOCSIZE, NULL))) {
+    stream->msg = "incorrect compilation: wrong integer sizes";
+    return XD3_INTERNAL;
+  }
+
+  /* Check/set secondary compressor. */
+  switch (stream->flags & XD3_SEC_TYPE) {
+  case 0:
+    if (stream->flags & XD3_SEC_NOALL) {
+      stream->msg = "XD3_SEC flags require a secondary compressor type";
+      return XD3_INTERNAL;
+    }
+    break;
+  case XD3_SEC_FGK:
+    FGK_CASE(stream);
+  case XD3_SEC_DJW:
+    DJW_CASE(stream);
+  case XD3_SEC_LZMA:
+    LZMA_CASE(stream);
+  default:
+    stream->msg = "too many secondary compressor types set";
+    return XD3_INTERNAL;
+  }
+
+  stream->code_table_desc = &__rfc3284_code_table_desc;
+  stream->code_table_func = xd3_rfc3284_code_table;
+
+  /* Check sprevsz */
+  if (smatcher->small_chain == 1 && smatcher->small_lchain == 1) {
+    stream->sprevsz = 0;
+  } else {
+    if ((ret = xd3_check_pow2(stream->sprevsz, NULL))) {
+      stream->msg = "sprevsz is required to be a power of two";
+      return XD3_INTERNAL;
+    }
+
+    stream->sprevmask = stream->sprevsz - 1;
+  }
+
+  /* Default scanner settings. */
+#if XD3_ENCODER
+  switch (config->smatch_cfg) {
+    IF_BUILD_SOFT(case XD3_SMATCH_SOFT : {
+      *smatcher = config->smatcher_soft;
+      smatcher->string_match = __smatcher_soft.string_match;
+      smatcher->name = __smatcher_soft.name;
+      if (smatcher->large_look < MIN_MATCH || smatcher->large_step < 1 ||
+          smatcher->small_look < MIN_MATCH) {
+        stream->msg = "invalid soft string-match config";
+        return XD3_INVALID;
+      }
+      break;
+    })
+
+    IF_BUILD_DEFAULT(case XD3_SMATCH_DEFAULT : *smatcher = __smatcher_default;
+                     break;)
+    IF_BUILD_SLOW(case XD3_SMATCH_SLOW : *smatcher = __smatcher_slow; break;)
+    IF_BUILD_FASTEST(case XD3_SMATCH_FASTEST : *smatcher = __smatcher_fastest;
+                     break;)
+    IF_BUILD_FASTER(case XD3_SMATCH_FASTER : *smatcher = __smatcher_faster;
+                    break;)
+    IF_BUILD_FAST(case XD3_SMATCH_FAST : *smatcher = __smatcher_fast; break;)
+  default:
+    stream->msg = "invalid string match config type";
+    return XD3_INTERNAL;
+  }
+
+  if (config->smatch_cfg == XD3_SMATCH_DEFAULT &&
+      (stream->flags & XD3_COMPLEVEL_MASK) != 0) {
+    int level = (stream->flags & XD3_COMPLEVEL_MASK) >> XD3_COMPLEVEL_SHIFT;
+
+    switch (level) {
+    case 1:
+      IF_BUILD_FASTEST(*smatcher = __smatcher_fastest; break;)
+    case 2:
+      IF_BUILD_FASTER(*smatcher = __smatcher_faster; break;)
+    case 3:
+    case 4:
+    case 5:
+      IF_BUILD_FAST(*smatcher = __smatcher_fast; break;)
+    case 6:
+      IF_BUILD_DEFAULT(*smatcher = __smatcher_default; break;)
+    default:
+      IF_BUILD_SLOW(*smatcher = __smatcher_slow; break;)
+      IF_BUILD_DEFAULT(*smatcher = __smatcher_default; break;)
+      IF_BUILD_FAST(*smatcher = __smatcher_fast; break;)
+      IF_BUILD_FASTER(*smatcher = __smatcher_faster; break;)
+      IF_BUILD_FASTEST(*smatcher = __smatcher_fastest; break;)
+    }
+  }
+#endif
+
+  return 0;
+}
+
+/***********************************************************
+ Getblk interface
+ ***********************************************************/
+
+inline xoff_t xd3_source_eof(const xd3_source *src) {
+  xoff_t r = (src->max_blkno << src->shiftby) + (xoff_t)src->onlastblk;
+  return r;
+}
+
+inline usize_t xd3_bytes_on_srcblk(xd3_source *src, xoff_t blkno) {
+  usize_t r = (blkno == src->max_blkno ? src->onlastblk : src->blksize);
+  return r;
+}
+
+/* This function interfaces with the client getblk function, checks
+ * its results, updates max_blkno, onlastblk, eof_known. */
+static int xd3_getblk(xd3_stream *stream, xoff_t blkno) {
+  int ret;
+  xd3_source *source = stream->src;
+
+  if (source->curblk == NULL || blkno != source->curblkno) {
+    source->getblkno = blkno;
+
+    if (stream->getblk == NULL) {
+      IF_DEBUG2(DP(RINT "[getblk] XD3_GETSRCBLK %" XD3_Q "u\n", blkno));
+      stream->msg = "getblk source input";
+      return XD3_GETSRCBLK;
+    }
+
+    ret = stream->getblk(stream, source, blkno);
+    if (ret != 0) {
+      IF_DEBUG2(DP(RINT "[getblk] app error blkno %" XD3_Q "u: %s\n", blkno,
+                   xd3_strerror(ret)));
+      return ret;
+    }
+
+    IF_DEBUG2(DP(RINT "[getblk] read source block %" XD3_Q "u onblk "
+                      "%" XD3_W "u blksize %" XD3_W "u max_blkno %" XD3_Q "u\n",
+                 blkno, source->onblk, source->blksize, source->max_blkno));
+  }
+
+  if (blkno > source->max_blkno) {
+    source->max_blkno = blkno;
+
+    if (source->onblk == source->blksize) {
+      IF_DEBUG1(DP(RINT "[getblk] full source blkno %" XD3_Q "u: "
+                        "source length unknown %" XD3_Q "u\n",
+                   blkno, xd3_source_eof(source)));
+    } else if (!source->eof_known) {
+      IF_DEBUG1(DP(RINT "[getblk] eof block has %" XD3_W "u bytes; "
+                        "source length known %" XD3_Q "u\n",
+                   xd3_bytes_on_srcblk(source, blkno), xd3_source_eof(source)));
+      source->eof_known = 1;
+    }
+  }
+
+  XD3_ASSERT(source->curblk != NULL);
+
+  if (blkno == source->max_blkno) {
+    /* In case the application sets the source as 1 block w/ a
+     * preset buffer. */
+    source->onlastblk = source->onblk;
+  }
+  return 0;
+}
+
+/***********************************************************
+ Stream open/close
+ ***************************************************************/
+
+int xd3_set_source(xd3_stream *stream, xd3_source *src) {
+  usize_t shiftby;
+
+  stream->src = src;
+  src->srclen = 0;
+  src->srcbase = 0;
+
+  /* Enforce power-of-two blocksize so that source-block number
+   * calculations are cheap. */
+  if (xd3_check_pow2(src->blksize, &shiftby) != 0) {
+    src->blksize = xd3_pow2_roundup(src->blksize);
+    xd3_check_pow2(src->blksize, &shiftby);
+    IF_DEBUG1(DP(RINT "raising src_blksz to %" XD3_W "u\n", src->blksize));
+  }
+
+  src->shiftby = shiftby;
+  src->maskby = (1ULL << shiftby) - 1ULL;
+
+  if (xd3_check_pow2(src->max_winsize, NULL) != 0) {
+    src->max_winsize = xd3_xoff_roundup(src->max_winsize);
+    IF_DEBUG1(DP(RINT "raising src_maxsize to %" XD3_W "u\n", src->blksize));
+  }
+  src->max_winsize = xd3_max(src->max_winsize, XD3_ALLOCSIZE);
+
+  /* Enforce the source-window cap in the library.  srclen and source-copy
+   * addresses are window-relative usize_t values bounded by max_winsize;
+   * a value beyond XD3_MAXSRCWINSZ could overflow on a 32-bit-usize_t
+   * build, so reject it here rather than trusting the CLI arg parser. */
+  if (src->max_winsize > XD3_MAXSRCWINSZ) {
+    stream->msg = "source max_winsize exceeds the maximum";
+    return XD3_INVALID;
+  }
+  return 0;
+}
+
+int xd3_set_source_and_size(xd3_stream *stream, xd3_source *user_source,
+                            xoff_t source_size) {
+  int ret = xd3_set_source(stream, user_source);
+  if (ret == 0) {
+    stream->src->eof_known = 1;
+    IF_DEBUG2(DP(RINT "[set source] size known %" XD3_Q "u\n", source_size));
+    xd3_blksize_div(source_size, stream->src, &stream->src->max_blkno,
+                    &stream->src->onlastblk);
+
+    IF_DEBUG1(DP(RINT "[set source] size known %" XD3_Q "u max_blkno %" XD3_Q
+                      "u\n",
+                 source_size, stream->src->max_blkno));
+  }
+  return ret;
+}
+
+void xd3_abort_stream(xd3_stream *stream) {
+  stream->dec_state = DEC_ABORTED;
+  stream->enc_state = ENC_ABORTED;
+}
+
+int xd3_close_stream(xd3_stream *stream) {
+  if (stream->enc_state != 0 && stream->enc_state != ENC_ABORTED) {
+    if (stream->buf_leftover != NULL) {
+      stream->msg = "encoding is incomplete";
+      return XD3_INTERNAL;
+    }
+
+    if (stream->enc_state == ENC_POSTWIN) {
+#if XD3_ENCODER
+      xd3_encode_reset(stream);
+#endif
+      stream->current_window += 1;
+      stream->enc_state = ENC_INPUT;
+    }
+
+    /* If encoding, should be ready for more input but not actually
+       have any. */
+    if (stream->enc_state != ENC_INPUT || stream->avail_in != 0) {
+      stream->msg = "encoding is incomplete";
+      return XD3_INTERNAL;
+    }
+  } else {
+    switch (stream->dec_state) {
+    case DEC_VCHEAD:
+    case DEC_WININD:
+      /* TODO: Address the zero-byte ambiguity.  Does the encoder
+       * emit a window or not?  If so, then catch an error here.
+       * If not, need another routine to say
+       * decode_at_least_one_if_empty. */
+    case DEC_ABORTED:
+      break;
+    default:
+      /* If decoding, should be ready for the next window. */
+      stream->msg = "eof in decode";
+      return XD3_INVALID_INPUT;
+    }
+  }
+
+  return 0;
+}
+
+/**************************************************************
+ Application header
+ ****************************************************************/
+
+int xd3_get_appheader(xd3_stream *stream, uint8_t **data, usize_t *size) {
+  if (stream->dec_state < DEC_WININD) {
+    stream->msg = "application header not available";
+    return XD3_INTERNAL;
+  }
+
+  (*data) = stream->dec_appheader;
+  (*size) = stream->dec_appheadsz;
+  return 0;
+}
+
+/**********************************************************
+ Decoder stuff
+ *************************************************/
+
+#include "xdelta3-decode.h"
+
+/****************************************************************
+ Encoder stuff
+ *****************************************************************/
+
+#if XD3_ENCODER
+void xd3_set_appheader(xd3_stream *stream, const uint8_t *data, usize_t size) {
+  stream->enc_appheader = data;
+  stream->enc_appheadsz = size;
+}
+
+#if XD3_DEBUG
+static int xd3_iopt_check(xd3_stream *stream) {
+  usize_t ul = xd3_rlist_length(&stream->iopt_used);
+  usize_t fl = xd3_rlist_length(&stream->iopt_free);
+
+  return (ul + fl + (stream->iout ? 1 : 0)) == stream->iopt_size;
+}
+#endif
+
+static xd3_rinst *xd3_iopt_free(xd3_stream *stream, xd3_rinst *i) {
+  xd3_rinst *n = xd3_rlist_remove(i);
+  xd3_rlist_push_back(&stream->iopt_free, i);
+  return n;
+}
+
+static void xd3_iopt_free_nonadd(xd3_stream *stream, xd3_rinst *i) {
+  if (i->type != XD3_ADD) {
+    xd3_rlist_push_back(&stream->iopt_free, i);
+  }
+}
+
+/* When an instruction is ready to flush from the iopt buffer, this
+ * function is called to produce an encoding.  It writes the
+ * instruction plus size, address, and data to the various encoding
+ * sections. */
+static int xd3_iopt_finish_encoding(xd3_stream *stream, xd3_rinst *inst) {
+  int ret;
+
+  /* Check for input overflow. */
+  XD3_ASSERT(inst->pos + inst->size <= stream->avail_in);
+
+  switch (inst->type) {
+  case XD3_CPY: {
+    /* the address may have an offset if there is a source window. */
+    usize_t addr;
+    xd3_source *src = stream->src;
+
+    if (src != NULL) {
+      /* If there is a source copy, the source must have its
+       * source window decided before we can encode.  This can
+       * be bad -- we have to make this decision even if no
+       * source matches have been found. */
+      if (stream->srcwin_decided == 0) {
+        if ((ret = xd3_srcwin_setup(stream))) {
+          return ret;
+        }
+      } else {
+        stream->srcwin_decided_early =
+            (!stream->src->eof_known ||
+             (stream->srcwin_cksum_pos < xd3_source_eof(stream->src)));
+      }
+
+      /* xtra field indicates the copy is from the source */
+      if (inst->xtra) {
+        XD3_ASSERT(inst->addr >= src->srcbase);
+        XD3_ASSERT(inst->addr + inst->size <= src->srcbase + src->srclen);
+        if ((ret = xd3_to_usize(inst->addr - src->srcbase, &addr))) {
+          stream->msg = "source copy address exceeds window size";
+          return ret;
+        }
+        stream->n_scpy += 1;
+        stream->l_scpy += inst->size;
+      } else {
+        /* with source window: target copy address is offset
+         * by taroff. */
+        if ((ret = xd3_to_usize((xoff_t)stream->taroff + inst->addr, &addr))) {
+          stream->msg = "target copy address exceeds window size";
+          return ret;
+        }
+        stream->n_tcpy += 1;
+        stream->l_tcpy += inst->size;
+      }
+    } else {
+      if ((ret = xd3_to_usize(inst->addr, &addr))) {
+        stream->msg = "copy address exceeds window size";
+        return ret;
+      }
+      stream->n_tcpy += 1;
+      stream->l_tcpy += inst->size;
+    }
+
+    /* Note: used to assert inst->size >= MIN_MATCH, but not true
+     * for merge operations & identical match heuristics. */
+    /* the "here" position is always offset by taroff */
+    if ((ret = xd3_encode_address(stream, addr, inst->pos + stream->taroff,
+                                  &inst->type))) {
+      return ret;
+    }
+
+    IF_DEBUG2({
+      static int cnt;
+      DP(RINT "[iopt copy:%d] pos %" XD3_Q "u-%" XD3_Q "u addr %" XD3_Q
+              "u-%" XD3_Q "u size %" XD3_W "u\n",
+         cnt++, stream->total_in + inst->pos,
+         stream->total_in + inst->pos + inst->size, inst->addr,
+         inst->addr + inst->size, inst->size);
+    });
+    break;
+  }
+  case XD3_RUN: {
+    if ((ret = xd3_emit_byte(stream, &DATA_TAIL(stream), inst->xtra))) {
+      return ret;
+    }
+
+    stream->n_run += 1;
+    stream->l_run += inst->size;
+
+    IF_DEBUG2({
+      static int cnt;
+      DP(RINT "[iopt run:%d] pos %" XD3_Q "u size %" XD3_W "u\n", cnt++,
+         stream->total_in + inst->pos, inst->size);
+    });
+    break;
+  }
+  case XD3_ADD: {
+    if ((ret = xd3_emit_bytes(stream, &DATA_TAIL(stream),
+                              stream->next_in + inst->pos, inst->size))) {
+      return ret;
+    }
+
+    stream->n_add += 1;
+    stream->l_add += inst->size;
+
+    IF_DEBUG2({
+      static int cnt;
+      DP(RINT "[iopt add:%d] pos %" XD3_Q "u size %" XD3_W "u\n", cnt++,
+         stream->total_in + inst->pos, inst->size);
+    });
+
+    break;
+  }
+  }
+
+  /* This is the only place stream->unencoded_offset is incremented. */
+  XD3_ASSERT(stream->unencoded_offset == inst->pos);
+  stream->unencoded_offset += inst->size;
+
+  inst->code2 = 0;
+
+  XD3_CHOOSE_INSTRUCTION(stream, stream->iout, inst);
+
+  if (stream->iout != NULL) {
+    if (stream->iout->code2 != 0) {
+      if ((ret = xd3_emit_double(stream, stream->iout, inst,
+                                 stream->iout->code2))) {
+        return ret;
+      }
+
+      xd3_iopt_free_nonadd(stream, stream->iout);
+      xd3_iopt_free_nonadd(stream, inst);
+      stream->iout = NULL;
+      return 0;
+    } else {
+      if ((ret = xd3_emit_single(stream, stream->iout, stream->iout->code1))) {
+        return ret;
+      }
+
+      xd3_iopt_free_nonadd(stream, stream->iout);
+    }
+  }
+
+  stream->iout = inst;
+
+  return 0;
+}
+
+/* This possibly encodes an add instruction, iadd, which must remain
+ * on the stack until the following call to
+ * xd3_iopt_finish_encoding. */
+static int xd3_iopt_add(xd3_stream *stream, usize_t pos, xd3_rinst *iadd) {
+  int ret;
+  usize_t off = stream->unencoded_offset;
+
+  if (pos > off) {
+    iadd->type = XD3_ADD;
+    iadd->pos = off;
+    iadd->size = pos - off;
+
+    if ((ret = xd3_iopt_finish_encoding(stream, iadd))) {
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+/* This function calls xd3_iopt_finish_encoding to finish encoding an
+ * instruction, and it may also produce an add instruction for an
+ * unmatched region. */
+static int xd3_iopt_add_encoding(xd3_stream *stream, xd3_rinst *inst) {
+  int ret;
+  xd3_rinst iadd;
+
+  if ((ret = xd3_iopt_add(stream, inst->pos, &iadd))) {
+    return ret;
+  }
+
+  if ((ret = xd3_iopt_finish_encoding(stream, inst))) {
+    return ret;
+  }
+
+  return 0;
+}
+
+/* Generates a final add instruction to encode the remaining input. */
+static int xd3_iopt_add_finalize(xd3_stream *stream) {
+  int ret;
+  xd3_rinst iadd;
+
+  if ((ret = xd3_iopt_add(stream, stream->avail_in, &iadd))) {
+    return ret;
+  }
+
+  if (stream->iout) {
+    if ((ret = xd3_emit_single(stream, stream->iout, stream->iout->code1))) {
+      return ret;
+    }
+
+    xd3_iopt_free_nonadd(stream, stream->iout);
+    stream->iout = NULL;
+  }
+
+  return 0;
+}
+
+/* Compact the instruction buffer by choosing the best non-overlapping
+ * instructions when lazy string-matching.  There are no ADDs in the
+ * iopt buffer because those are synthesized in xd3_iopt_add_encoding
+ * and during xd3_iopt_add_finalize. */
+static int xd3_iopt_flush_instructions(xd3_stream *stream, int force) {
+  xd3_rinst *r1 = xd3_rlist_front(&stream->iopt_used);
+  xd3_rinst *r2;
+  xd3_rinst *r3;
+  usize_t r1end;
+  usize_t r2end;
+  usize_t r2off;
+  usize_t r2moff;
+  usize_t gap;
+  usize_t flushed;
+  int ret;
+
+  XD3_ASSERT(xd3_iopt_check(stream));
+
+  /* Note: once tried to skip this step if it's possible to assert
+   * there are no overlapping instructions.  Doesn't work because
+   * xd3_opt_erase leaves overlapping instructions. */
+  while (!xd3_rlist_end(&stream->iopt_used, r1) &&
+         !xd3_rlist_end(&stream->iopt_used, r2 = xd3_rlist_next(r1))) {
+    r1end = r1->pos + r1->size;
+
+    /* If the instructions do not overlap, continue. */
+    if (r1end <= r2->pos) {
+      r1 = r2;
+      continue;
+    }
+
+    r2end = r2->pos + r2->size;
+
+    /* The min_match adjustments prevent this. */
+    XD3_ASSERT(r2end > (r1end + LEAST_MATCH_INCR));
+
+    /* If r3 is available... */
+    if (!xd3_rlist_end(&stream->iopt_used, r3 = xd3_rlist_next(r2))) {
+      /* If r3 starts before r1 finishes or just about, r2 is irrelevant */
+      if (r3->pos <= r1end + 1) {
+        xd3_iopt_free(stream, r2);
+        continue;
+      }
+    } else if (!force) {
+      /* Unless force, end the loop when r3 is not available. */
+      break;
+    }
+
+    r2off = r2->pos - r1->pos;
+    r2moff = r2end - r1end;
+    gap = r2end - r1->pos;
+
+    /* If the two matches overlap almost entirely, choose the better match
+     * and discard the other.  The else branch can still create inefficient
+     * copies, e.g., a 4-byte copy that takes 4 bytes to encode, which
+     * xd3_smatch() wouldn't allow by its crude efficiency check.  However,
+     * in this case there are adjacent copies which mean the add would cost
+     * one extra byte.  Allow the inefficiency here. */
+    if (gap < 2 * MIN_MATCH || r2moff <= 2 || r2off <= 2) {
+      /* Only one match should be used, choose the longer one. */
+      if (r1->size < r2->size) {
+        xd3_iopt_free(stream, r1);
+        r1 = r2;
+      } else {
+        /* We are guaranteed that r1 does not overlap now, so advance
+         * past r2 */
+        r1 = xd3_iopt_free(stream, r2);
+      }
+      continue;
+    } else {
+      /* Shorten one of the instructions -- could be optimized
+       * based on the address cache. */
+      usize_t average;
+      usize_t newsize;
+      usize_t adjust1;
+
+      XD3_ASSERT(r1end > r2->pos && r2end > r1->pos);
+
+      /* Try to balance the length of both instructions, but avoid
+       * making both longer than MAX_MATCH_SPLIT . */
+      average = gap / 2;
+      newsize = xd3_min(MAX_MATCH_SPLIT, gap - average);
+
+      /* Should be possible to simplify this code. */
+      if (newsize > r1->size) {
+        /* shorten r2 */
+        adjust1 = r1end - r2->pos;
+      } else if (newsize > r2->size) {
+        /* shorten r1 */
+        adjust1 = r1end - r2->pos;
+
+        XD3_ASSERT(r1->size > adjust1);
+
+        r1->size -= adjust1;
+
+        /* don't shorten r2 */
+        adjust1 = 0;
+      } else {
+        /* shorten r1 */
+        adjust1 = r1->size - newsize;
+
+        if (r2->pos > r1end - adjust1) {
+          adjust1 -= r2->pos - (r1end - adjust1);
+        }
+
+        XD3_ASSERT(r1->size > adjust1);
+
+        r1->size -= adjust1;
+
+        /* shorten r2 */
+        XD3_ASSERT(r1->pos + r1->size >= r2->pos);
+
+        adjust1 = r1->pos + r1->size - r2->pos;
+      }
+
+      /* Fallthrough above if-else, shorten r2 */
+      XD3_ASSERT(r2->size > adjust1);
+
+      r2->size -= adjust1;
+      r2->pos += adjust1;
+      r2->addr += adjust1;
+
+      XD3_ASSERT(r1->size >= MIN_MATCH);
+      XD3_ASSERT(r2->size >= MIN_MATCH);
+
+      r1 = r2;
+    }
+  }
+
+  XD3_ASSERT(xd3_iopt_check(stream));
+
+  /* If forcing, pick instructions until the list is empty, otherwise
+   * this empties 50% of the queue. */
+  for (flushed = 0; !xd3_rlist_empty(&stream->iopt_used);) {
+    xd3_rinst *renc = xd3_rlist_pop_front(&stream->iopt_used);
+    if ((ret = xd3_iopt_add_encoding(stream, renc))) {
+      return ret;
+    }
+
+    if (!force) {
+      if (++flushed > stream->iopt_size / 2) {
+        break;
+      }
+
+      /* If there are only two instructions remaining, break,
+       * because they were not optimized.  This means there were
+       * more than 50% eliminated by the loop above. */
+      r1 = xd3_rlist_front(&stream->iopt_used);
+      if (xd3_rlist_end(&stream->iopt_used, r1) ||
+          xd3_rlist_end(&stream->iopt_used, r2 = xd3_rlist_next(r1)) ||
+          xd3_rlist_end(&stream->iopt_used, r3 = xd3_rlist_next(r2))) {
+        break;
+      }
+    }
+  }
+
+  XD3_ASSERT(xd3_iopt_check(stream));
+
+  XD3_ASSERT(!force || xd3_rlist_length(&stream->iopt_used) == 0);
+
+  return 0;
+}
+
+static int xd3_iopt_get_slot(xd3_stream *stream, xd3_rinst **iptr) {
+  xd3_rinst *i;
+  int ret;
+
+  if (xd3_rlist_empty(&stream->iopt_free)) {
+    if (stream->iopt_unlimited) {
+      usize_t elts = XD3_ALLOCSIZE / sizeof(xd3_rinst);
+
+      if ((ret = xd3_alloc_iopt(stream, elts))) {
+        return ret;
+      }
+
+      stream->iopt_size += elts;
+    } else {
+      if ((ret = xd3_iopt_flush_instructions(stream, 0))) {
+        return ret;
+      }
+
+      XD3_ASSERT(!xd3_rlist_empty(&stream->iopt_free));
+    }
+  }
+
+  i = xd3_rlist_pop_back(&stream->iopt_free);
+
+  xd3_rlist_push_back(&stream->iopt_used, i);
+
+  (*iptr) = i;
+
+  ++stream->i_slots_used;
+
+  return 0;
+}
+
+/* A copy is about to be emitted that extends backwards to POS,
+ * therefore it may completely cover some existing instructions in the
+ * buffer.  If an instruction is completely covered by this new match,
+ * erase it.  If the new instruction is covered by the previous one,
+ * return 1 to skip it. */
+static void xd3_iopt_erase(xd3_stream *stream, usize_t pos, usize_t size) {
+  while (!xd3_rlist_empty(&stream->iopt_used)) {
+    xd3_rinst *r = xd3_rlist_back(&stream->iopt_used);
+
+    /* Verify that greedy is working.  The previous instruction
+     * should end before the new one begins. */
+    XD3_ASSERT((stream->flags & XD3_BEGREEDY) == 0 ||
+               (r->pos + r->size <= pos));
+    /* Verify that min_match is working.  The previous instruction
+     * should end before the new one ends. */
+    XD3_ASSERT((stream->flags & XD3_BEGREEDY) != 0 ||
+               (r->pos + r->size < pos + size));
+
+    /* See if the last instruction starts before the new
+     * instruction.  If so, there is nothing to erase. */
+    if (r->pos < pos) {
+      return;
+    }
+
+    /* Otherwise, the new instruction covers the old one, delete it
+       and repeat. */
+    xd3_rlist_remove(r);
+    xd3_rlist_push_back(&stream->iopt_free, r);
+    --stream->i_slots_used;
+  }
+}
+
+/* This function tells the last matched input position. */
+static usize_t xd3_iopt_last_matched(xd3_stream *stream) {
+  xd3_rinst *r;
+
+  if (xd3_rlist_empty(&stream->iopt_used)) {
+    return 0;
+  }
+
+  r = xd3_rlist_back(&stream->iopt_used);
+
+  return r->pos + r->size;
+}
+
+/*********************************************************
+ Emit routines
+ ***********************************************************/
+
+static int xd3_emit_single(xd3_stream *stream, xd3_rinst *single,
+                           uint8_t code) {
+  int has_size = stream->code_table[code].size1 == 0;
+  int ret;
+
+  IF_DEBUG2(DP(RINT "[emit1] %" XD3_W "u %s (%" XD3_W "u) code %u\n",
+               single->pos, xd3_rtype_to_string((xd3_rtype)single->type, 0),
+               single->size, code));
+
+  if ((ret = xd3_emit_byte(stream, &INST_TAIL(stream), code))) {
+    return ret;
+  }
+
+  if (has_size) {
+    if ((ret = xd3_emit_size(stream, &INST_TAIL(stream), single->size))) {
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+static int xd3_emit_double(xd3_stream *stream, xd3_rinst *first,
+                           xd3_rinst *second, uint8_t code) {
+  int ret;
+
+  /* All double instructions use fixed sizes, so all we need to do is
+   * output the instruction code, no sizes. */
+  XD3_ASSERT(stream->code_table[code].size1 != 0 &&
+             stream->code_table[code].size2 != 0);
+
+  if ((ret = xd3_emit_byte(stream, &INST_TAIL(stream), code))) {
+    return ret;
+  }
+
+  IF_DEBUG2(DP(
+      RINT "[emit2]: %" XD3_W "u %s (%" XD3_W "u) %s (%" XD3_W "u) code %u\n",
+      first->pos, xd3_rtype_to_string((xd3_rtype)first->type, 0), first->size,
+      xd3_rtype_to_string((xd3_rtype)second->type, 0), second->size, code));
+
+  return 0;
+}
+
+/* This enters a potential run instruction into the iopt buffer.  The
+ * position argument is relative to the target window. */
+static int xd3_emit_run(xd3_stream *stream, usize_t pos, usize_t size,
+                        uint8_t *run_c) {
+  xd3_rinst *ri;
+  int ret;
+
+  if ((ret = xd3_iopt_get_slot(stream, &ri))) {
+    return ret;
+  }
+
+  ri->type = XD3_RUN;
+  ri->xtra = *run_c;
+  ri->pos = pos;
+  ri->size = size;
+
+  return 0;
+}
+
+/* This enters a potential copy instruction into the iopt buffer.  The
+ * position argument is relative to the target window.. */
+int xd3_found_match(xd3_stream *stream, usize_t pos, usize_t size, xoff_t addr,
+                    int is_source) {
+  xd3_rinst *ri;
+  int ret;
+
+  if ((ret = xd3_iopt_get_slot(stream, &ri))) {
+    return ret;
+  }
+
+  ri->type = XD3_CPY;
+  ri->xtra = is_source;
+  ri->pos = pos;
+  ri->size = size;
+  ri->addr = addr;
+
+  return 0;
+}
+
+static int xd3_emit_hdr(xd3_stream *stream) {
+  int ret;
+  int use_secondary = stream->sec_type != NULL;
+  int use_adler32 = stream->flags & (XD3_ADLER32 | XD3_ADLER32_RECODE);
+  int vcd_source = xd3_encoder_used_source(stream);
+  uint8_t win_ind = 0;
+  uint8_t del_ind = 0;
+  usize_t enc_len;
+  usize_t tgt_len;
+  usize_t data_len;
+  usize_t inst_len;
+  usize_t addr_len;
+
+  if (stream->current_window == 0) {
+    uint8_t hdr_ind = 0;
+    int use_appheader = stream->enc_appheader != NULL;
+
+    if (use_secondary) {
+      hdr_ind |= VCD_SECONDARY;
+    }
+    if (use_appheader) {
+      hdr_ind |= VCD_APPHEADER;
+    }
+
+    if ((ret = xd3_emit_byte(stream, &HDR_TAIL(stream), VCDIFF_MAGIC1)) != 0 ||
+        (ret = xd3_emit_byte(stream, &HDR_TAIL(stream), VCDIFF_MAGIC2)) != 0 ||
+        (ret = xd3_emit_byte(stream, &HDR_TAIL(stream), VCDIFF_MAGIC3)) != 0 ||
+        (ret = xd3_emit_byte(stream, &HDR_TAIL(stream), VCDIFF_VERSION)) != 0 ||
+        (ret = xd3_emit_byte(stream, &HDR_TAIL(stream), hdr_ind)) != 0) {
+      return ret;
+    }
+
+    /* Secondary compressor ID */
+#if SECONDARY_ANY
+    if (use_secondary && (ret = xd3_emit_byte(stream, &HDR_TAIL(stream),
+                                              stream->sec_type->id))) {
+      return ret;
+    }
+#endif
+
+    /* Application header */
+    if (use_appheader) {
+      if ((ret = xd3_emit_size(stream, &HDR_TAIL(stream),
+                               stream->enc_appheadsz)) ||
+          (ret =
+               xd3_emit_bytes(stream, &HDR_TAIL(stream), stream->enc_appheader,
+                              stream->enc_appheadsz))) {
+        return ret;
+      }
+    }
+  }
+
+  /* try to compress this window */
+#if SECONDARY_ANY
+  if (use_secondary) {
+    int data_sec = 0;
+    int inst_sec = 0;
+    int addr_sec = 0;
+
+#define ENCODE_SECONDARY_SECTION(UPPER, LOWER)                                 \
+  ((stream->flags & XD3_SEC_NO##UPPER) == 0 &&                                 \
+   (ret = xd3_encode_secondary(                                                \
+        stream, &UPPER##_HEAD(stream), &UPPER##_TAIL(stream),                  \
+        &xd3_sec_##LOWER(stream), &stream->sec_##LOWER, &LOWER##_sec)))
+
+    if (ENCODE_SECONDARY_SECTION(DATA, data) ||
+        ENCODE_SECONDARY_SECTION(INST, inst) ||
+        ENCODE_SECONDARY_SECTION(ADDR, addr)) {
+      return ret;
+    }
+
+    del_ind |= (data_sec ? VCD_DATACOMP : 0);
+    del_ind |= (inst_sec ? VCD_INSTCOMP : 0);
+    del_ind |= (addr_sec ? VCD_ADDRCOMP : 0);
+  }
+#endif
+
+  /* if (vcd_target) { win_ind |= VCD_TARGET; } */
+  if (vcd_source) {
+    win_ind |= VCD_SOURCE;
+  }
+  if (use_adler32) {
+    win_ind |= VCD_ADLER32;
+  }
+
+  /* window indicator */
+  if ((ret = xd3_emit_byte(stream, &HDR_TAIL(stream), win_ind))) {
+    return ret;
+  }
+
+  /* source window */
+  if (vcd_source) {
+    /* or (vcd_target) { ... } */
+    if ((ret = xd3_emit_size(stream, &HDR_TAIL(stream), stream->src->srclen)) ||
+        (ret = xd3_emit_offset(stream, &HDR_TAIL(stream),
+                               stream->src->srcbase))) {
+      return ret;
+    }
+  }
+
+  tgt_len = stream->avail_in;
+  data_len = xd3_sizeof_output(DATA_HEAD(stream));
+  inst_len = xd3_sizeof_output(INST_HEAD(stream));
+  addr_len = xd3_sizeof_output(ADDR_HEAD(stream));
+
+  /* The enc_len field is a redundency for future extensions. */
+  enc_len = (1 +
+             (xd3_sizeof_size(tgt_len) + xd3_sizeof_size(data_len) +
+              xd3_sizeof_size(inst_len) + xd3_sizeof_size(addr_len)) +
+             data_len + inst_len + addr_len + (use_adler32 ? 4 : 0));
+
+  if ((ret = xd3_emit_size(stream, &HDR_TAIL(stream), enc_len)) ||
+      (ret = xd3_emit_size(stream, &HDR_TAIL(stream), tgt_len)) ||
+      (ret = xd3_emit_byte(stream, &HDR_TAIL(stream), del_ind)) ||
+      (ret = xd3_emit_size(stream, &HDR_TAIL(stream), data_len)) ||
+      (ret = xd3_emit_size(stream, &HDR_TAIL(stream), inst_len)) ||
+      (ret = xd3_emit_size(stream, &HDR_TAIL(stream), addr_len))) {
+    return ret;
+  }
+
+  if (use_adler32) {
+    uint8_t send[4];
+    uint32_t a32;
+
+    if (stream->flags & XD3_ADLER32) {
+      a32 = adler32(1L, stream->next_in, stream->avail_in);
+    } else {
+      a32 = stream->recode_adler32;
+    }
+
+    /* Four bytes. */
+    send[0] = (uint8_t)(a32 >> 24);
+    send[1] = (uint8_t)(a32 >> 16);
+    send[2] = (uint8_t)(a32 >> 8);
+    send[3] = (uint8_t)(a32 & 0x000000FFU);
+
+    if ((ret = xd3_emit_bytes(stream, &HDR_TAIL(stream), send, 4))) {
+      return ret;
+    }
+  }
+
+  return 0;
+}
+
+/****************************************************************
+ Encode routines
+ ****************************************************************/
+
+static int xd3_encode_buffer_leftover(xd3_stream *stream) {
+  usize_t take;
+  usize_t room;
+
+  /* Allocate the buffer. */
+  if (stream->buf_in == NULL && (stream->buf_in = (uint8_t *)xd3_alloc(
+                                     stream, stream->winsize, 1)) == NULL) {
+    return ENOMEM;
+  }
+
+  IF_DEBUG2(DP(RINT "[leftover] flush?=%s\n",
+               (stream->flags & XD3_FLUSH) ? "yes" : "no"));
+
+  /* Take leftover input first. */
+  if (stream->buf_leftover != NULL) {
+    XD3_ASSERT(stream->buf_avail == 0);
+    XD3_ASSERT(stream->buf_leftavail < stream->winsize);
+
+    IF_DEBUG2(DP(RINT "[leftover] previous %" XD3_W "u avail %" XD3_W "u\n",
+                 stream->buf_leftavail, stream->avail_in));
+
+    memcpy(stream->buf_in, stream->buf_leftover, stream->buf_leftavail);
+
+    stream->buf_leftover = NULL;
+    stream->buf_avail = stream->buf_leftavail;
+  }
+
+  /* Copy into the buffer. */
+  room = stream->winsize - stream->buf_avail;
+  take = xd3_min(room, stream->avail_in);
+
+  memcpy(stream->buf_in + stream->buf_avail, stream->next_in, take);
+
+  stream->buf_avail += take;
+
+  if (take < stream->avail_in) {
+    /* Buffer is full */
+    stream->buf_leftover = stream->next_in + take;
+    stream->buf_leftavail = stream->avail_in - take;
+  } else if ((stream->buf_avail < stream->winsize) &&
+             !(stream->flags & XD3_FLUSH)) {
+    /* Buffer has space */
+    IF_DEBUG2(DP(RINT "[leftover] emptied %" XD3_W "u\n", take));
+    return XD3_INPUT;
+  }
+
+  /* Use the buffer: */
+  IF_DEBUG2(DP(RINT "[leftover] take %" XD3_W "u remaining %" XD3_W "u\n", take,
+               stream->buf_leftavail));
+  stream->next_in = stream->buf_in;
+  stream->avail_in = stream->buf_avail;
+  stream->buf_avail = 0;
+
+  return 0;
+}
+
+/* Allocates one block of xd3_rlist elements */
+static int xd3_alloc_iopt(xd3_stream *stream, usize_t elts) {
+  usize_t i;
+  xd3_iopt_buflist *last =
+      (xd3_iopt_buflist *)xd3_alloc(stream, sizeof(xd3_iopt_buflist), 1);
+
+  if (last == NULL || (last->buffer = (xd3_rinst *)xd3_alloc(
+                           stream, sizeof(xd3_rinst), elts)) == NULL) {
+    return ENOMEM;
+  }
+
+  last->next = stream->iopt_alloc;
+  stream->iopt_alloc = last;
+
+  for (i = 0; i < elts; i += 1) {
+    xd3_rlist_push_back(&stream->iopt_free, &last->buffer[i]);
+  }
+
+  return 0;
+}
+
+/* This function allocates all memory initially used by the encoder. */
+static int xd3_encode_init(xd3_stream *stream, int full_init) {
+  int ret;
+  int i;
+
+  if (full_init) {
+    int large_comp = (stream->src != NULL);
+    int small_comp = !(stream->flags & XD3_NOCOMPRESS);
+
+    /* Memory allocations for checksum tables are delayed until
+     * xd3_string_match_init in the first call to string_match--that way
+     * identical or short inputs require no table allocation. */
+    if (large_comp) {
+      /* TODO Need to check for overflow here. */
+      usize_t hash_values =
+          stream->src->max_winsize / stream->smatcher.large_step;
+
+      if ((ret = xd3_size_hashtable(stream, hash_values,
+                                    stream->smatcher.large_look,
+                                    &stream->large_hash))) {
+        return ret;
+      }
+    }
+
+    if (small_comp) {
+      /* TODO: This is under devel: used to have min (sprevsz) here, which
+       * sort of makes sense, but observed fast performance w/ larger
+       * tables, which also sort of makes sense. @@@ */
+      usize_t hash_values = stream->winsize;
+
+      if ((ret = xd3_size_hashtable(stream, hash_values,
+                                    stream->smatcher.small_look,
+                                    &stream->small_hash))) {
+        return ret;
+      }
+    }
+  }
+
+  /* data buffers */
+  for (i = 0; i < ENC_SECTS; i += 1) {
+    if ((stream->enc_heads[i] = stream->enc_tails[i] =
+             xd3_alloc_output(stream, NULL)) == NULL) {
+      return ENOMEM;
+    }
+  }
+
+  /* iopt buffer */
+  xd3_rlist_init(&stream->iopt_used);
+  xd3_rlist_init(&stream->iopt_free);
+
+  if (xd3_alloc_iopt(stream, stream->iopt_size) != 0) {
+    goto fail;
+  }
+
+  XD3_ASSERT(xd3_rlist_length(&stream->iopt_free) == stream->iopt_size);
+  XD3_ASSERT(xd3_rlist_length(&stream->iopt_used) == 0);
+
+  /* address cache, code table */
+  stream->acache.s_near = stream->code_table_desc->near_modes;
+  stream->acache.s_same = stream->code_table_desc->same_modes;
+  stream->code_table = stream->code_table_func();
+
+  return xd3_alloc_cache(stream);
+
+fail:
+
+  return ENOMEM;
+}
+
+int xd3_encode_init_full(xd3_stream *stream) {
+  return xd3_encode_init(stream, 1);
+}
+
+int xd3_encode_init_partial(xd3_stream *stream) {
+  return xd3_encode_init(stream, 0);
+}
+
+/* Called after the ENC_POSTOUT state, this puts the output buffers
+ * back into separate lists and re-initializes some variables.  (The
+ * output lists were spliced together during the ENC_FLUSH state.) */
+static void xd3_encode_reset(xd3_stream *stream) {
+  int i;
+  xd3_output *olist;
+
+  stream->avail_in = 0;
+  stream->small_reset = 1;
+  stream->i_slots_used = 0;
+
+  if (stream->src != NULL) {
+    stream->src->srcbase = 0;
+    stream->src->srclen = 0;
+    stream->srcwin_decided = 0;
+    stream->srcwin_decided_early = 0;
+    stream->match_minaddr = 0;
+    stream->match_maxaddr = 0;
+    stream->taroff = 0;
+  }
+
+  /* Reset output chains. */
+  olist = stream->enc_heads[0];
+
+  for (i = 0; i < ENC_SECTS; i += 1) {
+    XD3_ASSERT(olist != NULL);
+
+    stream->enc_heads[i] = olist;
+    stream->enc_tails[i] = olist;
+    olist = olist->next_page;
+
+    stream->enc_heads[i]->next = 0;
+    stream->enc_heads[i]->next_page = NULL;
+
+    stream->enc_tails[i]->next_page = NULL;
+    stream->enc_tails[i] = stream->enc_heads[i];
+  }
+
+  xd3_freelist_output(stream, olist);
+}
+
+/* The main encoding routine. */
+int xd3_encode_input(xd3_stream *stream) {
+  int ret, i;
+
+  if (stream->dec_state != 0) {
+    stream->msg = "encoder/decoder transition";
+    return XD3_INTERNAL;
+  }
+
+  switch (stream->enc_state) {
+  case ENC_INIT:
+    /* Only reached on first time through: memory setup. */
+    if ((ret = xd3_encode_init_full(stream))) {
+      return ret;
+    }
+
+    stream->enc_state = ENC_INPUT;
+
+  case ENC_INPUT:
+
+    /* If there is no input yet, just return.  This checks for
+     * next_in == NULL, not avail_in == 0 since zero bytes is a
+     * valid input.  There is an assertion in xd3_avail_input() that
+     * next_in != NULL for this reason.  By returning right away we
+     * avoid creating an input buffer before the caller has supplied
+     * its first data.  It is possible for xd3_avail_input to be
+     * called both before and after the first call to
+     * xd3_encode_input(). */
+    if (stream->next_in == NULL) {
+      return XD3_INPUT;
+    }
+
+  enc_flush:
+    /* See if we should buffer the input: either if there is already
+     * a leftover buffer, or if the input is short of winsize
+     * without flush.  The label at this point is reached by a goto
+     * below, when there is leftover input after postout. */
+    if ((stream->buf_leftover != NULL) || (stream->buf_avail != 0) ||
+        (stream->avail_in < stream->winsize && !(stream->flags & XD3_FLUSH))) {
+      if ((ret = xd3_encode_buffer_leftover(stream))) {
+        return ret;
+      }
+    }
+
+    /* Initalize the address cache before each window. */
+    xd3_init_cache(&stream->acache);
+
+    stream->input_position = 0;
+    stream->min_match = MIN_MATCH;
+    stream->unencoded_offset = 0;
+
+    stream->enc_state = ENC_SEARCH;
+
+    IF_DEBUG2(DP(RINT "[WINSTART:%" XD3_Q "u] input bytes %" XD3_W
+                      "u offset %" XD3_Q "u\n",
+                 stream->current_window, stream->avail_in, stream->total_in));
+    return XD3_WINSTART;
+
+  case ENC_SEARCH:
+    IF_DEBUG2(DP(RINT "[SEARCH] match_state %d avail_in %" XD3_W "u %s\n",
+                 stream->match_state, stream->avail_in,
+                 stream->src ? "source" : "no source"));
+
+    /* Reentrant matching. */
+    if (stream->src != NULL) {
+      switch (stream->match_state) {
+      case MATCH_TARGET:
+        /* Try matching forward at the start of the target.
+         * This is entered the first time through, to check for
+         * a perfect match, and whenever there is a source match
+         * that extends to the end of the previous window.  The
+         * match_srcpos field is initially zero and later set
+         * during xd3_source_extend_match. */
+
+        if (stream->avail_in > 0) {
+          /* This call can't fail because the source window is
+           * unrestricted. */
+          ret = xd3_source_match_setup(stream, stream->match_srcpos);
+          XD3_ASSERT(ret == 0);
+          stream->match_state = MATCH_FORWARD;
+        } else {
+          stream->match_state = MATCH_SEARCHING;
+          stream->match_fwd = 0;
+        }
+        XD3_ASSERT(stream->match_fwd == 0);
+
+      case MATCH_FORWARD:
+      case MATCH_BACKWARD:
+        if (stream->avail_in != 0) {
+          if ((ret = xd3_source_extend_match(stream)) != 0) {
+            return ret;
+          }
+
+          /* The search has to make forward progress here
+           * or else it can get stuck in a match-backward
+           * (getsrcblk) then match-forward (getsrcblk),
+           * find insufficient match length, then repeat
+
+           * exactly the same search.
+           */
+          stream->input_position += stream->match_fwd;
+        }
+
+      case MATCH_SEARCHING:
+        /* Continue string matching.  (It's possible that the
+         * initial match continued through the entire input, in
+         * which case we're still in MATCH_FORWARD and should
+         * remain so for the next input window.) */
+        break;
+      }
+    }
+
+    /* String matching... */
+    if (stream->avail_in != 0 &&
+        (ret = stream->smatcher.string_match(stream))) {
+      return ret;
+    }
+
+    stream->enc_state = ENC_INSTR;
+
+  case ENC_INSTR:
+    /* Note: Jump here to encode VCDIFF deltas w/o using this
+     * string-matching code.  Merging code enters here. */
+
+    /* Flush the instrution buffer, then possibly add one more
+     * instruction, then emit the header. */
+    if ((ret = xd3_iopt_flush_instructions(stream, 1)) ||
+        (ret = xd3_iopt_add_finalize(stream))) {
+      return ret;
+    }
+
+    stream->enc_state = ENC_FLUSH;
+
+  case ENC_FLUSH:
+    /* Note: main_recode_func() bypasses string-matching by setting
+     * ENC_FLUSH. */
+    if ((ret = xd3_emit_hdr(stream))) {
+      return ret;
+    }
+
+    /* Begin output. */
+    stream->enc_current = HDR_HEAD(stream);
+
+    /* Chain all the outputs together.  After doing this, it looks
+     * as if there is only one section.  The other enc_heads are set
+     * to NULL to avoid freeing them more than once. */
+    for (i = 1; i < ENC_SECTS; i += 1) {
+      stream->enc_tails[i - 1]->next_page = stream->enc_heads[i];
+      stream->enc_heads[i] = NULL;
+    }
+
+  enc_output:
+
+    stream->enc_state = ENC_POSTOUT;
+    stream->next_out = stream->enc_current->base;
+    stream->avail_out = stream->enc_current->next;
+    stream->total_out += stream->avail_out;
+
+    /* If there is any output in this buffer, return it, otherwise
+     * fall through to handle the next buffer or finish the window
+     * after all buffers have been output. */
+    if (stream->avail_out > 0) {
+      /* This is the only place xd3_encode returns XD3_OUTPUT */
+      return XD3_OUTPUT;
+    }
+
+  case ENC_POSTOUT:
+
+    if (stream->avail_out != 0) {
+      stream->msg = "missed call to consume output";
+      return XD3_INTERNAL;
+    }
+
+    /* Continue outputting one buffer at a time, until the next is NULL. */
+    if ((stream->enc_current = stream->enc_current->next_page) != NULL) {
+      goto enc_output;
+    }
+
+    stream->total_in += stream->avail_in;
+    stream->enc_state = ENC_POSTWIN;
+
+    IF_DEBUG2(DP(RINT "[WINFINISH:%" XD3_Q "u] in=%" XD3_Q "u\n",
+                 stream->current_window, stream->total_in));
+    return XD3_WINFINISH;
+
+  case ENC_POSTWIN:
+
+    xd3_encode_reset(stream);
+
+    stream->current_window += 1;
+    stream->enc_state = ENC_INPUT;
+
+    /* If there is leftover input to flush, repeat. */
+    if (stream->buf_leftover != NULL) {
+      goto enc_flush;
+    }
+
+    /* Ready for more input. */
+    return XD3_INPUT;
+
+  default:
+    stream->msg = "invalid state";
+    return XD3_INTERNAL;
+  }
+}
+#endif /* XD3_ENCODER */
+
+/*****************************************************************
+ Client convenience functions
+ ******************************************************************/
+
+int xd3_process_stream(int is_encode, xd3_stream *stream,
+                       int (*func)(xd3_stream *), int close_stream,
+                       const uint8_t *input, usize_t input_size,
+                       uint8_t *output, usize_t *output_size,
+                       usize_t output_size_max) {
+  usize_t ipos = 0;
+  usize_t n = xd3_min(stream->winsize, input_size);
+
+  (*output_size) = 0;
+
+  stream->flags |= XD3_FLUSH;
+
+  xd3_avail_input(stream, input + ipos, n);
+  ipos += n;
+
+  for (;;) {
+    int ret;
+    switch ((ret = func(stream))) {
+    case XD3_OUTPUT: { /* memcpy below */
+      break;
+    }
+    case XD3_INPUT: {
+      n = xd3_min(stream->winsize, input_size - ipos);
+      if (n == 0) {
+        goto done;
+      }
+      xd3_avail_input(stream, input + ipos, n);
+      ipos += n;
+      continue;
+    }
+    case XD3_GOTHEADER: { /* ignore */
+      continue;
+    }
+    case XD3_WINSTART: { /* ignore */
+      continue;
+    }
+    case XD3_WINFINISH: { /* ignore */
+      continue;
+    }
+    case XD3_GETSRCBLK: {
+      /* When the getblk function is NULL, it is necessary to
+       * provide the complete source as a single block using
+       * xd3_set_source_and_size, otherwise this error.  The
+       * library should never ask for another source block. */
+      stream->msg = "library requested source block";
+      return XD3_INTERNAL;
+    }
+    case 0: {
+      /* xd3_encode_input/xd3_decode_input never return 0 */
+      stream->msg = "invalid return: 0";
+      return XD3_INTERNAL;
+    }
+    default:
+      return ret;
+    }
+
+    if (*output_size + stream->avail_out > output_size_max) {
+      stream->msg = "insufficient output space";
+      return ENOSPC;
+    }
+
+    memcpy(output + *output_size, stream->next_out, stream->avail_out);
+
+    *output_size += stream->avail_out;
+
+    xd3_consume_output(stream);
+  }
+done:
+  return (close_stream == 0) ? 0 : xd3_close_stream(stream);
+}
+
+static int xd3_process_memory(int is_encode, int (*func)(xd3_stream *),
+                              const uint8_t *input, usize_t input_size,
+                              const uint8_t *source, usize_t source_size,
+                              uint8_t *output, usize_t *output_size,
+                              usize_t output_size_max, int flags) {
+  xd3_stream stream;
+  xd3_config config;
+  xd3_source src;
+  int ret;
+
+  memset(&stream, 0, sizeof(stream));
+  memset(&config, 0, sizeof(config));
+
+  if (input == NULL || output == NULL) {
+    stream.msg = "invalid input/output buffer";
+    ret = XD3_INTERNAL;
+    goto exit;
+  }
+
+  config.flags = flags;
+
+  if (is_encode) {
+    /* The convenience encoder always emits a per-window checksum so
+       decoders can detect a wrong source or a corrupt delta. */
+    config.flags |= XD3_ADLER32;
+    config.winsize = xd3_min(input_size, (usize_t)XD3_DEFAULT_WINSIZE);
+    config.sprevsz = xd3_pow2_roundup(config.winsize);
+  }
+
+  if ((ret = xd3_config_stream(&stream, &config)) != 0) {
+    goto exit;
+  }
+
+  if (source != NULL) {
+    memset(&src, 0, sizeof(src));
+
+    src.blksize = source_size;
+    src.onblk = source_size;
+    src.curblk = source;
+    src.curblkno = 0;
+    src.max_winsize = source_size;
+
+    if ((ret = xd3_set_source_and_size(&stream, &src, source_size)) != 0) {
+      goto exit;
+    }
+  }
+
+  if ((ret = xd3_process_stream(is_encode, &stream, func, 1, input, input_size,
+                                output, output_size, output_size_max)) != 0) {
+    goto exit;
+  }
+
+exit:
+  if (ret != 0) {
+    IF_DEBUG2(DP(RINT "process_memory: %d: %s\n", ret, stream.msg));
+  }
+  xd3_free_stream(&stream);
+  return ret;
+}
+
+int xd3_decode_stream(xd3_stream *stream, const uint8_t *input,
+                      usize_t input_size, uint8_t *output, usize_t *output_size,
+                      usize_t output_size_max) {
+  return xd3_process_stream(0, stream, &xd3_decode_input, 1, input, input_size,
+                            output, output_size, output_size_max);
+}
+
+int xd3_decode_memory(const uint8_t *input, usize_t input_size,
+                      const uint8_t *source, usize_t source_size,
+                      uint8_t *output, usize_t *output_size,
+                      usize_t output_size_max, int flags) {
+  return xd3_process_memory(0, &xd3_decode_input, input, input_size, source,
+                            source_size, output, output_size, output_size_max,
+                            flags);
+}
+
+#if XD3_ENCODER
+int xd3_encode_stream(xd3_stream *stream, const uint8_t *input,
+                      usize_t input_size, uint8_t *output, usize_t *output_size,
+                      usize_t output_size_max) {
+  return xd3_process_stream(1, stream, &xd3_encode_input, 1, input, input_size,
+                            output, output_size, output_size_max);
+}
+
+int xd3_encode_memory(const uint8_t *input, usize_t input_size,
+                      const uint8_t *source, usize_t source_size,
+                      uint8_t *output, usize_t *output_size,
+                      usize_t output_size_max, int flags) {
+  return xd3_process_memory(1, &xd3_encode_input, input, input_size, source,
+                            source_size, output, output_size, output_size_max,
+                            flags);
+}
+#endif
+
+/*************************************************************
+ String matching helpers
+ *************************************************************/
+
+#if XD3_ENCODER
+/* Do the initial xd3_string_match() checksum table setup.
+ * Allocations are delayed until first use to avoid allocation
+ * sometimes (e.g., perfect matches, zero-length inputs). */
+static int xd3_string_match_init(xd3_stream *stream) {
+  const int DO_SMALL = !(stream->flags & XD3_NOCOMPRESS);
+  const int DO_LARGE = (stream->src != NULL);
+
+  if (DO_LARGE && stream->large_table == NULL) {
+    if ((stream->large_table = (usize_t *)xd3_alloc0(
+             stream, stream->large_hash.size, sizeof(usize_t))) == NULL) {
+      return ENOMEM;
+    }
+  }
+
+  if (DO_SMALL) {
+    /* Subsequent calls can return immediately after checking reset. */
+    if (stream->small_table != NULL) {
+      /* The target hash table is reinitialized once per window. */
+      /* TODO: This would not have to be reinitialized if absolute
+       * offsets were being stored. */
+      if (stream->small_reset) {
+        stream->small_reset = 0;
+        memset(stream->small_table, 0,
+               sizeof(usize_t) * stream->small_hash.size);
+      }
+
+      return 0;
+    }
+
+    if ((stream->small_table = (usize_t *)xd3_alloc0(
+             stream, stream->small_hash.size, sizeof(usize_t))) == NULL) {
+      return ENOMEM;
+    }
+
+    /* If there is a previous table needed. */
+    if (stream->smatcher.small_lchain > 1 || stream->smatcher.small_chain > 1) {
+      if ((stream->small_prev = (xd3_slist *)xd3_alloc(
+               stream, stream->sprevsz, sizeof(xd3_slist))) == NULL) {
+        return ENOMEM;
+      }
+    }
+  }
+
+  return 0;
+}
+
+#if XD3_USE_LARGEFILE64 && !XD3_USE_LARGESIZET
+/* This function handles the 32/64bit ambiguity -- file positions are 64bit
+ * but the hash table for source-offsets is 32bit. */
+static xoff_t xd3_source_cksum_offset(xd3_stream *stream, usize_t low) {
+  xoff_t scp = stream->srcwin_cksum_pos;
+  xoff_t s0 = scp >> 32;
+
+  usize_t sr = (usize_t)scp;
+
+  if (s0 == 0) {
+    return low;
+  }
+
+  /* This should not be >= because srcwin_cksum_pos is the next
+   * position to index. */
+  if (low > sr) {
+    return (--s0 << 32) | low;
+  }
+
+  return (s0 << 32) | low;
+}
+#else
+static xoff_t xd3_source_cksum_offset(xd3_stream *stream, usize_t low) {
+  return low;
+}
+#endif
+
+/* This function sets up the stream->src fields srcbase, srclen.  The
+ * call is delayed until these values are needed to encode a copy
+ * address.  At this point the decision has to be made. */
+static int xd3_srcwin_setup(xd3_stream *stream) {
+  xd3_source *src = stream->src;
+  xoff_t length, x;
+
+  /* Check the undecided state. */
+  XD3_ASSERT(src->srclen == 0 && src->srcbase == 0);
+
+  /* Avoid repeating this call. */
+  stream->srcwin_decided = 1;
+
+  /* If the stream is flushing, then the iopt buffer was able to
+   * contain the complete encoding.  If no copies were issued no
+   * source window is actually needed.  This prevents the VCDIFF
+   * header from including source base/len.  xd3_emit_hdr checks for
+   * srclen == 0. */
+  if (stream->enc_state == ENC_INSTR && stream->match_maxaddr == 0) {
+    goto done;
+  }
+
+  /* Check for overflow, srclen is usize_t - this can't happen unless
+   * XD3_DEFAULT_SRCBACK and related parameters are extreme - should
+   * use smaller windows. */
+  length = stream->match_maxaddr - stream->match_minaddr;
+
+  x = USIZE_T_MAX;
+  if (length > x) {
+    stream->msg = "source window length overflow (not 64bit)";
+    return XD3_INTERNAL;
+  }
+
+  /* If ENC_INSTR, then we know the exact source window to use because
+   * no more copies can be issued. */
+  if (stream->enc_state == ENC_INSTR) {
+    src->srcbase = stream->match_minaddr;
+    src->srclen = (usize_t)length;
+    XD3_ASSERT(src->srclen);
+    goto done;
+  }
+
+  /* Otherwise, we have to make a guess.  More copies may still be
+   * issued, but we have to decide the source window base and length
+   * now.
+   * TODO: This may not working well in practice, more testing needed. */
+  src->srcbase = stream->match_minaddr;
+  src->srclen =
+      xd3_max((usize_t)length, stream->avail_in + (stream->avail_in >> 2));
+
+  if (src->eof_known) {
+    /* Note: if the source size is known, we must reduce srclen or
+     * code that expects to pass a single block w/ getblk == NULL
+     * will not function, as the code will return GETSRCBLK asking
+     * for the second block. */
+    src->srclen = xd3_min(src->srclen, xd3_source_eof(src) - src->srcbase);
+  }
+  IF_DEBUG1(DP(RINT "[srcwin_setup_constrained] base %" XD3_Q "u len %" XD3_W
+                    "u\n",
+               src->srcbase, src->srclen));
+
+  XD3_ASSERT(src->srclen);
+done:
+  /* Set the taroff.  This convenience variable is used even when
+     stream->src == NULL. */
+  stream->taroff = src->srclen;
+  return 0;
+}
+
+/* Sets the bounding region for a newly discovered source match, prior
+ * to calling xd3_source_extend_match().  This sets the match_maxfwd,
+ * match_maxback variables.  Note: srcpos is an absolute position
+ * (xoff_t) but the match_maxfwd, match_maxback variables are usize_t.
+ * Returns 0 if the setup succeeds, or 1 if the source position lies
+ * outside an already-decided srcbase/srclen window. */
+static int xd3_source_match_setup(xd3_stream *stream, xoff_t srcpos) {
+  xd3_source *const src = stream->src;
+  usize_t greedy_or_not;
+
+  stream->match_maxback = 0;
+  stream->match_maxfwd = 0;
+  stream->match_back = 0;
+  stream->match_fwd = 0;
+
+  /* This avoids a non-blocking endless loop caused by scanning
+   * backwards across a block boundary, only to find not enough
+   * matching bytes to beat the current min_match due to a better lazy
+   * target match: the re-entry to xd3_string_match() repeats the same
+   * long match because the input position hasn't changed.  TODO: if
+   * ever duplicates are added to the source hash table, this logic
+   * won't suffice to avoid loops.  See testing/regtest.cc's
+   * TestNonBlockingProgress test! */
+  if (srcpos != 0 && srcpos == stream->match_last_srcpos) {
+    IF_DEBUG2(DP(RINT "[match_setup] looping failure\n"));
+    goto bad;
+  }
+
+  /* Implement src->max_winsize, which prevents the encoder from seeking
+   * back further than the LRU cache maintaining FIFO discipline, (to
+   * avoid seeking). */
+  if (srcpos < stream->srcwin_cksum_pos &&
+      stream->srcwin_cksum_pos - srcpos > src->max_winsize) {
+    IF_DEBUG2(DP(RINT "[match_setup] rejected due to src->max_winsize "
+                      "distance eof=%" XD3_Q "u srcpos=%" XD3_Q
+                      "u max_winsz=%" XD3_Q "u\n",
+                 xd3_source_eof(src), srcpos, src->max_winsize));
+    goto bad;
+  }
+
+  /* There are cases where the above test does not reject a match that
+   * will experience XD3_TOOFARBACK at the first xd3_getblk call
+   * because the input may have advanced up to one block beyond the
+   * actual EOF. */
+  IF_DEBUG2(DP(RINT "[match_setup] %" XD3_Q "u srcpos %" XD3_Q "u, "
+                    "src->max_winsize %" XD3_Q "u\n",
+               stream->total_in + stream->input_position, srcpos,
+               src->max_winsize));
+
+  /* Going backwards, the 1.5-pass algorithm allows some
+   * already-matched input may be covered by a longer source match.
+   * The greedy algorithm does not allow this.
+   * TODO: Measure this. */
+  if (stream->flags & XD3_BEGREEDY) {
+    /* The greedy algorithm allows backward matching to the last
+     * matched position. */
+    greedy_or_not = xd3_iopt_last_matched(stream);
+  } else {
+    /* The 1.5-pass algorithm allows backward matching to go back as
+     * far as the unencoded offset, which is updated as instructions
+     * pass out of the iopt buffer.  If this (default) is chosen, it
+     * means xd3_iopt_erase may be called to eliminate instructions
+     * when a covering source match is found. */
+    greedy_or_not = stream->unencoded_offset;
+  }
+
+  /* Backward target match limit. */
+  XD3_ASSERT(stream->input_position >= greedy_or_not);
+  stream->match_maxback = stream->input_position - greedy_or_not;
+
+  /* Forward target match limit. */
+  XD3_ASSERT(stream->avail_in > stream->input_position);
+  stream->match_maxfwd = stream->avail_in - stream->input_position;
+
+  /* Now we take the source position into account.  It depends whether
+   * the srclen/srcbase have been decided yet. */
+  if (stream->srcwin_decided == 0) {
+    /* Unrestricted case: the match can cover the entire source,
+     * 0--src->size.  We compare the usize_t
+     * match_maxfwd/match_maxback against the xoff_t
+     * src->size/srcpos values and take the min. */
+    /* TODO #if XD3_USE_LARGESIZET ? */
+    if (srcpos < stream->match_maxback) {
+      stream->match_maxback = (usize_t)srcpos;
+    }
+
+    if (src->eof_known) {
+      xoff_t srcavail = xd3_source_eof(src) - srcpos;
+
+      if (srcavail < stream->match_maxfwd) {
+        stream->match_maxfwd = (usize_t)srcavail;
+      }
+    }
+
+    IF_DEBUG2(DP(RINT "[match_setup] srcpos %" XD3_Q "u (tgtpos %" XD3_Q "u) "
+                      "unrestricted maxback %" XD3_W "u maxfwd %" XD3_W "u\n",
+                 srcpos, stream->total_in + stream->input_position,
+                 stream->match_maxback, stream->match_maxfwd));
+    goto good;
+  }
+
+  /* Decided some source window. */
+  XD3_ASSERT(src->srclen > 0);
+
+  /* Restricted case: fail if the srcpos lies outside the source window */
+  if ((srcpos < src->srcbase) || (srcpos > (src->srcbase + src->srclen))) {
+    IF_DEBUG1(DP(RINT "[match_setup] restricted source window failure\n"));
+    goto bad;
+  } else {
+    usize_t srcavail;
+
+    srcavail = (usize_t)(srcpos - src->srcbase);
+    if (srcavail < stream->match_maxback) {
+      stream->match_maxback = srcavail;
+    }
+
+    srcavail = src->srcbase + src->srclen - srcpos;
+    if (srcavail < stream->match_maxfwd) {
+      stream->match_maxfwd = srcavail;
+    }
+
+    IF_DEBUG2(DP(RINT "[match_setup] srcpos %" XD3_Q "u (tgtpos %" XD3_Q "u) "
+                      "restricted maxback %" XD3_W "u maxfwd %" XD3_W "u\n",
+                 srcpos, stream->total_in + stream->input_position,
+                 stream->match_maxback, stream->match_maxfwd));
+    goto good;
+  }
+
+good:
+  stream->match_state = MATCH_BACKWARD;
+  stream->match_srcpos = srcpos;
+  stream->match_last_srcpos = srcpos;
+  return 0;
+
+bad:
+  stream->match_state = MATCH_SEARCHING;
+  stream->match_last_srcpos = srcpos;
+  return 1;
+}
+
+static inline usize_t xd3_forward_match(const uint8_t *s1c, const uint8_t *s2c,
+                                        usize_t n) {
+  usize_t i = 0;
+#if UNALIGNED_OK
+  usize_t nint = n / sizeof(int);
+
+  if (nint >> 3) {
+    usize_t j = 0;
+    const int *s1 = (const int *)s1c;
+    const int *s2 = (const int *)s2c;
+    usize_t nint_8 = nint - 8;
+
+    while (i <= nint_8 && s1[i++] == s2[j++] && s1[i++] == s2[j++] &&
+           s1[i++] == s2[j++] && s1[i++] == s2[j++] && s1[i++] == s2[j++] &&
+           s1[i++] == s2[j++] && s1[i++] == s2[j++] && s1[i++] == s2[j++]) {
+    }
+
+    i = (i - 1) * sizeof(int);
+  }
+#endif
+
+  while (i < n && s1c[i] == s2c[i]) {
+    i++;
+  }
+  return i;
+}
+
+/* This function expands the source match backward and forward.  It is
+ * reentrant, since xd3_getblk may return XD3_GETSRCBLK, so most
+ * variables are kept in xd3_stream.  There are two callers of this
+ * function, the string_matching routine when a checksum match is
+ * discovered, and xd3_encode_input whenever a continuing (or initial)
+ * match is suspected.  The two callers do different things with the
+ * input_position, thus this function leaves that variable untouched.
+ * If a match is taken the resulting stream->match_fwd is left
+ * non-zero. */
+static int xd3_source_extend_match(xd3_stream *stream) {
+  int ret;
+  xd3_source *const src = stream->src;
+  xoff_t matchoff;   /* matchoff is the current right/left-boundary of
+                        the source match being tested. */
+  usize_t streamoff; /* streamoff is the current right/left-boundary
+                        of the input match being tested. */
+  xoff_t tryblk;     /* tryblk, tryoff are the block, offset position
+                        of matchoff */
+  usize_t tryoff;
+  usize_t tryrem; /* tryrem is the number of matchable bytes */
+  usize_t matched;
+
+  IF_DEBUG2(
+      DP(RINT "[extend match] srcpos %" XD3_Q "u\n", stream->match_srcpos));
+
+  XD3_ASSERT(src != NULL);
+
+  /* Does it make sense to compute backward match AFTER forward match? */
+  if (stream->match_state == MATCH_BACKWARD) {
+    /* Note: this code is practically duplicated below, substituting
+     * match_fwd/match_back and direction. */
+    matchoff = stream->match_srcpos - stream->match_back;
+    streamoff = stream->input_position - stream->match_back;
+    xd3_blksize_div(matchoff, src, &tryblk, &tryoff);
+
+    /* this loops backward over source blocks */
+    while (stream->match_back < stream->match_maxback) {
+      /* see if we're backing across a source block boundary */
+      if (tryoff == 0) {
+        tryoff = src->blksize;
+        tryblk -= 1;
+      }
+
+      if ((ret = xd3_getblk(stream, tryblk))) {
+        if (ret == XD3_TOOFARBACK) {
+          IF_DEBUG2(DP(RINT "[maxback] %" XD3_Q "u TOOFARBACK: %" XD3_W
+                            "u INP %" XD3_Q "u CKSUM %" XD3_Q "u\n",
+                       tryblk, stream->match_back,
+                       stream->total_in + stream->input_position,
+                       stream->srcwin_cksum_pos));
+
+          /* the starting position is too far back. */
+          if (stream->match_back == 0) {
+            XD3_ASSERT(stream->match_fwd == 0);
+            goto donefwd;
+          }
+
+          /* search went too far back, continue forward. */
+          goto doneback;
+        }
+
+        /* could be a XD3_GETSRCBLK failure. */
+        return ret;
+      }
+
+      tryrem = xd3_min(tryoff, stream->match_maxback - stream->match_back);
+
+      IF_DEBUG2(DP(RINT "[maxback] maxback %" XD3_W "u trysrc %" XD3_Q
+                        "u/%" XD3_W "u tgt %" XD3_W "u tryrem %" XD3_W "u\n",
+                   stream->match_maxback, tryblk, tryoff, streamoff, tryrem));
+
+      /* TODO: This code can be optimized similar to xd3_match_forward() */
+      for (; tryrem != 0; tryrem -= 1, stream->match_back += 1) {
+        if (src->curblk[tryoff - 1] != stream->next_in[streamoff - 1]) {
+          goto doneback;
+        }
+
+        tryoff -= 1;
+        streamoff -= 1;
+      }
+    }
+
+  doneback:
+    stream->match_state = MATCH_FORWARD;
+  }
+
+  XD3_ASSERT(stream->match_state == MATCH_FORWARD);
+
+  matchoff = stream->match_srcpos + stream->match_fwd;
+  streamoff = stream->input_position + stream->match_fwd;
+  xd3_blksize_div(matchoff, src, &tryblk, &tryoff);
+
+  /* Note: practically the same code as backwards case above: same comments */
+  while (stream->match_fwd < stream->match_maxfwd) {
+    if (tryoff == src->blksize) {
+      tryoff = 0;
+      tryblk += 1;
+    }
+
+    if ((ret = xd3_getblk(stream, tryblk))) {
+      if (ret == XD3_TOOFARBACK) {
+        IF_DEBUG2(DP(RINT "[maxfwd] %" XD3_Q "u TOOFARBACK: %" XD3_W
+                          "u INP %" XD3_Q "u CKSUM %" XD3_Q "u\n",
+                     tryblk, stream->match_fwd,
+                     stream->total_in + stream->input_position,
+                     stream->srcwin_cksum_pos));
+        goto donefwd;
+      }
+
+      /* could be a XD3_GETSRCBLK failure. */
+      return ret;
+    }
+
+    tryrem =
+        xd3_min(stream->match_maxfwd - stream->match_fwd, src->onblk - tryoff);
+
+    if (tryrem == 0) {
+      /* Generally, this means we have a power-of-two size source
+       * and we just found the end-of-file, in this case it's an
+       * empty block. */
+      XD3_ASSERT(src->onblk < src->blksize);
+      break;
+    }
+
+    matched = xd3_forward_match(src->curblk + tryoff,
+                                stream->next_in + streamoff, tryrem);
+    tryoff += matched;
+    streamoff += matched;
+    stream->match_fwd += matched;
+
+    if (tryrem != matched) {
+      break;
+    }
+  }
+
+donefwd:
+  stream->match_state = MATCH_SEARCHING;
+
+  IF_DEBUG2(DP(RINT "[extend match] input %" XD3_Q "u srcpos %" XD3_Q
+                    "u len %" XD3_W "u\n",
+               stream->input_position + stream->total_in, stream->match_srcpos,
+               stream->match_fwd));
+
+  /* If the match ends short of the last instruction end, we probably
+   * don't want it.  There is the possibility that a copy ends short
+   * of the last copy but also goes further back, in which case we
+   * might want it.  This code does not implement such: if so we would
+   * need more complicated xd3_iopt_erase logic. */
+  if (stream->match_fwd < stream->min_match) {
+    stream->match_fwd = 0;
+  } else {
+    usize_t total = stream->match_fwd + stream->match_back;
+
+    /* Correct the variables to remove match_back from the equation. */
+    usize_t target_position = stream->input_position - stream->match_back;
+    usize_t match_length = stream->match_back + stream->match_fwd;
+    xoff_t match_position = stream->match_srcpos - stream->match_back;
+    xoff_t match_end = stream->match_srcpos + stream->match_fwd;
+
+    /* At this point we may have to erase any iopt-buffer
+     * instructions that are fully covered by a backward-extending
+     * copy. */
+    if (stream->match_back > 0) {
+      xd3_iopt_erase(stream, target_position, total);
+    }
+
+    stream->match_back = 0;
+
+    /* Update ranges.  The first source match occurs with both
+       values set to 0. */
+    if (stream->match_maxaddr == 0 || match_position < stream->match_minaddr) {
+      stream->match_minaddr = match_position;
+    }
+
+    if (match_end > stream->match_maxaddr) {
+      /* Note: per-window */
+      stream->match_maxaddr = match_end;
+    }
+
+    if (match_end > stream->maxsrcaddr) {
+      /* Note: across windows */
+      stream->maxsrcaddr = match_end;
+    }
+
+    IF_DEBUG2({
+      static int x = 0;
+      DP(RINT "[source match:%d] length %" XD3_W "u <inp %" XD3_Q "u %" XD3_Q
+              "u>  <src %" XD3_Q "u %" XD3_Q "u> (%s)\n",
+         x++, match_length, stream->total_in + target_position,
+         stream->total_in + target_position + match_length, match_position,
+         match_position + match_length,
+         (stream->total_in + target_position == match_position) ? "same"
+                                                                : "diff");
+    });
+
+    if ((ret = xd3_found_match(stream,
+                               /* decoder position */ target_position,
+                               /* length */ match_length,
+                               /* address */ match_position,
+                               /* is_source */ 1))) {
+      return ret;
+    }
+
+    /* If the match ends with the available input: */
+    if (target_position + match_length == stream->avail_in) {
+      /* Setup continuing match for the next window. */
+      stream->match_state = MATCH_TARGET;
+      stream->match_srcpos = match_end;
+    }
+  }
+
+  return 0;
+}
+
+/* Update the small hash.  Values in the small_table are offset by
+ * HASH_CKOFFSET (1) to distinguish empty buckets from real offsets. */
+static void xd3_scksum_insert(xd3_stream *stream, usize_t inx, usize_t scksum,
+                              usize_t pos) {
+  /* If we are maintaining previous duplicates. */
+  if (stream->small_prev) {
+    usize_t last_pos = stream->small_table[inx];
+    xd3_slist *pos_list = &stream->small_prev[pos & stream->sprevmask];
+
+    /* Note last_pos is offset by HASH_CKOFFSET. */
+    pos_list->last_pos = last_pos;
+  }
+
+  /* Enter the new position into the hash bucket. */
+  stream->small_table[inx] = pos + HASH_CKOFFSET;
+}
+
+#if XD3_DEBUG
+static int xd3_check_smatch(const uint8_t *ref0, const uint8_t *inp0,
+                            const uint8_t *inp_max, usize_t cmp_len) {
+  usize_t i;
+
+  for (i = 0; i < cmp_len; i += 1) {
+    XD3_ASSERT(ref0[i] == inp0[i]);
+  }
+
+  if (inp0 + cmp_len < inp_max) {
+    XD3_ASSERT(inp0[i] != ref0[i]);
+  }
+
+  return 1;
+}
+#endif /* XD3_DEBUG */
+
+/* When the hash table indicates a possible small string match, it
+ * calls this routine to find the best match.  The first matching
+ * position is taken from the small_table, HASH_CKOFFSET is subtracted
+ * to get the actual position.  After checking that match, if previous
+ * linked lists are in use (because stream->smatcher.small_chain > 1),
+ * previous matches are tested searching for the longest match.  If
+ * (stream->min_match > MIN_MATCH) then a lazy match is in effect.
+ */
+static usize_t xd3_smatch(xd3_stream *stream, usize_t base, usize_t scksum,
+                          usize_t *match_offset) {
+  usize_t cmp_len;
+  usize_t match_length = 0;
+  usize_t chain =
+      (stream->min_match == MIN_MATCH ? stream->smatcher.small_chain
+                                      : stream->smatcher.small_lchain);
+  const uint8_t *inp_max = stream->next_in + stream->avail_in;
+  const uint8_t *inp;
+  const uint8_t *ref;
+
+  SMALL_HASH_DEBUG1(stream, stream->next_in + stream->input_position);
+
+  XD3_ASSERT(stream->min_match + stream->input_position <= stream->avail_in);
+
+  base -= HASH_CKOFFSET;
+
+again:
+
+  IF_DEBUG2(DP(RINT "smatch at base=%" XD3_W "u inp=%" XD3_W "u cksum=%" XD3_W
+                    "u\n",
+               base, stream->input_position, scksum));
+
+  /* For small matches, we can always go to the end-of-input because
+   * the matching position must be less than the input position. */
+  XD3_ASSERT(base < stream->input_position);
+
+  ref = stream->next_in + base;
+  inp = stream->next_in + stream->input_position;
+
+  SMALL_HASH_DEBUG2(stream, ref);
+
+  /* Expand potential match forward. */
+  while (inp < inp_max && *inp == *ref) {
+    ++inp;
+    ++ref;
+  }
+
+  cmp_len = (usize_t)(inp - (stream->next_in + stream->input_position));
+
+  /* Verify correctness */
+  XD3_ASSERT(xd3_check_smatch(stream->next_in + base,
+                              stream->next_in + stream->input_position, inp_max,
+                              cmp_len));
+
+  /* Update longest match */
+  if (cmp_len > match_length) {
+    (match_length) = cmp_len;
+    (*match_offset) = base;
+
+    /* Stop if we match the entire input or have a long_enough match. */
+    if (inp == inp_max || cmp_len >= stream->smatcher.long_enough) {
+      goto done;
+    }
+  }
+
+  /* If we have not reached the chain limit, see if there is another
+     previous position. */
+  while (--chain != 0) {
+    /* Calculate the previous offset. */
+    usize_t prev_pos = stream->small_prev[base & stream->sprevmask].last_pos;
+    usize_t diff_pos;
+
+    if (prev_pos == 0) {
+      break;
+    }
+
+    prev_pos -= HASH_CKOFFSET;
+
+    if (prev_pos > base) {
+      break;
+    }
+
+    base = prev_pos;
+
+    XD3_ASSERT(stream->input_position > base);
+    diff_pos = stream->input_position - base;
+
+    /* Stop searching if we go beyond sprevsz, since those entries
+     * are for unrelated checksum entries. */
+    if (diff_pos & ~stream->sprevmask) {
+      break;
+    }
+
+    goto again;
+  }
+
+done:
+  /* Crude efficiency test: if the match is very short and very far back, it's
+   * unlikely to help, but the exact calculation requires knowing the state of
+   * the address cache and adjacent instructions, which we can't do here.
+   * Rather than encode a probably inefficient copy here and check it later
+   * (which complicates the code a lot), do this:
+   */
+  if (match_length == 4 &&
+      stream->input_position - (*match_offset) >= 1 << 14) {
+    /* It probably takes >2 bytes to encode an address >= 2^14 from here */
+    return 0;
+  }
+  if (match_length == 5 &&
+      stream->input_position - (*match_offset) >= 1 << 21) {
+    /* It probably takes >3 bytes to encode an address >= 2^21 from here */
+    return 0;
+  }
+
+  /* It's unlikely that a window is large enough for the (match_length == 6 &&
+   * address >= 2^28) check */
+  return match_length;
+}
+
+#if XD3_DEBUG
+static void xd3_verify_small_state(xd3_stream *stream, const uint8_t *inp,
+                                   uint32_t x_cksum) {
+  uint32_t state;
+  uint32_t cksum = xd3_scksum(&state, inp, stream->smatcher.small_look);
+
+  XD3_ASSERT(cksum == x_cksum);
+}
+
+static void xd3_verify_large_state(xd3_stream *stream, const uint8_t *inp,
+                                   usize_t x_cksum) {
+  usize_t cksum =
+      xd3_large_cksum(&stream->large_hash, inp, stream->smatcher.large_look);
+  XD3_ASSERT(cksum == x_cksum);
+}
+static void xd3_verify_run_state(xd3_stream *stream, const uint8_t *inp,
+                                 usize_t x_run_l, uint8_t *x_run_c) {
+  usize_t slook = stream->smatcher.small_look;
+  uint8_t run_c;
+  usize_t run_l = xd3_comprun(inp, slook, &run_c);
+
+  XD3_ASSERT(run_l == 0 || run_c == *x_run_c);
+  XD3_ASSERT(x_run_l > slook || run_l == x_run_l);
+}
+#endif /* XD3_DEBUG */
+
+/* This function computes more source checksums to advance the window.
+ * Called at every entrance to the string-match loop and each time
+ * stream->input_position reaches the value returned as
+ * *next_move_point.  NB: this is one of the most expensive functions
+ * in this code and also the most critical for good compression.
+ */
+static int xd3_srcwin_move_point(xd3_stream *stream, usize_t *next_move_point) {
+  /* the source file is indexed until this point */
+  xoff_t target_cksum_pos;
+  /* the absolute target file input position */
+  xoff_t absolute_input_pos;
+
+  if (stream->src->eof_known) {
+    xoff_t source_size = xd3_source_eof(stream->src);
+    XD3_ASSERT(stream->srcwin_cksum_pos <= source_size);
+
+    if (stream->srcwin_cksum_pos == source_size) {
+      *next_move_point = USIZE_T_MAX;
+      return 0;
+    }
+  }
+
+  absolute_input_pos = stream->total_in + stream->input_position;
+
+  /* Immediately read the entire window.
+   *
+   * Note: this reverses a long held policy, at this point in the
+   * code, of advancing relatively slowly as the input is read, which
+   * results in better compression for very-similar inputs, but worse
+   * compression where data is deleted near the beginning of the file.
+   *
+   * The new policy is simpler, somewhat slower and can benefit, or
+   * slightly worsen, compression performance. */
+  if (absolute_input_pos < stream->src->max_winsize / 2) {
+    target_cksum_pos = stream->src->max_winsize;
+  } else {
+    /* TODO: The addition of 2 blocks here is arbitrary.  Do a
+     * better job of stream alignment based on observed source copy
+     * addresses, and when both input sizes are known, the
+     * difference in size. */
+    target_cksum_pos = absolute_input_pos + stream->src->max_winsize / 2 +
+                       stream->src->blksize * 2;
+    target_cksum_pos &= ~stream->src->maskby;
+  }
+
+  /* A long match may have extended past srcwin_cksum_pos.  Don't
+   * start checksumming already-matched source data. */
+  if (stream->maxsrcaddr > stream->srcwin_cksum_pos) {
+    stream->srcwin_cksum_pos = stream->maxsrcaddr;
+  }
+
+  if (target_cksum_pos < stream->srcwin_cksum_pos) {
+    target_cksum_pos = stream->srcwin_cksum_pos;
+  }
+
+  while (stream->srcwin_cksum_pos < target_cksum_pos &&
+         (!stream->src->eof_known ||
+          stream->srcwin_cksum_pos < xd3_source_eof(stream->src))) {
+    xoff_t blkno;
+    xoff_t blkbaseoffset;
+    usize_t blkrem;
+    ssize_t oldpos; /* Using ssize_t because of a  */
+    ssize_t blkpos; /* do { blkpos-- }
+                       while (blkpos >= oldpos); */
+    int ret;
+    xd3_blksize_div(stream->srcwin_cksum_pos, stream->src, &blkno, &blkrem);
+    oldpos = (ssize_t)blkrem;
+
+    if ((ret = xd3_getblk(stream, blkno))) {
+      /* TOOFARBACK should never occur here, since we read forward. */
+      if (ret == XD3_TOOFARBACK) {
+        ret = XD3_INTERNAL;
+      }
+
+      IF_DEBUG1(DP(RINT "[srcwin_move_point] async getblk return for %" XD3_Q
+                        "u: %s\n",
+                   blkno, xd3_strerror(ret)));
+      return ret;
+    }
+
+    IF_DEBUG1(DP(RINT "[srcwin_move_point] block %" XD3_Q "u T=%" XD3_Q
+                      "u S=%" XD3_Q "u L=%" XD3_Q "u EOF=%" XD3_Q "u %s\n",
+                 blkno, stream->total_in + stream->input_position,
+                 stream->srcwin_cksum_pos, target_cksum_pos,
+                 xd3_source_eof(stream->src),
+                 stream->src->eof_known ? "known" : "unknown"));
+
+    blkpos = (ssize_t)xd3_bytes_on_srcblk(stream->src, blkno);
+
+    if (blkpos < (ssize_t)stream->smatcher.large_look) {
+      stream->srcwin_cksum_pos = (blkno + 1) * stream->src->blksize;
+      IF_DEBUG2(DP(RINT "[srcwin_move_point] continue (end-of-block): %" XD3_Z
+                        "d\n",
+                   blkpos));
+      continue;
+    }
+
+    /* This inserts checksums for the entire block, in reverse,
+     * starting from the end of the block.  This logic does not test
+     * stream->srcwin_cksum_pos because it always advances it to the
+     * start of the next block.
+     *
+     * oldpos is the srcwin_cksum_pos within this block.  blkpos is
+     * the number of bytes available.  Each iteration inspects
+     * large_look bytes then steps back large_step bytes.  The
+     * if-stmt above ensures at least one large_look of data. */
+    blkpos -= (ssize_t)stream->smatcher.large_look;
+    blkbaseoffset = stream->src->blksize * blkno;
+
+    do {
+      /* TODO: This would be significantly faster if the compiler
+       * knew stream->smatcher.large_look (which the template for
+       * xd3_string_match_* allows). */
+      usize_t cksum =
+          xd3_large_cksum(&stream->large_hash, stream->src->curblk + blkpos,
+                          stream->smatcher.large_look);
+      usize_t hval = xd3_checksum_hash(&stream->large_hash, cksum);
+
+      stream->large_table[hval] =
+          (usize_t)(blkbaseoffset + (xoff_t)(blkpos + HASH_CKOFFSET));
+
+      IF_DEBUG(stream->large_ckcnt += 1);
+
+      blkpos -= (ssize_t)stream->smatcher.large_step;
+    } while (blkpos >= oldpos);
+
+    stream->srcwin_cksum_pos = (blkno + 1) * stream->src->blksize;
+  }
+
+  IF_DEBUG1(DP(RINT "[srcwin_move_point] exited loop T=%" XD3_Q "u "
+                    "S=%" XD3_Q "u EOF=%" XD3_Q "u %s\n",
+               stream->total_in + stream->input_position,
+               stream->srcwin_cksum_pos, xd3_source_eof(stream->src),
+               stream->src->eof_known ? "known" : "unknown"));
+
+  if (stream->src->eof_known) {
+    xoff_t source_size = xd3_source_eof(stream->src);
+    if (stream->srcwin_cksum_pos >= source_size) {
+      /* This invariant is needed for xd3_source_cksum_offset() */
+      stream->srcwin_cksum_pos = source_size;
+      *next_move_point = USIZE_T_MAX;
+      IF_DEBUG1(DP(RINT "[srcwin_move_point] finished with source input\n"));
+      return 0;
+    }
+  }
+
+  /* How long until this function should be called again. */
+  XD3_ASSERT(stream->srcwin_cksum_pos >= target_cksum_pos);
+
+  *next_move_point =
+      stream->input_position + stream->src->blksize -
+      ((stream->srcwin_cksum_pos - target_cksum_pos) & stream->src->maskby);
+
+  IF_DEBUG2(DP(RINT "[srcwin_move_point] finished T=%" XD3_Q "u "
+                    "S=%" XD3_Q "u L=%" XD3_Q "u EOF=%" XD3_Q
+                    "u %s again in %" XD3_W "u\n",
+               stream->total_in + stream->input_position,
+               stream->srcwin_cksum_pos, target_cksum_pos,
+               xd3_source_eof(stream->src),
+               stream->src->eof_known ? "known" : "unknown",
+               *next_move_point - stream->input_position));
+
+  return 0;
+}
+
+#endif /* XD3_ENCODER */
+
+/********************************************************************
+ TEMPLATE pass
+ *********************************************************************/
+
+#endif /* __XDELTA3_C_INLINE_PASS__ */
+#ifdef __XDELTA3_C_TEMPLATE_PASS__
+
+#if XD3_ENCODER
+
+/********************************************************************
+ Templates
+ *******************************************************************/
+
+/* Template macros */
+#define XD3_TEMPLATE(x) XD3_TEMPLATE2(x, TEMPLATE)
+#define XD3_TEMPLATE2(x, n) XD3_TEMPLATE3(x, n)
+#define XD3_TEMPLATE3(x, n) x##n
+#define XD3_STRINGIFY(x) XD3_STRINGIFY2(x)
+#define XD3_STRINGIFY2(x) #x
+
+static int XD3_TEMPLATE(xd3_string_match_)(xd3_stream *stream);
+
+static const xd3_smatcher XD3_TEMPLATE(__smatcher_) = {
+    XD3_STRINGIFY(TEMPLATE),
+    XD3_TEMPLATE(xd3_string_match_),
+#if SOFTCFG == 1
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+#else
+    LLOOK,
+    LSTEP,
+    SLOOK,
+    SCHAIN,
+    SLCHAIN,
+    MAXLAZY,
+    LONGENOUGH
+#endif
+};
+
+static int XD3_TEMPLATE(xd3_string_match_)(xd3_stream *stream) {
+  const int DO_SMALL = !(stream->flags & XD3_NOCOMPRESS);
+  const int DO_LARGE = (stream->src != NULL);
+  const int DO_RUN = (1);
+
+  const uint8_t *inp;
+  uint32_t scksum = 0;
+  uint32_t scksum_state = 0;
+  usize_t lcksum = 0;
+  usize_t sinx;
+  usize_t linx;
+  uint8_t run_c;
+  usize_t run_l;
+  int ret;
+  usize_t match_length;
+  usize_t match_offset = 0;
+  usize_t next_move_point = 0;
+
+  IF_DEBUG2(DP(RINT "[string_match] initial entry %" XD3_W "u\n",
+               stream->input_position));
+
+  /* If there will be no compression due to settings or short input,
+   * skip it entirely. */
+  if (!(DO_SMALL || DO_LARGE || DO_RUN) ||
+      stream->input_position + SLOOK > stream->avail_in) {
+    goto loopnomore;
+  }
+
+  if ((ret = xd3_string_match_init(stream))) {
+    return ret;
+  }
+
+  /* The restartloop label is reached when the incremental loop state
+   * needs to be reset. */
+restartloop:
+
+  IF_DEBUG2(DP(RINT "[string_match] restartloop %" XD3_W "u\n",
+               stream->input_position));
+
+  /* If there is not enough input remaining for any kind of match,
+     skip it. */
+  if (stream->input_position + SLOOK > stream->avail_in) {
+    goto loopnomore;
+  }
+
+  /* Now reset the incremental loop state: */
+
+  /* The min_match variable is updated to avoid matching the same lazy
+   * match over and over again.  For example, if you find a (small)
+   * match of length 9 at one position, you will likely find a match
+   * of length 8 at the next position. */
+  if (xd3_iopt_last_matched(stream) > stream->input_position) {
+    stream->min_match = xd3_max(MIN_MATCH, 1 + xd3_iopt_last_matched(stream) -
+                                               stream->input_position);
+  } else {
+    stream->min_match = MIN_MATCH;
+  }
+
+  /* The current input byte. */
+  inp = stream->next_in + stream->input_position;
+
+  /* Small match state. */
+  if (DO_SMALL) {
+    scksum = xd3_scksum(&scksum_state, inp, SLOOK);
+  }
+
+  /* Run state. */
+  if (DO_RUN) {
+    run_l = xd3_comprun(inp, SLOOK, &run_c);
+  }
+
+  /* Large match state.  We continue the loop even after not enough
+   * bytes for LLOOK remain, so always check stream->input_position in
+   * DO_LARGE code. */
+  if (DO_LARGE && (stream->input_position + LLOOK <= stream->avail_in)) {
+    /* Source window: next_move_point is the point that
+     * stream->input_position must reach before computing more
+     * source checksum.  Note: this is called unconditionally
+     * the first time after reentry, subsequent calls will be
+     * avoided if next_move_point is > input_position */
+    if ((ret = xd3_srcwin_move_point(stream, &next_move_point))) {
+      return ret;
+    }
+
+    lcksum = xd3_large_cksum(&stream->large_hash, inp, LLOOK);
+  }
+
+  /* TRYLAZYLEN: True if a certain length match should be followed by
+   * lazy search.  This checks that LEN is shorter than MAXLAZY and
+   * that there is enough leftover data to consider lazy matching.
+   * "Enough" is set to 2 since the next match will start at the next
+   * offset, it must match two extra characters. */
+#define TRYLAZYLEN(LEN, POS, MAX)                                              \
+  ((MAXLAZY) > 0 && (LEN) < (MAXLAZY) && (POS) + (LEN) <= (MAX) - 2)
+
+  /* HANDLELAZY: This statement is called each time an instruciton is
+   * emitted (three cases).  If the instruction is large enough, the
+   * loop is restarted, otherwise lazy matching may ensue. */
+#define HANDLELAZY(mlen)                                                       \
+  if (TRYLAZYLEN((mlen), (stream->input_position), (stream->avail_in))) {      \
+    stream->min_match = (mlen) + LEAST_MATCH_INCR;                             \
+    goto updateone;                                                            \
+  } else {                                                                     \
+    stream->input_position += (mlen);                                          \
+    goto restartloop;                                                          \
+  }
+
+  /* Now loop over one input byte at a time until a match is found... */
+  for (;; inp += 1, stream->input_position += 1) {
+    /* Now we try three kinds of string match in order of expense:
+     * run, large match, small match. */
+
+    /* Expand the start of a RUN.  The test for (run_l == SLOOK)
+     * avoids repeating this check when we pass through a run area
+     * performing lazy matching.  The run is only expanded once when
+     * the min_match is first reached.  If lazy matching is
+     * performed, the run_l variable will remain inconsistent until
+     * the first non-running input character is reached, at which
+     * time the run_l may then again grow to SLOOK. */
+    if (DO_RUN && run_l == SLOOK) {
+      usize_t max_len = stream->avail_in - stream->input_position;
+
+      IF_DEBUG(xd3_verify_run_state(stream, inp, run_l, &run_c));
+
+      while (run_l < max_len && inp[run_l] == run_c) {
+        run_l += 1;
+      }
+
+      /* Output a RUN instruction. */
+      if (run_l >= stream->min_match && run_l >= MIN_RUN) {
+        if ((ret =
+                 xd3_emit_run(stream, stream->input_position, run_l, &run_c))) {
+          return ret;
+        }
+
+        HANDLELAZY(run_l);
+      }
+    }
+
+    /* If there is enough input remaining. */
+    if (DO_LARGE && (stream->input_position + LLOOK <= stream->avail_in)) {
+      if ((stream->input_position >= next_move_point) &&
+          (ret = xd3_srcwin_move_point(stream, &next_move_point))) {
+        return ret;
+      }
+
+      linx = xd3_checksum_hash(&stream->large_hash, lcksum);
+
+      IF_DEBUG(xd3_verify_large_state(stream, inp, lcksum));
+
+      if (stream->large_table[linx] != 0) {
+        /* the match_setup will fail if the source window has
+         * been decided and the match lies outside it.
+         * OPT: Consider forcing a window at this point to
+         * permit a new source window. */
+        xoff_t adj_offset = xd3_source_cksum_offset(
+            stream, stream->large_table[linx] - HASH_CKOFFSET);
+        if (xd3_source_match_setup(stream, adj_offset) == 0) {
+          if ((ret = xd3_source_extend_match(stream))) {
+            return ret;
+          }
+
+          /* Update stream position.  match_fwd is zero if no
+           * match. */
+          if (stream->match_fwd > 0) {
+            HANDLELAZY(stream->match_fwd);
+          }
+        }
+      }
+    }
+
+    /* Small matches. */
+    if (DO_SMALL) {
+      sinx = xd3_checksum_hash(&stream->small_hash, scksum);
+
+      /* Verify incremental state in debugging mode. */
+      IF_DEBUG(xd3_verify_small_state(stream, inp, scksum));
+
+      /* Search for the longest match */
+      if (stream->small_table[sinx] != 0) {
+        match_length = xd3_smatch(stream, stream->small_table[sinx], scksum,
+                                  &match_offset);
+      } else {
+        match_length = 0;
+      }
+
+      /* Insert a hash for this string. */
+      xd3_scksum_insert(stream, sinx, scksum, stream->input_position);
+
+      /* Maybe output a COPY instruction */
+      if (match_length >= stream->min_match) {
+        IF_DEBUG2({
+          static int x = 0;
+          DP(RINT "[target match:%d] <inp %" XD3_W "u %" XD3_W
+                  "u>  <cpy %" XD3_W "u %" XD3_W "u> "
+                  "(-%" XD3_W "d) [ %" XD3_W "u bytes ]\n",
+             x++, stream->input_position, stream->input_position + match_length,
+             match_offset, match_offset + match_length,
+             stream->input_position - match_offset, match_length);
+        });
+
+        if ((ret = xd3_found_match(stream,
+                                   /* decoder position */
+                                   stream->input_position,
+                                   /* length */ match_length,
+                                   /* address */ (xoff_t)match_offset,
+                                   /* is_source */ 0))) {
+          return ret;
+        }
+
+        /* Copy instruction. */
+        HANDLELAZY(match_length);
+      }
+    }
+
+    /* The logic above prevents excess work during lazy matching by
+     * increasing min_match to avoid smaller matches.  Each time we
+     * advance stream->input_position by one, the minimum match
+     * shortens as well.  */
+    if (stream->min_match > MIN_MATCH) {
+      stream->min_match -= 1;
+    }
+
+  updateone:
+
+    /* See if there are no more incremental cksums to compute. */
+    if (stream->input_position + SLOOK == stream->avail_in) {
+      goto loopnomore;
+    }
+
+    /* Compute next RUN, CKSUM */
+    if (DO_RUN) {
+      NEXTRUN(inp[SLOOK]);
+    }
+
+    if (DO_SMALL) {
+      scksum = xd3_small_cksum_update(&scksum_state, inp, SLOOK);
+    }
+
+    if (DO_LARGE && (stream->input_position + LLOOK < stream->avail_in)) {
+      lcksum = xd3_large_cksum_update(&stream->large_hash, lcksum, inp, LLOOK);
+    }
+  }
+
+loopnomore:
+  return 0;
+}
+
+#endif /* XD3_ENCODER */
+#endif /* __XDELTA3_C_TEMPLATE_PASS__ */

--- a/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3.h
+++ b/client-sdks/sockudo-swift/Vendor/xdelta3/xdelta3.h
@@ -1,0 +1,1427 @@
+/* xdelta3 - delta compression tools and library
+   Copyright 2016 Joshua MacDonald
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/* To learn more about Xdelta, start by reading xdelta3.c.  If you are
+ * ready to use the API, continue reading here.  There are two
+ * interfaces -- xd3_encode_input and xd3_decode_input -- plus a dozen
+ * or so related calls.  This interface is styled after Zlib. */
+
+#ifndef _XDELTA3_H_
+#define _XDELTA3_H_
+
+#define _POSIX_SOURCE 200112L
+#define _ISOC99_SOURCE
+#define _C99_SOURCE
+
+#if HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
+/****************************************************************/
+
+/* Default configured value of stream->winsize.  If the program
+ * supplies xd3_encode_input() with data smaller than winsize the
+ * stream will automatically buffer the input, otherwise the input
+ * buffer is used directly.
+ */
+#ifndef XD3_DEFAULT_WINSIZE
+#define XD3_DEFAULT_WINSIZE (1U << 23)
+#endif
+
+/* Default total size of the source window used in xdelta3-main.h */
+#ifndef XD3_DEFAULT_SRCWINSZ
+#define XD3_DEFAULT_SRCWINSZ (1U << 26)
+#endif
+
+/* When Xdelta requests a memory allocation for certain buffers, it
+ * rounds up to units of at least this size.  The code assumes (and
+ * asserts) that this is a power-of-two. */
+#ifndef XD3_ALLOCSIZE
+#define XD3_ALLOCSIZE (1U << 14)
+#endif
+
+/* The XD3_HARDMAXWINSIZE parameter is a safety mechanism to protect
+ * decoders against malicious files.  The decoder will never decode a
+ * window larger than this.  If the file specifies VCD_TARGET the
+ * decoder may require two buffers of this size.
+ *
+ * 8-16MB is reasonable, probably don't need to go larger. */
+#ifndef XD3_HARDMAXWINSIZE
+#define XD3_HARDMAXWINSIZE (1U << 26)
+#endif
+/* The IOPT_SIZE value sets the size of a buffer used to batch
+ * overlapping copy instructions before they are optimized by picking
+ * the best non-overlapping ranges.  The larger this buffer, the
+ * longer a forced xd3_srcwin_setup() decision is held off.  Setting
+ * this value to 0 causes an unlimited buffer to be used. */
+#ifndef XD3_DEFAULT_IOPT_SIZE
+#define XD3_DEFAULT_IOPT_SIZE (1U << 15)
+#endif
+
+/* The maximum distance backward to search for small matches */
+#ifndef XD3_DEFAULT_SPREVSZ
+#define XD3_DEFAULT_SPREVSZ (1U << 18)
+#endif
+
+/* The default compression level */
+#ifndef XD3_DEFAULT_LEVEL
+#define XD3_DEFAULT_LEVEL 3
+#endif
+
+#ifndef XD3_DEFAULT_SECONDARY_LEVEL
+#define XD3_DEFAULT_SECONDARY_LEVEL 6
+#endif
+
+#ifndef XD3_USE_LARGEFILE64
+#define XD3_USE_LARGEFILE64 1
+#endif
+
+/* The source window size is limited to 2GB unless
+ * XD3_USE_LARGESIZET is defined to 1. */
+#ifndef XD3_USE_LARGESIZET
+#define XD3_USE_LARGESIZET 1
+#endif
+
+/* Sizes and addresses within VCDIFF windows are represented as usize_t
+ *
+ * For source-file offsets and total file sizes, total input and
+ * output counts, the xoff_t type is used.  The decoder and encoder
+ * generally check for overflow of the xoff_t size (this is tested at
+ * the 32bit boundary [xdelta3-test.h]).
+ */
+#ifndef _WIN32
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <stdint.h>
+#else /* WIN32 case */
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef WINVER
+#if XD3_USE_LARGEFILE64
+/* 64 bit file offsets: uses GetFileSizeEx and SetFilePointerEx. */
+#define WINVER 0x0500
+#define _WIN32_WINNT 0x0500
+#else /* xoff_t is 32bit */
+/* 32 bit file offsets: uses GetFileSize and SetFilePointer. */
+#define WINVER 0x0400
+#define _WIN32_WINNT 0x0400
+#endif /* if XD3_USE_LARGEFILE64 */
+#endif /* ifndef WINVER */
+
+#include <windows.h>
+
+/* _MSV_VER is defined by Microsoft tools, not by Mingw32 */
+#ifdef _MSC_VER
+typedef signed int ssize_t;
+typedef int pid_t;
+#if _MSC_VER < 1600
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned long uint32_t;
+typedef ULONGLONG uint64_t;
+#else /* _MSC_VER >= 1600 */
+/* For MSVC10 and above */
+#include <stdint.h>
+#define inline __inline
+#endif /* _MSC_VER < 1600 */
+#else  /* _MSC_VER not defined  */
+/* Mingw32 */
+#include <stdint.h>
+#endif /* _MSC_VER defined */
+
+#endif /* _WIN32 defined */
+
+/* Settings based on the size of xoff_t (32 vs 64 file offsets) */
+#if XD3_USE_LARGEFILE64
+/* xoff_t is a 64-bit type */
+#define __USE_FILE_OFFSET64 1 /* GLIBC: for 64bit fileops. */
+
+#ifndef _LARGEFILE_SOURCE
+#define _LARGEFILE_SOURCE
+#endif
+
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+
+/* Portable compile-time assertion.  C11 and later provide
+ * _Static_assert; under C99 we fall back to a negative-size-array
+ * typedef trick.  (The standard <assert.h> "static_assert" macro is
+ * only defined for C11+, so it cannot be used while the build still
+ * targets C99.) */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define XD3_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#else
+#define XD3_STATIC_ASSERT_PASTE2(a, b) a##b
+#define XD3_STATIC_ASSERT_PASTE(a, b) XD3_STATIC_ASSERT_PASTE2(a, b)
+#define XD3_STATIC_ASSERT(cond, msg)                                           \
+  typedef char XD3_STATIC_ASSERT_PASTE(xd3_static_assert_,                     \
+                                       __LINE__)[(cond) ? 1 : -1]
+#endif
+
+XD3_STATIC_ASSERT(SIZEOF_SIZE_T == sizeof(size_t),
+                  "SIZEOF_SIZE_T not correctly set");
+XD3_STATIC_ASSERT(SIZEOF_UNSIGNED_LONG_LONG == sizeof(unsigned long long),
+                  "SIZEOF_UNSIGNED_LONG_LONG not correctly set");
+
+/* Set a xoff_t typedef and the "XD3_Q" printf insert. */
+#if defined(_WIN32)
+typedef uint64_t xoff_t;
+#define XD3_Q "I64"
+#elif SIZEOF_UNSIGNED_LONG == 8
+typedef unsigned long xoff_t;
+#define XD3_Q "l"
+#elif SIZEOF_SIZE_T == 8
+typedef size_t xoff_t;
+#define XD3_Q "z"
+#elif SIZEOF_UNSIGNED_LONG_LONG == 8
+typedef unsigned long long xoff_t;
+#define XD3_Q "ll"
+#endif /* typedef and #define XD3_Q */
+
+#define SIZEOF_XOFF_T 8
+
+#else /* XD3_USE_LARGEFILE64 == 0 */
+
+#if SIZEOF_UNSIGNED_INT == 4
+typedef unsigned int xoff_t;
+#elif SIZEOF_UNSIGNED_LONG == 4
+typedef unsigned long xoff_t;
+#else
+typedef uint32_t xoff_t;
+#endif /* xoff_t is 32 bits */
+
+#define SIZEOF_XOFF_T 4
+#define XD3_Q
+#endif /* 64 vs 32 bit xoff_t */
+
+/* Settings based on the size of usize_t (32 and 64 bit window size) */
+#if XD3_USE_LARGESIZET
+
+/* Set a usize_ttypedef and the "XD3_W" printf insert. */
+#if defined(_WIN32)
+typedef uint64_t usize_t;
+#define XD3_W "I64"
+#elif SIZEOF_UNSIGNED_LONG == 8
+typedef unsigned long usize_t;
+#define XD3_W "l"
+#elif SIZEOF_SIZE_T == 8
+typedef size_t usize_t;
+#define XD3_W "z"
+#elif SIZEOF_UNSIGNED_LONG_LONG == 8
+typedef unsigned long long usize_t;
+#define XD3_W "ll"
+#endif /* typedef and #define XD3_W */
+
+#define SIZEOF_USIZE_T 8
+
+#else /* XD3_USE_LARGESIZET == 0 */
+
+#if SIZEOF_UNSIGNED_INT == 4
+typedef unsigned int usize_t;
+#elif SIZEOF_UNSIGNED_LONG == 4
+typedef unsigned long usize_t;
+#else
+typedef uint32_t usize_t;
+#endif /* usize_t is 32 bits */
+
+#define SIZEOF_USIZE_T 4
+#define XD3_W
+
+#endif /* 64 vs 32 bit usize_t */
+
+/* Settings based on the size of size_t (the system-provided,
+ * usually-but-maybe-not an unsigned type) */
+#if SIZEOF_SIZE_T == 4
+#define XD3_Z "z"
+#elif SIZEOF_SIZE_T == 8
+#ifdef _WIN32
+#define XD3_Z "I64"
+#else /* !_WIN32 */
+#define XD3_Z "z"
+#endif /* Windows or not */
+#else
+#error Bad configure script
+#endif /* size_t printf flags */
+
+#define USE_UINT32                                                             \
+  (SIZEOF_USIZE_T == 4 || SIZEOF_XOFF_T == 4 || REGRESSION_TEST)
+#define USE_UINT64                                                             \
+  (SIZEOF_USIZE_T == 8 || SIZEOF_XOFF_T == 8 || REGRESSION_TEST)
+
+#ifndef UNALIGNED_OK
+#ifdef HAVE_ALIGNED_ACCESS_REQUIRED
+#define UNALIGNED_OK 0
+#else
+/* This generally includes all Windows builds. */
+#define UNALIGNED_OK 1
+#endif
+#endif
+
+/**********************************************************************/
+
+/* Whether to build the encoder, otherwise only build the decoder. */
+#ifndef XD3_ENCODER
+#define XD3_ENCODER 1
+#endif
+
+/* The code returned when main() fails, also defined in system
+   includes. */
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
+/* REGRESSION TEST enables the "xdelta3 test" command, which runs a
+   series of self-tests. */
+#ifndef REGRESSION_TEST
+#define REGRESSION_TEST 0
+#endif
+
+/* XD3_DEBUG=1 enables assertions and various statistics.  Levels > 1
+ * enable some additional output only useful during development and
+ * debugging. */
+#ifndef XD3_DEBUG
+#define XD3_DEBUG 0
+#endif
+
+#ifndef PYTHON_MODULE
+#define PYTHON_MODULE 0
+#endif
+
+#ifndef SWIG_MODULE
+#define SWIG_MODULE 0
+#endif
+
+#ifndef NOT_MAIN
+#define NOT_MAIN 0
+#endif
+
+/* There are three string matching functions supplied: one fast, one
+ * slow (default), and one soft-configurable.  To disable any of
+ * these, use the following definitions. */
+#ifndef XD3_BUILD_SLOW
+#define XD3_BUILD_SLOW 1
+#endif
+#ifndef XD3_BUILD_FAST
+#define XD3_BUILD_FAST 1
+#endif
+#ifndef XD3_BUILD_FASTER
+#define XD3_BUILD_FASTER 1
+#endif
+#ifndef XD3_BUILD_FASTEST
+#define XD3_BUILD_FASTEST 1
+#endif
+#ifndef XD3_BUILD_SOFT
+#define XD3_BUILD_SOFT 1
+#endif
+#ifndef XD3_BUILD_DEFAULT
+#define XD3_BUILD_DEFAULT 1
+#endif
+
+#if XD3_DEBUG
+#include <stdio.h>
+#endif
+
+typedef struct _xd3_stream xd3_stream;
+typedef struct _xd3_source xd3_source;
+typedef struct _xd3_hash_cfg xd3_hash_cfg;
+typedef struct _xd3_smatcher xd3_smatcher;
+typedef struct _xd3_rinst xd3_rinst;
+typedef struct _xd3_dinst xd3_dinst;
+typedef struct _xd3_hinst xd3_hinst;
+typedef struct _xd3_winst xd3_winst;
+typedef struct _xd3_rpage xd3_rpage;
+typedef struct _xd3_addr_cache xd3_addr_cache;
+typedef struct _xd3_output xd3_output;
+typedef struct _xd3_desect xd3_desect;
+typedef struct _xd3_iopt_buflist xd3_iopt_buflist;
+typedef struct _xd3_rlist xd3_rlist;
+typedef struct _xd3_sec_type xd3_sec_type;
+typedef struct _xd3_sec_cfg xd3_sec_cfg;
+typedef struct _xd3_sec_stream xd3_sec_stream;
+typedef struct _xd3_config xd3_config;
+typedef struct _xd3_code_table_desc xd3_code_table_desc;
+typedef struct _xd3_code_table_sizes xd3_code_table_sizes;
+typedef struct _xd3_slist xd3_slist;
+typedef struct _xd3_whole_state xd3_whole_state;
+typedef struct _xd3_wininfo xd3_wininfo;
+
+/* The stream configuration has three callbacks functions, all of
+ * which may be supplied with NULL values.  If config->getblk is
+ * provided as NULL, the stream returns XD3_GETSRCBLK. */
+
+typedef void *(xd3_alloc_func)(void *opaque, size_t items, usize_t size);
+typedef void(xd3_free_func)(void *opaque, void *address);
+
+typedef int(xd3_getblk_func)(xd3_stream *stream, xd3_source *source,
+                             xoff_t blkno);
+
+typedef const xd3_dinst *(xd3_code_table_func)(void);
+
+#ifdef _WIN32
+#define vsnprintf_func _vsnprintf
+#define snprintf_func _snprintf
+#else
+#define vsnprintf_func vsnprintf
+#define snprintf_func snprintf
+#endif
+#define short_sprintf(sb, fmt, ...)                                            \
+  snprintf_func((sb).buf, sizeof((sb).buf), fmt, __VA_ARGS__)
+
+/* Type used for short snprintf calls. */
+typedef struct {
+  char buf[48];
+} shortbuf;
+
+#ifndef PRINTF_ATTRIBUTE
+#ifdef __GNUC__
+#define PRINTF_ATTRIBUTE(x, y) __attribute__((__format__(__printf__, x, y)))
+#else
+#define PRINTF_ATTRIBUTE(x, y)
+#endif
+#endif
+
+/* Underlying xprintf() */
+int xsnprintf_func(char *str, size_t n, const char *fmt, ...)
+    PRINTF_ATTRIBUTE(3, 4);
+
+/* XPR(NT "", ...) (used by main) prefixes an "xdelta3: " to the output. */
+void xprintf(const char *fmt, ...) PRINTF_ATTRIBUTE(1, 2);
+#define XPR xprintf
+#define NT "xdelta3: "
+#define NTR ""
+/* DP(RINT ...) */
+#define DP xprintf
+#define RINT ""
+
+#if XD3_DEBUG
+#define XD3_ASSERT(x)                                                          \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      DP(RINT "%s:%d: XD3 assertion failed: %s\n", __FILE__, __LINE__, #x);    \
+      abort();                                                                 \
+    }                                                                          \
+  } while (0)
+#else
+#define XD3_ASSERT(x) (void)0
+#endif /* XD3_DEBUG */
+
+#define xd3_max(x, y) ((x) < (y) ? (y) : (x))
+#define xd3_min(x, y) ((x) < (y) ? (x) : (y))
+
+/****************************************************************
+ PUBLIC ENUMS
+ ******************************************************************/
+
+/* These are the five ordinary status codes returned by the
+ * xd3_encode_input() and xd3_decode_input() state machines. */
+typedef enum {
+
+  /* An application must be prepared to handle these five return
+   * values from either xd3_encode_input or xd3_decode_input, except
+   * in the case of no-source compression, in which case XD3_GETSRCBLK
+   * is never returned.  More detailed comments for these are given in
+   * xd3_encode_input and xd3_decode_input comments, below. */
+  XD3_INPUT = -17703,         /* need input */
+  XD3_OUTPUT = -17704,        /* have output */
+  XD3_GETSRCBLK = -17705,     /* need a block of source input (with no
+                               * xd3_getblk function), a chance to do
+                               * non-blocking read. */
+  XD3_GOTHEADER = -17706,     /* (decode-only) after the initial VCDIFF &
+                                 first window header */
+  XD3_WINSTART = -17707,      /* notification: returned before a window is
+                               * processed, giving a chance to
+                               * XD3_SKIP_WINDOW or not XD3_SKIP_EMIT that
+                               * window. */
+  XD3_WINFINISH = -17708,     /* notification: returned after
+                                 encode/decode & output for a window */
+  XD3_TOOFARBACK = -17709,    /* (encoder only) may be returned by
+                                 getblk() if the block is too old */
+  XD3_INTERNAL = -17710,      /* internal error */
+  XD3_INVALID = -17711,       /* invalid config */
+  XD3_INVALID_INPUT = -17712, /* invalid input/decoder error */
+  XD3_NOSECOND = -17713,      /* when secondary compression finds no
+                                 improvement. */
+  XD3_UNIMPLEMENTED = -17714  /* currently VCD_TARGET, VCD_CODETABLE */
+} xd3_rvalues;
+
+/* special values in config->flags */
+typedef enum {
+  XD3_JUST_HDR = (1 << 1),    /* used by VCDIFF tools, see
+                                 xdelta3-main.h. */
+  XD3_SKIP_WINDOW = (1 << 2), /* used by VCDIFF tools, see
+                                 xdelta3-main.h. */
+  XD3_SKIP_EMIT = (1 << 3),   /* used by VCDIFF tools, see
+                                 xdelta3-main.h. */
+  XD3_FLUSH = (1 << 4),       /* flush the stream buffer to
+                                 prepare for
+                                 xd3_stream_close(). */
+
+  XD3_SEC_DJW = (1 << 5),   /* use DJW static huffman */
+  XD3_SEC_FGK = (1 << 6),   /* use FGK adaptive huffman */
+  XD3_SEC_LZMA = (1 << 24), /* use LZMA secondary */
+
+  XD3_SEC_TYPE = (XD3_SEC_DJW | XD3_SEC_FGK | XD3_SEC_LZMA),
+
+  XD3_SEC_NODATA = (1 << 7), /* disable secondary compression of
+                                the data section. */
+  XD3_SEC_NOINST = (1 << 8), /* disable secondary compression of
+                                the inst section. */
+  XD3_SEC_NOADDR = (1 << 9), /* disable secondary compression of
+                                the addr section. */
+
+  XD3_SEC_NOALL = (XD3_SEC_NODATA | XD3_SEC_NOINST | XD3_SEC_NOADDR),
+
+  XD3_ADLER32 = (1 << 10),       /* enable checksum computation in
+                                    the encoder. */
+  XD3_ADLER32_NOVER = (1 << 11), /* disable checksum verification in
+                                    the decoder. */
+
+  XD3_NOCOMPRESS = (1 << 13),     /* disable ordinary data
+                                   * compression feature, only search
+                                   * the source, not the target. */
+  XD3_BEGREEDY = (1 << 14),       /* disable the "1.5-pass
+                                   * algorithm", instead use greedy
+                                   * matching.  Greedy is off by
+                                   * default. */
+  XD3_ADLER32_RECODE = (1 << 15), /* used by "recode". */
+
+  /* 4 bits to set the compression level the same as the command-line
+   * setting -1 through -9 (-0 corresponds to the XD3_NOCOMPRESS flag,
+   * and is independent of compression level).  This is for
+   * convenience, especially with xd3_encode_memory(). */
+
+  XD3_COMPLEVEL_SHIFT = 20, /* 20 - 23 */
+  XD3_COMPLEVEL_MASK = (0xF << XD3_COMPLEVEL_SHIFT),
+  XD3_COMPLEVEL_1 = (1 << XD3_COMPLEVEL_SHIFT),
+  XD3_COMPLEVEL_2 = (2 << XD3_COMPLEVEL_SHIFT),
+  XD3_COMPLEVEL_3 = (3 << XD3_COMPLEVEL_SHIFT),
+  XD3_COMPLEVEL_6 = (6 << XD3_COMPLEVEL_SHIFT),
+  XD3_COMPLEVEL_9 = (9 << XD3_COMPLEVEL_SHIFT)
+
+} xd3_flags;
+
+/* The values of this enumeration are set in xd3_config using the
+ * smatch_cfg variable.  It can be set to default, slow, fast, etc.,
+ * and soft. */
+typedef enum {
+  XD3_SMATCH_DEFAULT = 0, /* Flags may contain XD3_COMPLEVEL bits,
+                             else default. */
+  XD3_SMATCH_SLOW = 1,
+  XD3_SMATCH_FAST = 2,
+  XD3_SMATCH_FASTER = 3,
+  XD3_SMATCH_FASTEST = 4,
+  XD3_SMATCH_SOFT = 5
+} xd3_smatch_cfg;
+
+/*********************************************************************
+ PRIVATE ENUMS
+**********************************************************************/
+
+/* stream->match_state is part of the xd3_encode_input state machine
+ *  for source matching:
+ *
+ *  1. the XD3_GETSRCBLK block-read mechanism means reentrant matching
+ *  2. this state spans encoder windows: a match and end-of-window
+ *  will continue in the next 3. the initial target byte and source
+ *  byte are a presumed match, to avoid some computation in case the
+ *  inputs are identical.
+ */
+typedef enum {
+
+  MATCH_TARGET = 0,   /* in this state, attempt to match the start of
+                       * the target with the previously set source
+                       * address (initially 0). */
+  MATCH_BACKWARD = 1, /* currently expanding a match backward in the
+                         source/target. */
+  MATCH_FORWARD = 2,  /* currently expanding a match forward in the
+                         source/target. */
+  MATCH_SEARCHING = 3 /* currently searching for a match. */
+
+} xd3_match_state;
+
+/* The xd3_encode_input state machine steps through these states in
+ * the following order.  The matcher is reentrant and returns
+ * XD3_INPUT whenever it requires more data.  After receiving
+ * XD3_INPUT, if the application reads EOF it should call
+ * xd3_stream_close().
+ */
+typedef enum {
+
+  ENC_INIT = 0,    /* xd3_encode_input has never been called. */
+  ENC_INPUT = 1,   /* waiting for xd3_avail_input () to be called. */
+  ENC_SEARCH = 2,  /* currently searching for matches. */
+  ENC_INSTR = 3,   /* currently formatting output. */
+  ENC_FLUSH = 4,   /* currently emitting output. */
+  ENC_POSTOUT = 5, /* after an output section. */
+  ENC_POSTWIN = 6, /* after all output sections. */
+  ENC_ABORTED = 7  /* abort. */
+} xd3_encode_state;
+
+/* The xd3_decode_input state machine steps through these states in
+ * the following order.  The matcher is reentrant and returns
+ * XD3_INPUT whenever it requires more data.  After receiving
+ * XD3_INPUT, if the application reads EOF it should call
+ * xd3_stream_close().
+ *
+ * 0-8:   the VCDIFF header
+ * 9-18:  the VCDIFF window header
+ * 19-21: the three primary sections: data, inst, addr
+ * 22:    producing output: returns XD3_OUTPUT, possibly XD3_GETSRCBLK,
+ * 23:    return XD3_WINFINISH, set state=9 to decode more input
+ */
+typedef enum {
+
+  DEC_VCHEAD = 0, /* VCDIFF header */
+  DEC_HDRIND = 1, /* header indicator */
+
+  DEC_SECONDID = 2, /* secondary compressor ID */
+
+  DEC_TABLEN = 3, /* code table length */
+  DEC_NEAR = 4,   /* code table near */
+  DEC_SAME = 5,   /* code table same */
+  DEC_TABDAT = 6, /* code table data */
+
+  DEC_APPLEN = 7, /* application data length */
+  DEC_APPDAT = 8, /* application data */
+
+  DEC_WININD = 9, /* window indicator */
+
+  DEC_CPYLEN = 10, /* copy window length */
+  DEC_CPYOFF = 11, /* copy window offset */
+
+  DEC_ENCLEN = 12, /* length of delta encoding */
+  DEC_TGTLEN = 13, /* length of target window */
+  DEC_DELIND = 14, /* delta indicator */
+
+  DEC_DATALEN = 15, /* length of ADD+RUN data */
+  DEC_INSTLEN = 16, /* length of instruction data */
+  DEC_ADDRLEN = 17, /* length of address data */
+
+  DEC_CKSUM = 18, /* window checksum */
+
+  DEC_DATA = 19, /* data section */
+  DEC_INST = 20, /* instruction section */
+  DEC_ADDR = 21, /* address section */
+
+  DEC_EMIT = 22, /* producing data */
+
+  DEC_FINISH = 23, /* window finished */
+
+  DEC_ABORTED = 24 /* xd3_abort_stream */
+} xd3_decode_state;
+
+/************************************************************
+ internal types
+ ************************************************************/
+
+/* instruction lists used in the IOPT buffer */
+struct _xd3_rlist {
+  xd3_rlist *next;
+  xd3_rlist *prev;
+};
+
+/* the raw encoding of an instruction used in the IOPT buffer */
+struct _xd3_rinst {
+  uint8_t type;
+  uint8_t xtra;
+  uint8_t code1;
+  uint8_t code2;
+  usize_t pos;
+  usize_t size;
+  xoff_t addr;
+  xd3_rlist link;
+};
+
+/* the code-table form of an single- or double-instruction */
+struct _xd3_dinst {
+  uint8_t type1;
+  uint8_t size1;
+  uint8_t type2;
+  uint8_t size2;
+};
+
+/* the decoded form of a single (half) instruction. */
+struct _xd3_hinst {
+  uint8_t type;
+  usize_t size;
+  usize_t addr;
+};
+
+/* the form of a whole-file instruction */
+struct _xd3_winst {
+  uint8_t type; /* RUN, ADD, COPY */
+  uint8_t mode; /* 0, VCD_SOURCE, VCD_TARGET */
+  usize_t size;
+  xoff_t addr;
+  xoff_t position; /* absolute position of this inst */
+};
+
+/* used by the encoder to buffer output in sections.  list of blocks. */
+struct _xd3_output {
+  uint8_t *base;
+  usize_t next;
+  usize_t avail;
+  xd3_output *next_page;
+};
+
+/* used by the decoder to buffer input in sections. */
+struct _xd3_desect {
+  const uint8_t *buf;
+  const uint8_t *buf_max;
+  usize_t size;
+  usize_t pos;
+
+  /* used in xdelta3-decode.h */
+  uint8_t *copied1;
+  usize_t alloc1;
+
+  /* used in xdelta3-second.h */
+  uint8_t *copied2;
+  usize_t alloc2;
+};
+
+/* the VCDIFF address cache, see the RFC */
+struct _xd3_addr_cache {
+  usize_t s_near;
+  usize_t s_same;
+  usize_t next_slot;   /* the circular index for near */
+  usize_t *near_array; /* array of size s_near        */
+  usize_t *same_array; /* array of size s_same*256    */
+};
+
+/* the IOPT buffer list is just a list of buffers, which may be allocated
+ * during encode when using an unlimited buffer. */
+struct _xd3_iopt_buflist {
+  xd3_rinst *buffer;
+  xd3_iopt_buflist *next;
+};
+
+/* This is the record of a pre-compiled configuration, a subset of
+   xd3_config. */
+struct _xd3_smatcher {
+  const char *name;
+  int (*string_match)(xd3_stream *stream);
+  usize_t large_look;
+  usize_t large_step;
+  usize_t small_look;
+  usize_t small_chain;
+  usize_t small_lchain;
+  usize_t max_lazy;
+  usize_t long_enough;
+};
+
+/* hash table size & power-of-two hash function. */
+struct _xd3_hash_cfg {
+  usize_t size; // Number of buckets
+  usize_t shift;
+  usize_t mask;
+  usize_t look;       // How wide is this checksum
+  usize_t multiplier; // K * powers[0]
+  usize_t *powers;    // Array of [0,look) where powers[look-1] == 1
+                      // and powers[N] = powers[N+1]*K (Rabin-Karp)
+};
+
+/* the sprev list */
+struct _xd3_slist {
+  usize_t last_pos;
+};
+
+/* window info (for whole state) */
+struct _xd3_wininfo {
+  xoff_t offset;
+  usize_t length;
+  uint32_t adler32;
+};
+
+/* whole state for, e.g., merge */
+struct _xd3_whole_state {
+  usize_t addslen;
+  uint8_t *adds;
+  usize_t adds_alloc;
+
+  usize_t instlen;
+  xd3_winst *inst;
+  usize_t inst_alloc;
+
+  usize_t wininfolen;
+  xd3_wininfo *wininfo;
+  usize_t wininfo_alloc;
+
+  xoff_t length;
+};
+
+/********************************************************************
+ public types
+ *******************************************************************/
+
+/* Settings for the secondary compressor. */
+struct _xd3_sec_cfg {
+  int data_type;       /* Which section. (set automatically) */
+  usize_t ngroups;     /* Number of DJW Huffman groups. */
+  usize_t sector_size; /* Sector size. */
+  int inefficient; /* If true, ignore efficiency check [avoid XD3_NOSECOND]. */
+};
+
+/* This is the user-visible stream configuration. */
+struct _xd3_config {
+  usize_t winsize;   /* The encoder window size. */
+  usize_t sprevsz;   /* How far back small string
+                        matching goes */
+  usize_t iopt_size; /* entries in the
+                        instruction-optimizing
+                        buffer */
+
+  xd3_getblk_func *getblk; /* The three callbacks. */
+  xd3_alloc_func *alloc;
+  xd3_free_func *freef;
+  void *opaque;   /* Not used. */
+  uint32_t flags; /* stream->flags are initialized
+                   * from xd3_config & never
+                   * modified by the library.  Use
+                   * xd3_set_flags to modify flags
+                   * settings mid-stream. */
+
+  xd3_sec_cfg sec_data; /* Secondary compressor config: data */
+  xd3_sec_cfg sec_inst; /* Secondary compressor config: inst */
+  xd3_sec_cfg sec_addr; /* Secondary compressor config: addr */
+
+  xd3_smatch_cfg smatch_cfg; /* See enum: use fields below  for
+                                soft config */
+  xd3_smatcher smatcher_soft;
+};
+
+/* The primary source file object. You create one of these objects and
+ * initialize the first four fields.  This library maintains the next
+ * 5 fields.  The configured getblk implementation is responsible for
+ * setting the final 3 fields when called (and/or when XD3_GETSRCBLK
+ * is returned).
+ */
+struct _xd3_source {
+  /* you set */
+  usize_t blksize;    /* block size */
+  const char *name;   /* its name, for debug/print
+                         purposes */
+  void *ioh;          /* opaque handle */
+  xoff_t max_winsize; /* maximum visible buffer */
+
+  /* getblk sets */
+  xoff_t curblkno;       /* current block number: client
+                            sets after getblk request */
+  usize_t onblk;         /* number of bytes on current
+                            block: client sets,  must be >= 0
+                            and <= blksize */
+  const uint8_t *curblk; /* current block array: client
+                            sets after getblk request */
+
+  /* xd3 sets */
+  usize_t srclen;        /* length of this source window */
+  xoff_t srcbase;        /* offset of this source window
+                            in the source itself */
+  usize_t shiftby;       /* for power-of-two blocksizes */
+  usize_t maskby;        /* for power-of-two blocksizes */
+  xoff_t cpyoff_blocks;  /* offset of dec_cpyoff in blocks */
+  usize_t cpyoff_blkoff; /* offset of copy window in
+                            blocks, remainder */
+  xoff_t getblkno;       /* request block number: xd3 sets
+                            current getblk request */
+
+  /* See xd3_getblk() */
+  xoff_t max_blkno;  /* Maximum block, if eof is known,
+                      * otherwise, equals frontier_blkno
+                      * (initially 0). */
+  usize_t onlastblk; /* Number of bytes on max_blkno */
+  int eof_known;     /* Set to true when the first
+                      * partial block is read. */
+};
+
+/* The primary xd3_stream object, used for encoding and decoding.  You
+ * may access only two fields: avail_out, next_out.  Use the methods
+ * above to operate on xd3_stream. */
+struct _xd3_stream {
+  /* input state */
+  const uint8_t *next_in; /* next input byte */
+  usize_t avail_in;       /* number of bytes available at
+                             next_in */
+  xoff_t total_in;        /* how many bytes in */
+
+  /* output state */
+  uint8_t *next_out;     /* next output byte */
+  usize_t avail_out;     /* number of bytes available at
+                            next_out */
+  usize_t space_out;     /* total out space */
+  xoff_t current_window; /* number of windows encoded/decoded */
+  xoff_t total_out;      /* how many bytes out */
+
+  /* to indicate an error, xd3 sets */
+  const char *msg; /* last error message, NULL if
+                      no error */
+
+  /* source configuration */
+  xd3_source *src; /* source array */
+
+  /* encoder memory configuration */
+  usize_t winsize;   /* suggested window size */
+  usize_t sprevsz;   /* small string, previous window
+                        size (power of 2) */
+  usize_t sprevmask; /* small string, previous window
+                        size mask */
+  usize_t iopt_size;
+  usize_t iopt_unlimited;
+
+  /* general configuration */
+  xd3_getblk_func *getblk; /* set nxtblk, nxtblkno to scanblkno */
+  xd3_alloc_func *alloc;   /* malloc function */
+  xd3_free_func *free;     /* free function */
+  void *opaque;            /* private data object passed to
+                              alloc, free, and getblk */
+  uint32_t flags;          /* various options */
+
+  /* secondary compressor configuration */
+  xd3_sec_cfg sec_data; /* Secondary compressor config: data */
+  xd3_sec_cfg sec_inst; /* Secondary compressor config: inst */
+  xd3_sec_cfg sec_addr; /* Secondary compressor config: addr */
+
+  xd3_smatcher smatcher;
+
+  usize_t *large_table;    /* table of large checksums */
+  xd3_hash_cfg large_hash; /* large hash config */
+
+  usize_t *small_table;  /* table of small checksums */
+  xd3_slist *small_prev; /* table of previous offsets,
+                            circular linked list */
+  int small_reset;       /* true if small table should
+                            be reset */
+
+  xd3_hash_cfg small_hash;    /* small hash config */
+  xd3_addr_cache acache;      /* the vcdiff address cache */
+  xd3_encode_state enc_state; /* state of the encoder */
+
+  usize_t taroff;           /* base offset of the target input */
+  usize_t input_position;   /* current input position */
+  usize_t min_match;        /* current minimum match
+                               length, avoids redundent
+                               matches */
+  usize_t unencoded_offset; /* current input, first
+                             * unencoded offset. this value
+                             * is <= the first instruction's
+                             * position in the iopt buffer,
+                             * if there is at least one
+                             * match in the buffer. */
+
+  /* SRCWIN */
+  int srcwin_decided;       /* boolean: true if srclen and
+                               srcbase have been
+                               decided. */
+  int srcwin_decided_early; /* boolean: true if srclen
+                               and srcbase were
+                               decided early. */
+  xoff_t srcwin_cksum_pos;  /* Source checksum position */
+
+  /* MATCH */
+  xd3_match_state match_state; /* encoder match state */
+  xoff_t match_srcpos;         /* current match source
+                                  position relative to
+                                  srcbase */
+  xoff_t match_last_srcpos;    /* previously attempted
+                                * srcpos, to avoid loops. */
+  xoff_t match_minaddr;        /* smallest matching address to
+                                * set window params (reset each
+                                * window xd3_encode_reset) */
+  xoff_t match_maxaddr;        /* largest matching address to
+                                * set window params (reset each
+                                * window xd3_encode_reset) */
+  usize_t match_back;          /* match extends back so far */
+  usize_t match_maxback;       /* match extends back maximum */
+  usize_t match_fwd;           /* match extends forward so far */
+  usize_t match_maxfwd;        /* match extends forward maximum */
+
+  xoff_t maxsrcaddr; /* address of the last source
+                        match (across windows) */
+
+  uint8_t *buf_in;             /* for saving buffered input */
+  usize_t buf_avail;           /* amount of saved input */
+  const uint8_t *buf_leftover; /* leftover content of next_in
+                                  (i.e., user's buffer) */
+  usize_t buf_leftavail;       /* amount of leftover content */
+
+  xd3_output *enc_current;  /* current output buffer */
+  xd3_output *enc_free;     /* free output buffers */
+  xd3_output *enc_heads[4]; /* array of encoded outputs:
+                               head of chain */
+  xd3_output *enc_tails[4]; /* array of encoded outputs:
+                               tail of chain */
+  uint32_t recode_adler32;  /* set the adler32 checksum
+                             * during "recode". */
+
+  xd3_rlist iopt_used; /* instruction optimizing buffer */
+  xd3_rlist iopt_free;
+  xd3_rinst *iout; /* next single instruction */
+  xd3_iopt_buflist *iopt_alloc;
+
+  const uint8_t *enc_appheader; /* application header to encode */
+  usize_t enc_appheadsz;        /* application header size */
+
+  /* decoder stuff */
+  xd3_decode_state dec_state; /* current DEC_XXX value */
+  usize_t dec_hdr_ind;        /* VCDIFF header indicator */
+  usize_t dec_win_ind;        /* VCDIFF window indicator */
+  usize_t dec_del_ind;        /* VCDIFF delta indicator */
+
+  uint8_t dec_magic[4];   /* First four bytes */
+  usize_t dec_magicbytes; /* Magic position. */
+
+  usize_t dec_secondid; /* Optional secondary compressor ID. */
+
+  usize_t dec_codetblsz;    /* Optional code table: length. */
+  uint8_t *dec_codetbl;     /* Optional code table: storage. */
+  usize_t dec_codetblbytes; /* Optional code table: position. */
+
+  usize_t dec_appheadsz;    /* Optional application header:
+                               size. */
+  uint8_t *dec_appheader;   /* Optional application header:
+                               storage */
+  usize_t dec_appheadbytes; /* Optional application header:
+                               position. */
+
+  usize_t dec_cksumbytes; /* Optional checksum: position. */
+  uint8_t dec_cksum[4];   /* Optional checksum: storage. */
+  uint32_t dec_adler32;   /* Optional checksum: value. */
+
+  usize_t dec_cpylen; /* length of copy window
+                         (VCD_SOURCE or VCD_TARGET) */
+  xoff_t dec_cpyoff;  /* offset of copy window
+                         (VCD_SOURCE or VCD_TARGET) */
+  usize_t dec_enclen; /* length of delta encoding */
+  usize_t dec_tgtlen; /* length of target window */
+
+#if USE_UINT64
+  uint64_t dec_64part; /* part of a decoded uint64_t */
+#endif
+#if USE_UINT32
+  uint32_t dec_32part; /* part of a decoded uint32_t */
+#endif
+
+  xoff_t dec_winstart;     /* offset of the start of
+                              current target window */
+  xoff_t dec_window_count; /* == current_window + 1 in
+                              DEC_FINISH */
+  usize_t dec_winbytes;    /* bytes of the three sections
+                              so far consumed */
+  usize_t dec_hdrsize;     /* VCDIFF + app header size */
+
+  const uint8_t *dec_tgtaddrbase; /* Base of decoded target
+                                     addresses (addr >=
+                                     dec_cpylen). */
+  const uint8_t *dec_cpyaddrbase; /* Base of decoded copy
+                                     addresses (addr <
+                                     dec_cpylen). */
+
+  usize_t dec_position;   /* current decoder position
+                             counting the cpylen
+                             offset */
+  usize_t dec_maxpos;     /* maximum decoder position
+                             counting the cpylen
+                             offset */
+  xd3_hinst dec_current1; /* current instruction */
+  xd3_hinst dec_current2; /* current instruction */
+
+  uint8_t *dec_buffer;   /* Decode buffer */
+  uint8_t *dec_lastwin;  /* In case of VCD_TARGET, the
+                            last target window. */
+  usize_t dec_lastlen;   /* length of the last target
+                            window */
+  xoff_t dec_laststart;  /* offset of the start of last
+                            target window */
+  usize_t dec_lastspace; /* allocated space of last
+                            target window, for reuse */
+
+  xd3_desect inst_sect; /* staging area for decoding
+                           window sections */
+  xd3_desect addr_sect;
+  xd3_desect data_sect;
+
+  xd3_code_table_func *code_table_func;
+  const xd3_dinst *code_table;
+  const xd3_code_table_desc *code_table_desc;
+  xd3_dinst *code_table_alloc;
+
+  /* secondary compression */
+  const xd3_sec_type *sec_type;
+  xd3_sec_stream *sec_stream_d;
+  xd3_sec_stream *sec_stream_i;
+  xd3_sec_stream *sec_stream_a;
+
+  /* state for reconstructing whole files (e.g., for merge), this only
+   * supports loading USIZE_T_MAX instructions, adds, etc. */
+  xd3_whole_state whole_target;
+
+  /* statistics */
+  xoff_t n_scpy;
+  xoff_t n_tcpy;
+  xoff_t n_add;
+  xoff_t n_run;
+
+  xoff_t l_scpy;
+  xoff_t l_tcpy;
+  xoff_t l_add;
+  xoff_t l_run;
+
+  usize_t i_slots_used;
+
+#if XD3_DEBUG
+  usize_t large_ckcnt;
+
+  /* memory usage */
+  usize_t alloc_cnt;
+  usize_t free_cnt;
+#endif
+};
+
+/**************************************************************************
+ PUBLIC FUNCTIONS
+ **************************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/* This function configures an xd3_stream using the provided in-memory
+ * input buffer, source buffer, output buffer, and flags.  The output
+ * array must be large enough or else ENOSPC will be returned.  This
+ * is the simplest in-memory encoding interface. */
+int xd3_encode_memory(const uint8_t *input, usize_t input_size,
+                      const uint8_t *source, usize_t source_size,
+                      uint8_t *output_buffer, usize_t *output_size,
+                      usize_t avail_output, int flags);
+
+/* The reverse of xd3_encode_memory. */
+int xd3_decode_memory(const uint8_t *input, usize_t input_size,
+                      const uint8_t *source, usize_t source_size,
+                      uint8_t *output_buf, usize_t *output_size,
+                      usize_t avail_output, int flags);
+
+/* This function encodes an in-memory input using a pre-configured
+ * xd3_stream.  This allows the caller to set a variety of options
+ * which are not available in the xd3_encode/decode_memory()
+ * functions.
+ *
+ * The output array must be large enough to hold the output or else
+ * ENOSPC is returned.  The source (if any) should be set using
+ * xd3_set_source_and_size() with a single-block xd3_source.  This
+ * calls the underlying non-blocking interfaces,
+ * xd3_encode/decode_input(), handling the necessary input/output
+ * states.  This method may be considered a reference for any
+ * application using xd3_encode_input() directly.
+ *
+ *   xd3_stream stream;
+ *   xd3_config config;
+ *   xd3_source src;
+ *
+ *   memset (& src, 0, sizeof (src));
+ *   memset (& stream, 0, sizeof (stream));
+ *   memset (& config, 0, sizeof (config));
+ *
+ *   if (source != NULL)
+ *     {
+ *       src.size = source_size;
+ *       src.blksize = source_size;
+ *       src.curblkno = 0;
+ *       src.onblk = source_size;
+ *       src.curblk = source;
+ *       src.max_winsize = source_size;
+ *       xd3_set_source(&stream, &src);
+ *     }
+ *
+ *   config.flags = flags;
+ *   config.winsize = input_size;
+ *
+ *   ... set smatcher, appheader, encoding-table, compression-level, etc.
+ *
+ *   xd3_config_stream(&stream, &config);
+ *   xd3_encode_stream(&stream, ...);
+ *   xd3_free_stream(&stream);
+ */
+int xd3_encode_stream(xd3_stream *stream, const uint8_t *input,
+                      usize_t input_size, uint8_t *output, usize_t *output_size,
+                      usize_t avail_output);
+
+/* The reverse of xd3_encode_stream. */
+int xd3_decode_stream(xd3_stream *stream, const uint8_t *input,
+                      usize_t input_size, uint8_t *output, usize_t *output_size,
+                      usize_t avail_size);
+
+/* This is the non-blocking interface.
+ *
+ * Handling input and output states is the same for encoding or
+ * decoding using the xd3_avail_input() and xd3_consume_output()
+ * routines, inlined below.
+ *
+ * Return values:
+ *
+ *   XD3_INPUT: the process requires more input: call
+ *               xd3_avail_input() then repeat
+ *
+ *   XD3_OUTPUT: the process has more output: read stream->next_out,
+ *               stream->avail_out, then call xd3_consume_output(),
+ *               then repeat
+ *
+ *   XD3_GOTHEADER: (decoder-only) notification returned following the
+ *               VCDIFF header and first window header.  the decoder
+ *               may use the header to configure itself.
+ *
+ *   XD3_WINSTART: a general notification returned once for each
+ *               window except the 0-th window, which is implied by
+ *               XD3_GOTHEADER.  It is recommended to use a
+ *               switch-stmt such as:
+ *
+ *                 ...
+ *               again:
+ *                 switch ((ret = xd3_decode_input (stream))) {
+ *                    case XD3_GOTHEADER: {
+ *                      assert(stream->current_window == 0);
+ *                      stuff;
+ *                    }
+ *                    // fallthrough
+ *                    case XD3_WINSTART: {
+ *                      something(stream->current_window);
+ *                      goto again;
+ *                    }
+ *                    ...
+ *
+ *   XD3_WINFINISH: a general notification, following the complete
+ *               input & output of a window.  at this point,
+ *               stream->total_in and stream->total_out are consistent
+ *               for either encoding or decoding.
+ *
+ *   XD3_GETSRCBLK: If the xd3_getblk() callback is NULL, this value
+ *               is returned to initiate a non-blocking source read.
+ */
+int xd3_decode_input(xd3_stream *stream);
+int xd3_encode_input(xd3_stream *stream);
+
+/* The xd3_config structure is used to initialize a stream - all data
+ * is copied into stream so config may be a temporary variable.  See
+ * the [documentation] or comments on the xd3_config structure. */
+int xd3_config_stream(xd3_stream *stream, xd3_config *config);
+
+/* Since Xdelta3 doesn't open any files, xd3_close_stream is just an
+ * error check that the stream is in a proper state to be closed: this
+ * means the encoder is flushed and the decoder is at a window
+ * boundary.  The application is responsible for freeing any of the
+ * resources it supplied. */
+int xd3_close_stream(xd3_stream *stream);
+
+/* This arranges for closes the stream to succeed.  Does not free the
+ * stream.*/
+void xd3_abort_stream(xd3_stream *stream);
+
+/* xd3_free_stream frees all memory allocated for the stream.  The
+ * application is responsible for freeing any of the resources it
+ * supplied. */
+void xd3_free_stream(xd3_stream *stream);
+
+/* This function informs the encoder or decoder that source matching
+ * (i.e., delta-compression) is possible.  For encoding, this should
+ * be called before the first xd3_encode_input.  A NULL source is
+ * ignored.  For decoding, this should be called before the first
+ * window is decoded, but the appheader may be read first
+ * (XD3_GOTHEADER).  After decoding the header, call xd3_set_source()
+ * if you have a source file.  Note: if (stream->dec_win_ind & VCD_SOURCE)
+ * is true, it means the first window expects there to be a source file.
+ */
+int xd3_set_source(xd3_stream *stream, xd3_source *source);
+
+/* If the source size is known, call this instead of xd3_set_source().
+ * to avoid having stream->getblk called (and/or to avoid XD3_GETSRCBLK).
+ *
+ * Follow these steps:
+  xd3_source source;
+  memset(&source, 0, sizeof(source));
+  source.blksize  = size;
+  source.onblk    = size;
+  source.curblk   = buf;
+  source.curblkno = 0;
+  int ret = xd3_set_source_and_size(&stream, &source, size);
+  ...
+ */
+int xd3_set_source_and_size(xd3_stream *stream, xd3_source *source,
+                            xoff_t source_size);
+
+/* This should be called before the first call to xd3_encode_input()
+ * to include application-specific data in the VCDIFF header. */
+void xd3_set_appheader(xd3_stream *stream, const uint8_t *data, usize_t size);
+
+/* xd3_get_appheader may be called in the decoder after XD3_GOTHEADER.
+ * For convenience, the decoder always adds a single byte padding to
+ * the end of the application header, which is set to zero in case the
+ * application header is a string. */
+int xd3_get_appheader(xd3_stream *stream, uint8_t **data, usize_t *size);
+
+/* To generate a VCDIFF encoded delta with xd3_encode_init() from
+ * another format, use:
+ *
+ *   xd3_encode_init_partial() -- initialze encoder state (w/o hash tables)
+ *   xd3_init_cache() -- reset VCDIFF address cache
+ *   xd3_found_match() -- to report a copy instruction
+ *
+ * set stream->enc_state to ENC_INSTR and call xd3_encode_input as usual.
+ */
+int xd3_encode_init_partial(xd3_stream *stream);
+void xd3_init_cache(xd3_addr_cache *acache);
+int xd3_found_match(xd3_stream *stream, usize_t pos, usize_t size, xoff_t addr,
+                    int is_source);
+
+/* Gives an error string for xdelta3-speficic errors, returns NULL for
+   system errors */
+const char *xd3_strerror(int ret);
+
+/* For convenience, zero & initialize the xd3_config structure with
+   specified flags. */
+static inline void xd3_init_config(xd3_config *config, uint32_t flags) {
+  memset(config, 0, sizeof(*config));
+  config->flags = flags;
+}
+
+/* This supplies some input to the stream.
+ *
+ * For encoding, if the input is larger than the configured window
+ * size (xd3_config.winsize), the entire input will be consumed and
+ * encoded anyway.  If you wish to strictly limit the window size,
+ * limit the buffer passed to xd3_avail_input to the window size.
+ *
+ * For encoding, if the input is smaller than the configured window
+ * size (xd3_config.winsize), the library will create a window-sized
+ * buffer and accumulate input until a full-sized window can be
+ * encoded.  XD3_INPUT will be returned.  The input must remain valid
+ * until the next time xd3_encode_input() returns XD3_INPUT.
+ *
+ * For decoding, the input will be consumed entirely before XD3_INPUT
+ * is returned again.
+ */
+static inline void xd3_avail_input(xd3_stream *stream, const uint8_t *idata,
+                                   usize_t isize) {
+  /* Even if isize is zero, the code expects a non-NULL idata.  Why?
+   * It uses this value to determine whether xd3_avail_input has ever
+   * been called.  If xd3_encode_input is called before
+   * xd3_avail_input it will return XD3_INPUT right away without
+   * allocating a stream->winsize buffer.  This is to avoid an
+   * unwanted allocation. */
+  XD3_ASSERT(idata != NULL || isize == 0);
+
+  stream->next_in = idata;
+  stream->avail_in = isize;
+}
+
+/* This acknowledges receipt of output data, must be called after any
+ * XD3_OUTPUT return. */
+static inline void xd3_consume_output(xd3_stream *stream) {
+  stream->avail_out = 0;
+}
+
+/* These are set for each XD3_WINFINISH return. */
+static inline int xd3_encoder_used_source(xd3_stream *stream) {
+  return stream->src != NULL && stream->src->srclen > 0;
+}
+static inline xoff_t xd3_encoder_srcbase(xd3_stream *stream) {
+  return stream->src->srcbase;
+}
+static inline usize_t xd3_encoder_srclen(xd3_stream *stream) {
+  return stream->src->srclen;
+}
+
+/* Checks for legal flag changes. */
+static inline void xd3_set_flags(xd3_stream *stream, uint32_t flags) {
+  /* The bitwise difference should contain only XD3_FLUSH or
+     XD3_SKIP_WINDOW */
+  XD3_ASSERT(((flags ^ stream->flags) & ~(XD3_FLUSH | XD3_SKIP_WINDOW)) == 0);
+  stream->flags = flags;
+}
+
+/* Gives some extra information about the latest library error, if any
+ * is known. */
+static inline const char *xd3_errstring(xd3_stream *stream) {
+  return stream->msg ? stream->msg : "";
+}
+
+/* 64-bit divisions are expensive, which is why we require a
+ * power-of-two source->blksize.  To relax this restriction is
+ * relatively easy, see the history for xd3_blksize_div(). */
+static inline void xd3_blksize_div(const xoff_t offset,
+                                   const xd3_source *source, xoff_t *blkno,
+                                   usize_t *blkoff) {
+  *blkno = offset >> source->shiftby;
+  *blkoff = offset & source->maskby;
+  XD3_ASSERT(*blkoff < source->blksize);
+}
+
+static inline void xd3_blksize_add(xoff_t *blkno, usize_t *blkoff,
+                                   const xd3_source *source,
+                                   const usize_t add) {
+  usize_t blkdiff;
+
+  /* Does not check for overflow, checked in xdelta3-decode.h. */
+  *blkoff += add;
+  blkdiff = *blkoff >> source->shiftby;
+
+  if (blkdiff) {
+    *blkno += blkdiff;
+    *blkoff &= source->maskby;
+  }
+
+  XD3_ASSERT(*blkoff < source->blksize);
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#define XD3_NOOP 0U
+#define XD3_ADD 1U
+#define XD3_RUN 2U
+#define XD3_CPY                                                                \
+  3U /* XD3_CPY rtypes are represented as (XD3_CPY +                           \
+      * copy-mode value) */
+
+#if XD3_DEBUG
+#define IF_DEBUG(x) x
+#else
+#define IF_DEBUG(x)
+#endif
+#if XD3_DEBUG > 1
+#define IF_DEBUG1(x) x
+#else
+#define IF_DEBUG1(x)
+#endif
+#if XD3_DEBUG > 2
+#define IF_DEBUG2(x) x
+#else
+#define IF_DEBUG2(x)
+#endif
+
+#define SIZEOF_ARRAY(x) (sizeof(x) / sizeof(x[0]))
+
+#endif /* _XDELTA3_H_ */


### PR DESCRIPTION
delta-codec-cocoa broke with Swift 6 strict C/C++ separation (SE-0403): its Package.swift only declares C++ settings, making SPM builds fail entirely.

Replace it with vendored upstream xdelta3 as a pure C SPM target. The public module shim forward-declares the decode/encode functions with concrete types rather than including the full header, because SPM compiler defines don't propagate to Clang's module-map pass and the library's custom typedefs would fail to resolve at import time.

A thin pure-Swift wrapper replaces the ObjC++ codec with no loss of behaviour.

Switch tweetnacl-swiftwrap from a bitmark-inc revision pin to the pusher fork to resolve the package identity conflict warning.

Apply the terminalEventHandled reconnect fix: handleSocketClosed was vulnerable to double-processing on concurrent disconnect events. The flag prevents re-entry, resets before each retry, and the didClose callback is dispatched on the main actor for thread safety.

Adds a round-trip encode/decode smoke test and a garbage-input error test.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
