### PR TITLE
perf: reduce presence and webhook overload hot paths

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -7,6 +7,7 @@ shutdown_grace_period = 2
 websocket_max_payload_kb = 64
 user_authentication_timeout = 3600
 activity_timeout = 120
+health_check_timeout_ms = 2000
 
 [adapter]
 driver = "local"
@@ -21,6 +22,7 @@ request_timeout_ms = 5000
 connection_timeout_ms = 5000
 discovery_max_wait_ms = 1000
 discovery_idle_wait_ms = 150
+no_echo = true
 
 [adapter.pulsar]
 url = "pulsar://127.0.0.1:6650"
@@ -270,6 +272,17 @@ max_capacity = 10000
 
 [queue]
 driver = "memory"
+
+[queue.redis]
+concurrency = 5
+prefix = "sockudo_queue:"
+response_timeout_ms = 30000
+
+[queue.redis_cluster]
+concurrency = 5
+prefix = "sockudo_queue:"
+nodes = ["redis://127.0.0.1:6379"]
+request_timeout_ms = 5000
 
 [queue.iggy]
 connection_string = "iggy://iggy:iggy@127.0.0.1:8090"

--- a/config/config.toml
+++ b/config/config.toml
@@ -13,6 +13,7 @@ health_check_timeout_ms = 2000
 driver = "local"
 enable_socket_counting = true
 aggregate_counts = false
+fast_presence_transitions = false
 fallback_to_local = true
 
 [adapter.nats]

--- a/crates/sockudo-adapter/src/factory.rs
+++ b/crates/sockudo-adapter/src/factory.rs
@@ -358,6 +358,7 @@ impl AdapterFactory {
                     client_capacity: config.nats.client_capacity,
                     max_reconnects: config.nats.max_reconnects,
                     presence_sync_chunk_size: config.nats.presence_sync_chunk_size,
+                    no_echo: config.nats.no_echo,
                 };
                 match NatsAdapter::new(nats_cfg).await {
                     Ok(mut adapter) => {

--- a/crates/sockudo-adapter/src/factory.rs
+++ b/crates/sockudo-adapter/src/factory.rs
@@ -258,6 +258,7 @@ impl AdapterFactory {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
                         adapter.set_aggregate_counts(config.aggregate_counts);
+                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Redis(adapter.clone());
                         Ok((adapter, typed))
@@ -319,6 +320,7 @@ impl AdapterFactory {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
                         adapter.set_aggregate_counts(config.aggregate_counts);
+                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::RedisCluster(adapter.clone());
                         Ok((adapter, typed))
@@ -365,6 +367,7 @@ impl AdapterFactory {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
                         adapter.set_aggregate_counts(config.aggregate_counts);
+                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Nats(adapter.clone());
                         Ok((adapter, typed))
@@ -400,6 +403,7 @@ impl AdapterFactory {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
                         adapter.set_aggregate_counts(config.aggregate_counts);
+                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Pulsar(adapter.clone());
                         Ok((adapter, typed))
@@ -435,6 +439,7 @@ impl AdapterFactory {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
                         adapter.set_aggregate_counts(config.aggregate_counts);
+                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::RabbitMq(adapter.clone());
                         Ok((adapter, typed))
@@ -470,6 +475,7 @@ impl AdapterFactory {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
                         adapter.set_aggregate_counts(config.aggregate_counts);
+                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::GooglePubSub(adapter.clone());
                         Ok((adapter, typed))
@@ -508,6 +514,7 @@ impl AdapterFactory {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
                         adapter.set_aggregate_counts(config.aggregate_counts);
+                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Kafka(adapter.clone());
                         Ok((adapter, typed))
@@ -554,6 +561,7 @@ impl AdapterFactory {
                         adapter.set_cluster_health(&config.cluster_health).await?;
                         adapter.set_socket_counting(config.enable_socket_counting);
                         adapter.set_aggregate_counts(config.aggregate_counts);
+                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Iggy(adapter.clone());
                         Ok((adapter, typed))

--- a/crates/sockudo-adapter/src/handler/connection_management.rs
+++ b/crates/sockudo-adapter/src/handler/connection_management.rs
@@ -788,10 +788,17 @@ impl ConnectionHandler {
     }
 
     pub async fn get_channel_member_count(&self, app_config: &App, channel: &str) -> Result<usize> {
-        self.connection_manager
-            .get_channel_members(&app_config.id, channel)
-            .await
-            .map(|members| members.len())
+        if channel.starts_with("presence-") {
+            self.connection_manager
+                .get_local_channel_members(&app_config.id, channel)
+                .await
+                .map(|members| members.len())
+        } else {
+            self.connection_manager
+                .get_channel_members(&app_config.id, channel)
+                .await
+                .map(|members| members.len())
+        }
     }
 
     pub async fn verify_channel_subscription(

--- a/crates/sockudo-adapter/src/horizontal_adapter/operations.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter/operations.rs
@@ -460,6 +460,40 @@ impl HorizontalAdapter {
         out
     }
 
+    /// Count peer-owned presence sockets for a user from the replicated presence
+    /// registry. Local sockets are intentionally excluded; callers add the local
+    /// adapter's authoritative count separately.
+    pub async fn remote_presence_user_connection_count(
+        &self,
+        app_id: &str,
+        channel: &str,
+        user_id: &str,
+    ) -> usize {
+        let registry = self.cluster_presence_registry.read().await;
+        registry
+            .iter()
+            .filter(|(node_id, _)| *node_id != &self.node_id)
+            .filter_map(|(_, node_data)| node_data.get(channel))
+            .flat_map(|channel_sockets| channel_sockets.values())
+            .filter(|entry| entry.app_id == app_id && entry.user_id == user_id)
+            .count()
+    }
+
+    pub async fn remote_presence_user_has_connections(
+        &self,
+        app_id: &str,
+        channel: &str,
+        user_id: &str,
+    ) -> bool {
+        let registry = self.cluster_presence_registry.read().await;
+        registry
+            .iter()
+            .filter(|(node_id, _)| *node_id != &self.node_id)
+            .filter_map(|(_, node_data)| node_data.get(channel))
+            .flat_map(|channel_sockets| channel_sockets.values())
+            .any(|entry| entry.app_id == app_id && entry.user_id == user_id)
+    }
+
     /// Remove a node's contributions for one app (snapshot replace).
     fn purge_node_channel_counts_for_app(&self, app_id: &str, node_id: &str) {
         self.cluster_channel_counts.retain(|key, entry| {

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
@@ -786,13 +786,13 @@ where
     }
 
     async fn get_sockets_count(&self, app_id: &str) -> Result<usize> {
-        // Check if socket counting is enabled
-        if !self.enable_socket_counting {
-            return Ok(0);
-        }
-
-        // Get local count
+        // Always keep the local count available for per-node quota checks.
         let local_count = self.local_adapter.get_sockets_count(app_id).await?;
+
+        // Disabling socket counting only skips the cross-node request/reply path.
+        if !self.enable_socket_counting {
+            return Ok(local_count);
+        }
 
         // Get distributed count
         match self

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
@@ -513,6 +513,18 @@ where
             }
         }
 
+        // Tier 1A: read peer contributions from the gossiped registry instead of
+        // publishing a request/reply batch during unsubscribe cleanup.
+        if self.aggregate_counts {
+            for ch in channels {
+                let remote_count = self.horizontal.remote_channel_count(app_id, ch);
+                if remote_count > 0 {
+                    *counts.entry((*ch).to_string()).or_insert(0) += remote_count;
+                }
+            }
+            return Ok(counts);
+        }
+
         if self.should_skip_horizontal_communication().await {
             return Ok(counts);
         }
@@ -666,6 +678,14 @@ where
             .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
             .await?;
 
+        if channel.starts_with("presence-") {
+            return Ok(local_count
+                + self
+                    .horizontal
+                    .remote_presence_user_connection_count(app_id, channel, user_id)
+                    .await);
+        }
+
         // Get remote count (no excluding_socket since it's local-only)
         match self
             .send_request(
@@ -699,6 +719,13 @@ where
 
         if local_count > 0 {
             return Ok(true);
+        }
+
+        if channel.starts_with("presence-") {
+            return Ok(self
+                .horizontal
+                .remote_presence_user_has_connections(app_id, channel, user_id)
+                .await);
         }
 
         match self

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
@@ -678,7 +678,7 @@ where
             .count_user_connections_in_channel(user_id, app_id, channel, excluding_socket)
             .await?;
 
-        if channel.starts_with("presence-") {
+        if self.fast_presence_transitions && channel.starts_with("presence-") {
             return Ok(local_count
                 + self
                     .horizontal
@@ -721,7 +721,7 @@ where
             return Ok(true);
         }
 
-        if channel.starts_with("presence-") {
+        if self.fast_presence_transitions && channel.starts_with("presence-") {
             return Ok(self
                 .horizontal
                 .remote_presence_user_has_connections(app_id, channel, user_id)

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
@@ -30,8 +30,9 @@ where
             heartbeat_interval_ms: cluster_health_defaults.heartbeat_interval_ms,
             node_timeout_ms: cluster_health_defaults.node_timeout_ms,
             cleanup_interval_ms: cluster_health_defaults.cleanup_interval_ms,
-            enable_socket_counting: true, // Default to enabled
-            aggregate_counts: false,      // Tier 1A: opt-in via config
+            enable_socket_counting: true,     // Default to enabled
+            aggregate_counts: false,          // Tier 1A: opt-in via config
+            fast_presence_transitions: false, // Opt-in eventual presence transitions
             #[cfg(feature = "delta")]
             delta_compression: None,
             #[cfg(feature = "delta")]
@@ -141,6 +142,11 @@ where
     /// Tier 1A: enable reading channel counts from the gossiped registry.
     pub fn set_aggregate_counts(&mut self, enable: bool) {
         self.aggregate_counts = enable;
+    }
+
+    /// Enable the eventual-consistency fast path for presence transition checks.
+    pub fn set_fast_presence_transitions(&mut self, enable: bool) {
+        self.fast_presence_transitions = enable;
     }
 
     /// Publish a pre-built RequestBody and collect responses from other nodes

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
@@ -330,16 +330,19 @@ where
                 }
                 _ = tokio::time::sleep_until(deadline.into()) => {
                     // Timeout occurred
-                    warn!(
-                        "Request {} timed out after {}ms",
-                        request_id,
-                        start.elapsed().as_millis()
-                    );
                     let responses = if let Some(pending_request) = self.horizontal.pending_requests.get(&request_id) {
                         pending_request.responses.clone()
                     } else {
                         Vec::new()
                     };
+                    warn!(
+                        "Request {} ({:?}) timed out after {}ms, got {}/{} responses",
+                        request_id,
+                        request_type,
+                        start.elapsed().as_millis(),
+                        responses.len(),
+                        max_expected_responses
+                    );
                     Some((responses, true))
                 }
             };

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/mod.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/mod.rs
@@ -56,6 +56,9 @@ pub struct HorizontalAdapterBase<T: HorizontalTransport> {
     /// Tier 1A: when true, channel counts are read from the gossiped registry
     /// (local + peers) instead of cross-node request/reply.
     pub aggregate_counts: bool,
+    /// When true, first-join/last-leave presence transition checks use the
+    /// replicated presence registry instead of request/reply.
+    pub fast_presence_transitions: bool,
     #[cfg(feature = "delta")]
     // Delta compression manager for bandwidth optimization
     delta_compression: Option<Arc<sockudo_delta::DeltaCompressionManager>>,

--- a/crates/sockudo-adapter/src/transports/nats_transport.rs
+++ b/crates/sockudo-adapter/src/transports/nats_transport.rs
@@ -78,9 +78,9 @@ impl TransportMetrics {
 /// NATS transport implementation
 pub struct NatsTransport {
     client: NatsClient,
-    broadcast_subject: String,
-    request_subject: String,
-    response_subject: String,
+    broadcast_subject: Subject,
+    request_subject: Subject,
+    response_subject: Subject,
     /// Shared inbox prefix for direct reply routing
     inbox_prefix: String,
     config: NatsAdapterConfig,
@@ -187,6 +187,12 @@ impl HorizontalTransport for NatsTransport {
             "NATS transport credentials configured"
         );
 
+        // Build subject names before connecting so hot publish paths can reuse
+        // validated subject bytes instead of rebuilding them per message.
+        let broadcast_subject = Subject::from(format!("{}.broadcast", config.prefix));
+        let request_subject = Subject::from(format!("{}.requests", config.prefix));
+        let response_subject = Subject::from(format!("{}.responses", config.prefix));
+
         // Build NATS Options
         let mut nats_options = NatsOptions::new()
             .retry_on_initial_connect()
@@ -224,6 +230,13 @@ impl HorizontalTransport for NatsTransport {
                 }
             });
 
+        // Sockudo already delivers locally before publishing horizontally and
+        // ignores its own horizontal messages. Suppressing self-echo avoids
+        // needless inbound NATS traffic and own-message parsing.
+        if config.no_echo {
+            nats_options = nats_options.no_echo();
+        }
+
         if let Some(cap) = config.subscription_capacity {
             nats_options = nats_options.subscription_capacity(cap);
         }
@@ -254,11 +267,6 @@ impl HorizontalTransport for NatsTransport {
             .await
             .map_err(|e| Error::Internal(format!("Failed to connect to NATS: {e}")))?;
 
-        // Build subject names
-        let broadcast_subject = format!("{}.broadcast", config.prefix);
-        let request_subject = format!("{}.requests", config.prefix);
-        let response_subject = format!("{}.responses", config.prefix);
-
         // Build inbox prefix
         let inbox_prefix = format!("_INBOX.{}.", Uuid::new_v4().as_simple());
 
@@ -282,10 +290,7 @@ impl HorizontalTransport for NatsTransport {
             .map_err(|e| Error::Other(format!("Failed to serialize broadcast message: {e}")))?;
 
         self.client
-            .publish(
-                Subject::from(self.broadcast_subject.clone()),
-                message_data.into(),
-            )
+            .publish(self.broadcast_subject.clone(), message_data.into())
             .await
             .map_err(|e| Error::Internal(format!("Failed to publish broadcast: {e}")))?;
 
@@ -298,10 +303,7 @@ impl HorizontalTransport for NatsTransport {
             .map_err(|e| Error::Other(format!("Failed to serialize request: {e}")))?;
 
         self.client
-            .publish(
-                Subject::from(self.request_subject.clone()),
-                request_data.into(),
-            )
+            .publish(self.request_subject.clone(), request_data.into())
             .await
             .map_err(|e| Error::Internal(format!("Failed to publish request: {e}")))?;
 
@@ -314,10 +316,7 @@ impl HorizontalTransport for NatsTransport {
             .map_err(|e| Error::Other(format!("Failed to serialize response: {e}")))?;
 
         self.client
-            .publish(
-                Subject::from(self.response_subject.clone()),
-                response_data.into(),
-            )
+            .publish(self.response_subject.clone(), response_data.into())
             .await
             .map_err(|e| Error::Internal(format!("Failed to publish response: {e}")))?;
 
@@ -350,7 +349,7 @@ impl HorizontalTransport for NatsTransport {
 
         // Subscribe to broadcast channel
         let mut broadcast_subscription = client
-            .subscribe(Subject::from(broadcast_subject.clone()))
+            .subscribe(broadcast_subject.clone())
             .await
             .map_err(|e| {
                 Error::Internal(format!("Failed to subscribe to broadcast subject: {e}"))
@@ -358,17 +357,18 @@ impl HorizontalTransport for NatsTransport {
 
         // Subscribe to requests channel
         let mut request_subscription = client
-            .subscribe(Subject::from(request_subject.clone()))
+            .subscribe(request_subject.clone())
             .await
             .map_err(|e| Error::Internal(format!("Failed to subscribe to request subject: {e}")))?;
 
         // Subscribe to responses channel
-        let mut response_subscription = client
-            .subscribe(Subject::from(response_subject.clone()))
-            .await
-            .map_err(|e| {
-                Error::Internal(format!("Failed to subscribe to response subject: {e}"))
-            })?;
+        let mut response_subscription =
+            client
+                .subscribe(response_subject.clone())
+                .await
+                .map_err(|e| {
+                    Error::Internal(format!("Failed to subscribe to response subject: {e}"))
+                })?;
 
         // Subscribe to shared inbox wildcard
         let inbox_subject = format!("{}*", self.inbox_prefix);
@@ -662,8 +662,8 @@ impl HorizontalTransport for NatsTransport {
 
         self.client
             .publish_with_reply(
-                Subject::from(self.request_subject.clone()),
-                Subject::from(reply_to.to_string()),
+                self.request_subject.clone(),
+                Subject::from(reply_to),
                 request_data.into(),
             )
             .await

--- a/crates/sockudo-adapter/tests/adapter/clustered_active_channels_gauge_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/clustered_active_channels_gauge_tests.rs
@@ -2,6 +2,7 @@
 //! where the local node count can differ from the cluster-wide count.
 
 use crate::adapter::horizontal_adapter_helpers::MockConfig;
+use ahash::AHashMap;
 use sockudo_adapter::ConnectionManager;
 use sockudo_adapter::channel_manager::ChannelManager;
 use sockudo_adapter::horizontal_adapter::RequestType;
@@ -162,5 +163,45 @@ async fn unsubscribe_local_does_not_fan_out_for_cluster_count() {
             .iter()
             .all(|request| request.request_type != RequestType::ChannelSocketsCount),
         "unsubscribe_local should not publish horizontal count requests"
+    );
+}
+
+#[tokio::test]
+async fn batch_socket_counts_use_registry_when_aggregate_counts_enabled() {
+    let mut adapter = MockConfig::create_multi_node_adapter().await.unwrap();
+    adapter.set_aggregate_counts(true);
+
+    let mut remote_counts = AHashMap::new();
+    remote_counts.insert(SHARED_CHANNEL.to_string(), 7);
+    remote_counts.insert("channel-2".to_string(), 3);
+    adapter
+        .horizontal
+        .apply_remote_channel_counts(APP_ID, "node-remote", remote_counts, false);
+
+    let socket = SocketId::new();
+    adapter
+        .add_to_channel(APP_ID, SHARED_CHANNEL, &socket)
+        .await
+        .unwrap();
+
+    let counts = adapter
+        .get_batch_channel_socket_counts(APP_ID, &[SHARED_CHANNEL, "channel-2", "channel-3"])
+        .await
+        .unwrap();
+
+    assert_eq!(counts.get(SHARED_CHANNEL), Some(&8));
+    assert_eq!(counts.get("channel-2"), Some(&3));
+    assert!(!counts.contains_key("channel-3"));
+
+    let published_batch_requests = adapter
+        .transport
+        .get_published_requests()
+        .await
+        .into_iter()
+        .filter(|request| request.request_type == RequestType::BatchChannelSocketsCount)
+        .count();
+    assert_eq!(
+        published_batch_requests, 0,
+        "aggregate batch socket counts should issue zero NATS requests"
     );
 }

--- a/crates/sockudo-adapter/tests/adapter/horizontal_adapter_base_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/horizontal_adapter_base_test.rs
@@ -5,12 +5,41 @@ use sockudo_adapter::horizontal_adapter::RequestType;
 use sockudo_adapter::horizontal_adapter_base::HorizontalAdapterBase;
 use sockudo_adapter::horizontal_transport::{HorizontalTransport, TransportConfig};
 use sockudo_core::error::Result;
-use sockudo_core::websocket::SocketId;
+use sockudo_core::namespace::Namespace;
+use sockudo_core::websocket::{SocketId, WebSocket, WebSocketRef};
 use sockudo_protocol::messages::{MessageData, PusherMessage};
+use sockudo_ws::axum_integration;
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, WebSocketStream};
 use sonic_rs::prelude::*;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::net::{TcpListener, TcpStream};
+
+async fn create_test_writer() -> axum_integration::WebSocketWriter {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let _ = sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+        .connect(client_stream, &addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    server.await.unwrap()
+}
 
 #[tokio::test]
 async fn test_horizontal_adapter_base_new() -> Result<()> {
@@ -651,6 +680,44 @@ async fn test_connection_manager_distributed_socket_count() -> Result<()> {
 
     // Should sum socket counts from all nodes: 3 + 3 = 6
     assert_eq!(count, 6); // Total socket count across both nodes
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_disabled_socket_counting_returns_local_count_without_remote_request() -> Result<()> {
+    let mut adapter = MockConfig::create_multi_node_adapter().await?;
+    adapter.set_socket_counting(false);
+    adapter.start_listeners().await?;
+
+    let socket_id = SocketId::from_string("local-socket-1").unwrap();
+    let writer = create_test_writer().await;
+    let ws_ref = WebSocketRef::new(WebSocket::new(socket_id, writer));
+
+    let namespace = adapter
+        .local_adapter
+        .namespaces
+        .entry("test-app".to_string())
+        .or_insert_with(|| Arc::new(Namespace::new("test-app".to_string())))
+        .clone();
+    namespace.sockets.insert(socket_id, ws_ref);
+
+    let count = adapter.get_sockets_count("test-app").await?;
+
+    assert_eq!(
+        count, 1,
+        "disabled socket counting must still report local sockets for quota checks"
+    );
+
+    let requests = adapter.transport.get_published_requests().await;
+    let socket_count_requests: Vec<_> = requests
+        .iter()
+        .filter(|r| r.request_type == RequestType::SocketsCount)
+        .collect();
+    assert!(
+        socket_count_requests.is_empty(),
+        "disabled socket counting should skip distributed SocketsCount requests"
+    );
 
     Ok(())
 }

--- a/crates/sockudo-adapter/tests/adapter/transports/nats_transport_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/nats_transport_test.rs
@@ -212,6 +212,7 @@ async fn test_subject_names() -> Result<()> {
         password: None,
         token: None,
         nodes_number: Some(2),
+        no_echo: false,
         ..Default::default()
     };
 

--- a/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
@@ -58,6 +58,7 @@ pub fn get_nats_config() -> NatsAdapterConfig {
         password: None,
         token: None,
         nodes_number: Some(2),
+        no_echo: false,
         ..Default::default()
     }
 }

--- a/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
@@ -1,9 +1,14 @@
 use crate::adapter::horizontal_adapter_helpers::MockConfig;
+use crate::mocks::connection_handler_mock::{MockAppManager, MockCacheManager};
 use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::handler::ConnectionHandler;
 use sockudo_adapter::horizontal_adapter::RequestType;
+use sockudo_core::app::{App, AppLimitsPolicy, AppManager, AppPolicy};
+use sockudo_core::cache::CacheManager;
 use sockudo_core::channel::PresenceMemberInfo;
 use sockudo_core::error::Result;
 use sockudo_core::namespace::Namespace;
+use sockudo_core::options::ServerOptions;
 use sockudo_core::websocket::{SocketId, WebSocket, WebSocketRef};
 use sockudo_ws::axum_integration;
 use sockudo_ws::client::WebSocketClient;
@@ -105,13 +110,85 @@ async fn test_user_has_connections_returns_true_from_local_without_remote_reques
     Ok(())
 }
 
-/// Test that absent local connections trigger a cross-cluster request
+/// Test that absent presence connections use the replicated presence registry
+/// instead of a cross-cluster request.
 #[tokio::test]
-async fn test_user_has_connections_falls_back_to_remote_when_no_local_connections() -> Result<()> {
+async fn test_user_has_connections_uses_presence_registry_when_no_local_connections() -> Result<()>
+{
+    let adapter = MockConfig::create_multi_node_adapter().await?;
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "remote-node",
+            "presence-chat",
+            "remote-socket-1",
+            "remote-user",
+            "app-1",
+            None,
+        )
+        .await;
+
+    let result = adapter
+        .user_has_connections_in_channel("remote-user", "app-1", "presence-chat", None)
+        .await?;
+
+    assert!(
+        result,
+        "should be true when the replicated presence registry contains the user"
+    );
+
+    let requests = adapter.transport.get_published_requests().await;
+    let count_requests: Vec<_> = requests
+        .iter()
+        .filter(|r| r.request_type == RequestType::CountUserConnectionsInChannel)
+        .collect();
+
+    assert!(
+        count_requests.is_empty(),
+        "presence registry lookup should issue zero remote count requests, got {}",
+        count_requests.len()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_user_has_connections_returns_false_for_empty_presence_registry_without_remote_request()
+-> Result<()> {
     let adapter = MockConfig::create_multi_node_adapter().await?;
 
     let result = adapter
         .user_has_connections_in_channel("absent-user", "app-1", "presence-chat", None)
+        .await?;
+
+    assert!(
+        !result,
+        "should be false when neither local nor remote nodes have the user"
+    );
+
+    let requests = adapter.transport.get_published_requests().await;
+    let count_requests: Vec<_> = requests
+        .iter()
+        .filter(|r| r.request_type == RequestType::CountUserConnectionsInChannel)
+        .collect();
+
+    assert!(
+        count_requests.is_empty(),
+        "empty presence registry lookup should issue zero remote count requests, got {}",
+        count_requests.len()
+    );
+
+    Ok(())
+}
+
+/// Non-presence user-connection calls keep the existing request/reply behavior.
+#[tokio::test]
+async fn test_user_has_connections_falls_back_to_remote_for_non_presence_channel() -> Result<()> {
+    let adapter = MockConfig::create_multi_node_adapter().await?;
+
+    let result = adapter
+        .user_has_connections_in_channel("absent-user", "app-1", "private-chat", None)
         .await?;
 
     assert!(
@@ -137,8 +214,115 @@ async fn test_user_has_connections_falls_back_to_remote_when_no_local_connection
     );
     assert_eq!(
         count_requests[0].channel,
-        Some("presence-chat".to_string()),
+        Some("private-chat".to_string()),
         "request must carry the queried channel"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_count_user_connections_in_channel_includes_presence_registry_without_remote_request()
+-> Result<()> {
+    let adapter = MockConfig::create_multi_node_adapter().await?;
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "remote-node-a",
+            "presence-chat",
+            "remote-socket-a",
+            "remote-user",
+            "app-1",
+            None,
+        )
+        .await;
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "remote-node-b",
+            "presence-chat",
+            "remote-socket-b",
+            "remote-user",
+            "app-1",
+            None,
+        )
+        .await;
+
+    let count = adapter
+        .count_user_connections_in_channel("remote-user", "app-1", "presence-chat", None)
+        .await?;
+
+    assert_eq!(count, 2);
+
+    let requests = adapter.transport.get_published_requests().await;
+    let count_requests: Vec<_> = requests
+        .iter()
+        .filter(|r| r.request_type == RequestType::CountUserConnectionsInChannel)
+        .collect();
+
+    assert!(
+        count_requests.is_empty(),
+        "presence count should issue zero remote count requests, got {}",
+        count_requests.len()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_presence_member_count_uses_registry_without_channel_members_request() -> Result<()> {
+    let adapter = Arc::new(MockConfig::create_multi_node_adapter().await?);
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "remote-node",
+            "presence-chat",
+            "remote-socket",
+            "remote-user",
+            "app-1",
+            None,
+        )
+        .await;
+
+    let handler = ConnectionHandler::builder(
+        Arc::new(MockAppManager::new()) as Arc<dyn AppManager + Send + Sync>,
+        adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(MockCacheManager::new()) as Arc<dyn CacheManager + Send + Sync>,
+        ServerOptions::default(),
+    )
+    .build();
+    let app = App::from_policy(
+        "app-1".to_string(),
+        "key".to_string(),
+        "secret".to_string(),
+        true,
+        AppPolicy {
+            limits: AppLimitsPolicy {
+                max_presence_members_per_channel: Some(100),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+
+    let count = handler
+        .get_channel_member_count(&app, "presence-chat")
+        .await?;
+
+    assert_eq!(count, 1);
+
+    let requests = adapter.transport.get_published_requests().await;
+    let channel_member_requests: Vec<_> = requests
+        .iter()
+        .filter(|r| r.request_type == RequestType::ChannelMembers)
+        .collect();
+
+    assert!(
+        channel_member_requests.is_empty(),
+        "presence member count should issue zero ChannelMembers requests, got {}",
+        channel_member_requests.len()
     );
 
     Ok(())

--- a/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
@@ -110,11 +110,10 @@ async fn test_user_has_connections_returns_true_from_local_without_remote_reques
     Ok(())
 }
 
-/// Test that absent presence connections use the replicated presence registry
-/// instead of a cross-cluster request.
+/// By default, presence transition checks keep strict request/reply semantics
+/// even if the replicated registry already has a matching remote entry.
 #[tokio::test]
-async fn test_user_has_connections_uses_presence_registry_when_no_local_connections() -> Result<()>
-{
+async fn test_user_has_connections_uses_remote_request_for_presence_by_default() -> Result<()> {
     let adapter = MockConfig::create_multi_node_adapter().await?;
 
     adapter
@@ -134,8 +133,8 @@ async fn test_user_has_connections_uses_presence_registry_when_no_local_connecti
         .await?;
 
     assert!(
-        result,
-        "should be true when the replicated presence registry contains the user"
+        !result,
+        "strict mode should ignore the eventually consistent presence registry"
     );
 
     let requests = adapter.transport.get_published_requests().await;
@@ -144,27 +143,50 @@ async fn test_user_has_connections_uses_presence_registry_when_no_local_connecti
         .filter(|r| r.request_type == RequestType::CountUserConnectionsInChannel)
         .collect();
 
-    assert!(
-        count_requests.is_empty(),
-        "presence registry lookup should issue zero remote count requests, got {}",
-        count_requests.len()
+    assert_eq!(
+        count_requests.len(),
+        1,
+        "strict presence transition check should issue one remote count request"
+    );
+    assert_eq!(
+        count_requests[0].user_id,
+        Some("remote-user".to_string()),
+        "request must carry the queried user_id"
+    );
+    assert_eq!(
+        count_requests[0].channel,
+        Some("presence-chat".to_string()),
+        "request must carry the queried channel"
     );
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_user_has_connections_returns_false_for_empty_presence_registry_without_remote_request()
+async fn test_user_has_connections_uses_presence_registry_when_fast_transitions_enabled()
 -> Result<()> {
-    let adapter = MockConfig::create_multi_node_adapter().await?;
+    let mut adapter = MockConfig::create_multi_node_adapter().await?;
+    adapter.set_fast_presence_transitions(true);
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "remote-node",
+            "presence-chat",
+            "remote-socket-1",
+            "remote-user",
+            "app-1",
+            None,
+        )
+        .await;
 
     let result = adapter
-        .user_has_connections_in_channel("absent-user", "app-1", "presence-chat", None)
+        .user_has_connections_in_channel("remote-user", "app-1", "presence-chat", None)
         .await?;
 
     assert!(
-        !result,
-        "should be false when neither local nor remote nodes have the user"
+        result,
+        "fast mode should use the replicated presence registry"
     );
 
     let requests = adapter.transport.get_published_requests().await;
@@ -175,7 +197,7 @@ async fn test_user_has_connections_returns_false_for_empty_presence_registry_wit
 
     assert!(
         count_requests.is_empty(),
-        "empty presence registry lookup should issue zero remote count requests, got {}",
+        "fast presence transition check should issue zero remote count requests, got {}",
         count_requests.len()
     );
 
@@ -222,9 +244,72 @@ async fn test_user_has_connections_falls_back_to_remote_for_non_presence_channel
 }
 
 #[tokio::test]
-async fn test_count_user_connections_in_channel_includes_presence_registry_without_remote_request()
+async fn test_count_user_connections_in_channel_uses_remote_request_for_presence_by_default()
 -> Result<()> {
     let adapter = MockConfig::create_multi_node_adapter().await?;
+
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "remote-node-a",
+            "presence-chat",
+            "remote-socket-a",
+            "remote-user",
+            "app-1",
+            None,
+        )
+        .await;
+    adapter
+        .horizontal
+        .add_presence_entry(
+            "remote-node-b",
+            "presence-chat",
+            "remote-socket-b",
+            "remote-user",
+            "app-1",
+            None,
+        )
+        .await;
+
+    let count = adapter
+        .count_user_connections_in_channel("remote-user", "app-1", "presence-chat", None)
+        .await?;
+
+    assert_eq!(
+        count, 0,
+        "strict mode should use request/reply instead of the replicated presence registry"
+    );
+
+    let requests = adapter.transport.get_published_requests().await;
+    let count_requests: Vec<_> = requests
+        .iter()
+        .filter(|r| r.request_type == RequestType::CountUserConnectionsInChannel)
+        .collect();
+
+    assert_eq!(
+        count_requests.len(),
+        1,
+        "strict presence count should issue one remote count request"
+    );
+    assert_eq!(
+        count_requests[0].user_id,
+        Some("remote-user".to_string()),
+        "request must carry the queried user_id"
+    );
+    assert_eq!(
+        count_requests[0].channel,
+        Some("presence-chat".to_string()),
+        "request must carry the queried channel"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_count_user_connections_in_channel_uses_registry_when_fast_transitions_enabled()
+-> Result<()> {
+    let mut adapter = MockConfig::create_multi_node_adapter().await?;
+    adapter.set_fast_presence_transitions(true);
 
     adapter
         .horizontal
@@ -263,7 +348,7 @@ async fn test_count_user_connections_in_channel_includes_presence_registry_witho
 
     assert!(
         count_requests.is_empty(),
-        "presence count should issue zero remote count requests, got {}",
+        "fast presence count should issue zero remote count requests, got {}",
         count_requests.len()
     );
 

--- a/crates/sockudo-app/src/cached_app_manager.rs
+++ b/crates/sockudo-app/src/cached_app_manager.rs
@@ -1,19 +1,38 @@
 use async_trait::async_trait;
+use dashmap::DashMap;
 use sockudo_core::app::{App, AppManager};
 use sockudo_core::cache::CacheManager;
 use sockudo_core::error::{Error, Result};
 use sockudo_core::options::CacheSettings;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::timeout;
 use tracing::{debug, warn};
 
 const CACHE_PREFIX_ID: &str = "app:id";
 const CACHE_PREFIX_KEY: &str = "app:key";
+const SHARED_CACHE_ACCESS_TIMEOUT: Duration = Duration::from_millis(100);
+
+#[derive(Clone)]
+struct LocalAppEntry {
+    app: App,
+    expires_at: Option<Instant>,
+}
+
+impl LocalAppEntry {
+    fn is_fresh(&self) -> bool {
+        self.expires_at
+            .is_none_or(|expires_at| Instant::now() < expires_at)
+    }
+}
 
 /// Caching decorator for AppManager implementations
 pub struct CachedAppManager {
     inner: Arc<dyn AppManager + Send + Sync>,
     cache: Arc<dyn CacheManager + Send + Sync>,
     settings: CacheSettings,
+    local_apps_by_id: DashMap<String, LocalAppEntry>,
+    local_app_id_by_key: DashMap<String, String>,
 }
 
 impl CachedAppManager {
@@ -26,6 +45,8 @@ impl CachedAppManager {
             inner,
             cache,
             settings,
+            local_apps_by_id: DashMap::new(),
+            local_app_id_by_key: DashMap::new(),
         }
     }
 
@@ -47,26 +68,107 @@ impl CachedAppManager {
             .map_err(|e| Error::Internal(format!("Deserialization failed: {}", e)))
     }
 
+    fn local_expires_at(&self) -> Option<Instant> {
+        if self.settings.ttl == 0 {
+            None
+        } else {
+            Some(Instant::now() + Duration::from_secs(self.settings.ttl))
+        }
+    }
+
+    fn remember_app(&self, app: &App) {
+        if let Some(previous) = self.local_apps_by_id.insert(
+            app.id.clone(),
+            LocalAppEntry {
+                app: app.clone(),
+                expires_at: self.local_expires_at(),
+            },
+        ) && previous.app.key != app.key
+        {
+            self.local_app_id_by_key.remove(&previous.app.key);
+        }
+
+        self.local_app_id_by_key
+            .insert(app.key.clone(), app.id.clone());
+    }
+
+    fn remember_apps(&self, apps: &[App]) {
+        self.local_apps_by_id.clear();
+        self.local_app_id_by_key.clear();
+        for app in apps {
+            self.remember_app(app);
+        }
+    }
+
+    fn forget_app(&self, app_id: &str, app_key: Option<&str>) {
+        if let Some((_, previous)) = self.local_apps_by_id.remove(app_id) {
+            self.local_app_id_by_key.remove(&previous.app.key);
+        }
+        if let Some(app_key) = app_key {
+            self.local_app_id_by_key.remove(app_key);
+        }
+    }
+
+    fn find_local_by_id(&self, app_id: &str) -> Option<App> {
+        let entry = self
+            .local_apps_by_id
+            .get(app_id)
+            .map(|entry| entry.value().clone())?;
+
+        if entry.is_fresh() {
+            Some(entry.app)
+        } else {
+            self.forget_app(app_id, Some(&entry.app.key));
+            None
+        }
+    }
+
+    fn find_local_by_key(&self, key: &str) -> Option<App> {
+        let app_id = self
+            .local_app_id_by_key
+            .get(key)
+            .map(|entry| entry.value().clone())?;
+        self.find_local_by_id(&app_id)
+    }
+
+    async fn warm_local_index(&self) {
+        match self.inner.get_apps().await {
+            Ok(apps) => {
+                self.remember_apps(&apps);
+                debug!("Warmed local app index with {} apps", apps.len());
+            }
+            Err(e) => {
+                warn!("Failed to warm local app index: {}", e);
+            }
+        }
+    }
+
     async fn get<T: serde::de::DeserializeOwned>(&self, key: &str) -> Option<T> {
-        match self.cache.get(key).await {
-            Ok(Some(json)) => match Self::deserialize(&json) {
-                Ok(value) => {
-                    debug!("Cache hit: {}", key);
-                    Some(value)
+        match timeout(SHARED_CACHE_ACCESS_TIMEOUT, self.cache.get(key)).await {
+            Err(_) => {
+                warn!("Cache get timeout for {}", key);
+                None
+            }
+            Ok(result) => match result {
+                Ok(Some(json)) => match Self::deserialize(&json) {
+                    Ok(value) => {
+                        debug!("Cache hit: {}", key);
+                        Some(value)
+                    }
+                    Err(e) => {
+                        warn!("Cache deserialize error for {}: {}", key, e);
+                        None
+                    }
+                },
+                Ok(None) => {
+                    debug!("Cache miss: {}", key);
+                    None
                 }
                 Err(e) => {
-                    warn!("Cache deserialize error for {}: {}", key, e);
+                    warn!("Cache get error for {}: {}", key, e);
                     None
                 }
             },
-            Ok(None) => {
-                debug!("Cache miss: {}", key);
-                None
-            }
-            Err(e) => {
-                warn!("Cache get error for {}: {}", key, e);
-                None
-            }
         }
     }
 
@@ -79,32 +181,49 @@ impl CachedAppManager {
             }
         };
 
-        if let Err(e) = self.cache.set(key, &json, self.settings.ttl).await {
-            warn!("Cache set error for {}: {}", key, e);
+        match timeout(
+            SHARED_CACHE_ACCESS_TIMEOUT,
+            self.cache.set(key, &json, self.settings.ttl),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => warn!("Cache set error for {}: {}", key, e),
+            Err(_) => warn!("Cache set timeout for {}", key),
         }
     }
 
     async fn remove(&self, key: &str) {
-        if let Err(e) = self.cache.remove(key).await {
-            warn!("Cache remove error for {}: {}", key, e);
+        match timeout(SHARED_CACHE_ACCESS_TIMEOUT, self.cache.remove(key)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => warn!("Cache remove error for {}: {}", key, e),
+            Err(_) => warn!("Cache remove timeout for {}", key),
         }
     }
 
     async fn cache_app(&self, app: &App) {
+        self.remember_app(app);
         self.set(&Self::cache_key_for_id(&app.id), app).await;
         self.set(&Self::cache_key_for_key(&app.key), app).await;
     }
 
     async fn invalidate_app(&self, app_id: &str, app_key: &str) {
+        self.forget_app(app_id, Some(app_key));
         self.remove(&Self::cache_key_for_id(app_id)).await;
         self.remove(&Self::cache_key_for_key(app_key)).await;
     }
 
     async fn invalidate_app_by_id(&self, app_id: &str) {
+        if let Some(app) = self.find_local_by_id(app_id) {
+            self.invalidate_app(app_id, &app.key).await;
+            return;
+        }
+
         let id_key = Self::cache_key_for_id(app_id);
         if let Some(app) = self.get::<App>(&id_key).await {
             self.invalidate_app(app_id, &app.key).await;
         } else {
+            self.forget_app(app_id, None);
             self.remove(&id_key).await;
         }
     }
@@ -113,7 +232,11 @@ impl CachedAppManager {
 #[async_trait]
 impl AppManager for CachedAppManager {
     async fn init(&self) -> Result<()> {
-        self.inner.init().await
+        self.inner.init().await?;
+        if self.settings.enabled {
+            self.warm_local_index().await;
+        }
+        Ok(())
     }
 
     /// Get an app by ID from cache or database
@@ -122,8 +245,13 @@ impl AppManager for CachedAppManager {
             return self.inner.find_by_id(app_id).await;
         }
 
+        if let Some(app) = self.find_local_by_id(app_id) {
+            return Ok(Some(app));
+        }
+
         let cache_key = Self::cache_key_for_id(app_id);
         if let Some(app) = self.get::<App>(&cache_key).await {
+            self.remember_app(&app);
             return Ok(Some(app));
         }
 
@@ -141,8 +269,13 @@ impl AppManager for CachedAppManager {
             return self.inner.find_by_key(key).await;
         }
 
+        if let Some(app) = self.find_local_by_key(key) {
+            return Ok(Some(app));
+        }
+
         let cache_key = Self::cache_key_for_key(key);
         if let Some(app) = self.get::<App>(&cache_key).await {
+            self.remember_app(&app);
             return Ok(Some(app));
         }
 
@@ -167,9 +300,20 @@ impl AppManager for CachedAppManager {
 
     /// Update an existing app and refresh the cache
     async fn update_app(&self, config: App) -> Result<()> {
+        let previous_key = if self.settings.enabled {
+            self.find_local_by_id(&config.id).map(|app| app.key)
+        } else {
+            None
+        };
+
         self.inner.update_app(config.clone()).await?;
 
         if self.settings.enabled {
+            if let Some(previous_key) = previous_key.as_deref()
+                && previous_key != config.key
+            {
+                self.remove(&Self::cache_key_for_key(previous_key)).await;
+            }
             self.invalidate_app(&config.id, &config.key).await;
             self.cache_app(&config).await;
         }
@@ -202,7 +346,8 @@ impl AppManager for CachedAppManager {
     async fn get_apps(&self) -> Result<Vec<App>> {
         let apps = self.inner.get_apps().await?;
 
-        if self.settings.enabled && !apps.is_empty() {
+        if self.settings.enabled {
+            self.remember_apps(&apps);
             for app in &apps {
                 self.cache_app(app).await;
             }
@@ -222,7 +367,77 @@ mod tests {
     use super::*;
     use crate::memory_app_manager::MemoryAppManager;
     use sockudo_cache::MemoryCacheManager;
+    use sockudo_core::cache::CacheManager;
+    use sockudo_core::cache::CacheScanPage;
     use sockudo_core::options::MemoryCacheOptions;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::time::sleep;
+
+    struct SlowCacheManager {
+        get_delay: Duration,
+        get_calls: AtomicUsize,
+        set_calls: AtomicUsize,
+        remove_calls: AtomicUsize,
+    }
+
+    impl SlowCacheManager {
+        fn new(get_delay: Duration) -> Self {
+            Self {
+                get_delay,
+                get_calls: AtomicUsize::new(0),
+                set_calls: AtomicUsize::new(0),
+                remove_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn get_calls(&self) -> usize {
+            self.get_calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl CacheManager for SlowCacheManager {
+        async fn has(&self, _key: &str) -> Result<bool> {
+            Ok(false)
+        }
+
+        async fn get(&self, _key: &str) -> Result<Option<String>> {
+            self.get_calls.fetch_add(1, Ordering::Relaxed);
+            sleep(self.get_delay).await;
+            Ok(None)
+        }
+
+        async fn set(&self, _key: &str, _value: &str, _ttl_seconds: u64) -> Result<()> {
+            self.set_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn remove(&self, _key: &str) -> Result<()> {
+            self.remove_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn disconnect(&self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn ttl(&self, _key: &str) -> Result<Option<Duration>> {
+            Ok(None)
+        }
+
+        async fn scan_prefix(&self, _prefix: &str, _limit: usize) -> Result<Vec<(String, String)>> {
+            Ok(Vec::new())
+        }
+
+        async fn scan_prefix_page(
+            &self,
+            _prefix: &str,
+            _cursor: Option<String>,
+            _limit: usize,
+        ) -> Result<CacheScanPage> {
+            Ok(CacheScanPage::default())
+        }
+    }
 
     fn create_test_app(id: &str) -> App {
         App::from_policy(
@@ -317,6 +532,132 @@ mod tests {
 
         manager.delete_app("test4").await.unwrap();
         assert!(manager.find_by_id("test4").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_by_id_uses_local_index_before_shared_cache() {
+        let inner = Arc::new(MemoryAppManager::new());
+        let cache = Arc::new(SlowCacheManager::new(Duration::from_secs(1)));
+        let manager = CachedAppManager::new(
+            inner,
+            cache.clone(),
+            CacheSettings {
+                enabled: true,
+                ttl: 300,
+            },
+        );
+        let app = create_test_app("local-fast");
+
+        manager.create_app(app).await.unwrap();
+
+        let found = timeout(Duration::from_millis(50), manager.find_by_id("local-fast"))
+            .await
+            .expect("local app lookup should not wait for shared cache")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(found.id, "local-fast");
+        assert_eq!(
+            cache.get_calls(),
+            0,
+            "local app lookup should issue zero shared cache gets"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_by_key_uses_local_index_before_shared_cache() {
+        let inner = Arc::new(MemoryAppManager::new());
+        let cache = Arc::new(SlowCacheManager::new(Duration::from_secs(1)));
+        let manager = CachedAppManager::new(
+            inner,
+            cache.clone(),
+            CacheSettings {
+                enabled: true,
+                ttl: 300,
+            },
+        );
+        let app = create_test_app("local-key-fast");
+
+        manager.create_app(app).await.unwrap();
+
+        let found = timeout(
+            Duration::from_millis(50),
+            manager.find_by_key("local-key-fast_key"),
+        )
+        .await
+        .expect("local key lookup should not wait for shared cache")
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(found.id, "local-key-fast");
+        assert_eq!(
+            cache.get_calls(),
+            0,
+            "local key lookup should issue zero shared cache gets"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_slow_shared_cache_get_falls_back_to_inner_manager_quickly() {
+        let inner = Arc::new(MemoryAppManager::new());
+        inner
+            .create_app(create_test_app("cold-fallback"))
+            .await
+            .unwrap();
+        let cache = Arc::new(SlowCacheManager::new(Duration::from_secs(1)));
+        let manager = CachedAppManager::new(
+            inner,
+            cache.clone(),
+            CacheSettings {
+                enabled: true,
+                ttl: 300,
+            },
+        );
+
+        let found = timeout(
+            Duration::from_millis(250),
+            manager.find_by_id("cold-fallback"),
+        )
+        .await
+        .expect("shared cache timeout should leave room for inner fallback")
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(found.id, "cold-fallback");
+        assert_eq!(cache.get_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_init_warms_local_index_without_shared_cache_get() {
+        let inner = Arc::new(MemoryAppManager::new());
+        inner
+            .create_app(create_test_app("warm-init"))
+            .await
+            .unwrap();
+        let cache = Arc::new(SlowCacheManager::new(Duration::from_secs(1)));
+        let manager = CachedAppManager::new(
+            inner,
+            cache.clone(),
+            CacheSettings {
+                enabled: true,
+                ttl: 300,
+            },
+        );
+
+        manager.init().await.unwrap();
+
+        let found = timeout(Duration::from_millis(50), manager.find_by_id("warm-init"))
+            .await
+            .expect("warm local index lookup should not wait for shared cache")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(found.id, "warm-init");
+        assert_eq!(
+            cache.get_calls(),
+            0,
+            "warm init should not require shared cache reads"
+        );
     }
 
     #[tokio::test]

--- a/crates/sockudo-cache/src/redis_cache_manager.rs
+++ b/crates/sockudo-cache/src/redis_cache_manager.rs
@@ -36,6 +36,9 @@ pub struct RedisCacheManager {
     client: Client,
     /// Connection manager with automatic reconnection. Clone is cheap (shared internal state).
     connection: ConnectionManager,
+    /// Dedicated connection manager for health checks so probes do not open a
+    /// new Redis connection or queue behind normal cache operations.
+    health_connection: ConnectionManager,
     /// Key prefix
     prefix: String,
 }
@@ -56,19 +59,27 @@ impl RedisCacheManager {
         let client = Client::open(redis_url)
             .map_err(|e| Error::Cache(format!("Failed to create Redis client: {e}")))?;
 
-        let connection_manager_config = redis::aio::ConnectionManagerConfig::new()
-            .set_number_of_retries(5)
-            .set_exponent_base(2.0)
-            .set_max_delay(std::time::Duration::from_millis(5000));
+        let connection_manager_config = Self::connection_manager_config(config.response_timeout);
 
         let connection = client
             .get_connection_manager_with_config(connection_manager_config)
             .await
             .map_err(|e| Error::Cache(format!("Failed to connect to Redis: {e}")))?;
+        let health_connection = client
+            .get_connection_manager_with_config(Self::connection_manager_config(
+                config.response_timeout,
+            ))
+            .await
+            .map_err(|e| {
+                Error::Cache(format!(
+                    "Failed to connect Redis health check connection: {e}"
+                ))
+            })?;
 
         Ok(Self {
             client,
             connection,
+            health_connection,
             prefix: config.prefix,
         })
     }
@@ -87,6 +98,16 @@ impl RedisCacheManager {
     /// Get the prefixed key
     fn prefixed_key(&self, key: &str) -> String {
         format!("{}:{}", self.prefix, key)
+    }
+
+    fn connection_manager_config(
+        response_timeout: Option<Duration>,
+    ) -> redis::aio::ConnectionManagerConfig {
+        redis::aio::ConnectionManagerConfig::new()
+            .set_number_of_retries(5)
+            .set_exponent_base(2.0)
+            .set_max_delay(Duration::from_millis(5000))
+            .set_response_timeout(response_timeout)
     }
 }
 
@@ -148,11 +169,7 @@ impl CacheManager for RedisCacheManager {
     }
 
     async fn check_health(&self) -> Result<()> {
-        let mut conn = self
-            .client
-            .get_multiplexed_async_connection()
-            .await
-            .map_err(|e| Error::Cache(format!("Failed to acquire health check connection: {e}")))?;
+        let mut conn = self.health_connection.clone();
 
         let response = redis::cmd("PING")
             .query_async::<String>(&mut conn)

--- a/crates/sockudo-core/src/options/adapter.rs
+++ b/crates/sockudo-core/src/options/adapter.rs
@@ -26,9 +26,19 @@ pub struct AdapterConfig {
     /// cross-node fan-out. Off by default; falls back to request/reply when off.
     #[serde(default = "default_aggregate_counts")]
     pub aggregate_counts: bool,
+    /// Use the replicated presence registry for first-join/last-leave transition
+    /// checks instead of request/reply. Faster under high churn, but registry
+    /// state is eventually consistent, so strict webhook/history behavior keeps
+    /// this off by default.
+    #[serde(default = "default_fast_presence_transitions")]
+    pub fast_presence_transitions: bool,
 }
 
 fn default_aggregate_counts() -> bool {
+    false
+}
+
+fn default_fast_presence_transitions() -> bool {
     false
 }
 
@@ -61,6 +71,7 @@ impl Default for AdapterConfig {
             enable_socket_counting: default_enable_socket_counting(),
             fallback_to_local: default_fallback_to_local(),
             aggregate_counts: default_aggregate_counts(),
+            fast_presence_transitions: default_fast_presence_transitions(),
         }
     }
 }

--- a/crates/sockudo-core/src/options/adapter.rs
+++ b/crates/sockudo-core/src/options/adapter.rs
@@ -103,6 +103,7 @@ pub struct NatsAdapterConfig {
     pub client_capacity: Option<usize>,
     pub max_reconnects: Option<usize>,
     pub presence_sync_chunk_size: Option<usize>,
+    pub no_echo: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -210,6 +211,7 @@ impl Default for NatsAdapterConfig {
             client_capacity: None,
             max_reconnects: None,
             presence_sync_chunk_size: None,
+            no_echo: true,
         }
     }
 }

--- a/crates/sockudo-core/src/options/env/adapters.rs
+++ b/crates/sockudo-core/src/options/env/adapters.rs
@@ -48,6 +48,7 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
     if let Some(v) = parse_env_optional::<usize>("NATS_PRESENCE_SYNC_CHUNK_SIZE") {
         options.adapter.nats.presence_sync_chunk_size = Some(v);
     }
+    options.adapter.nats.no_echo = parse_bool_env("NATS_NO_ECHO", options.adapter.nats.no_echo);
 
     // --- Pulsar Adapter ---
     if let Ok(url) = std::env::var("PULSAR_URL") {

--- a/crates/sockudo-core/src/options/env/databases.rs
+++ b/crates/sockudo-core/src/options/env/databases.rs
@@ -164,6 +164,10 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
         "REDIS_CLUSTER_QUEUE_CONCURRENCY",
         options.queue.redis_cluster.concurrency,
     );
+    options.queue.redis_cluster.request_timeout_ms = parse_env::<u64>(
+        "REDIS_CLUSTER_QUEUE_REQUEST_TIMEOUT_MS",
+        options.queue.redis_cluster.request_timeout_ms,
+    );
     if let Ok(prefix) = std::env::var("REDIS_CLUSTER_QUEUE_PREFIX") {
         options.queue.redis_cluster.prefix = Some(prefix);
     }

--- a/crates/sockudo-core/src/options/env/drivers.rs
+++ b/crates/sockudo-core/src/options/env/drivers.rs
@@ -16,6 +16,10 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
     );
     options.adapter.aggregate_counts =
         parse_env::<bool>("ADAPTER_AGGREGATE_COUNTS", options.adapter.aggregate_counts);
+    options.adapter.fast_presence_transitions = parse_env::<bool>(
+        "ADAPTER_FAST_PRESENCE_TRANSITIONS",
+        options.adapter.fast_presence_transitions,
+    );
     options.adapter.fallback_to_local = parse_env::<bool>(
         "ADAPTER_FALLBACK_TO_LOCAL",
         options.adapter.fallback_to_local,

--- a/crates/sockudo-core/src/options/env/queues.rs
+++ b/crates/sockudo-core/src/options/env/queues.rs
@@ -4,6 +4,10 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
     // --- Queue: Redis ---
     options.queue.redis.concurrency =
         parse_env::<u32>("QUEUE_REDIS_CONCURRENCY", options.queue.redis.concurrency);
+    options.queue.redis.response_timeout_ms = parse_env::<u64>(
+        "QUEUE_REDIS_RESPONSE_TIMEOUT_MS",
+        options.queue.redis.response_timeout_ms,
+    );
     if let Ok(prefix) = std::env::var("QUEUE_REDIS_PREFIX") {
         options.queue.redis.prefix = Some(prefix);
     }

--- a/crates/sockudo-core/src/options/queue.rs
+++ b/crates/sockudo-core/src/options/queue.rs
@@ -66,6 +66,7 @@ pub struct RedisQueueConfig {
     pub prefix: Option<String>,
     pub url_override: Option<String>,
     pub cluster_mode: bool,
+    pub response_timeout_ms: u64,
 }
 
 impl Default for SqsQueueConfig {
@@ -101,6 +102,18 @@ impl Default for RedisQueueConfig {
             prefix: Some("sockudo_queue:".to_string()),
             url_override: None,
             cluster_mode: false,
+            response_timeout_ms: 30000,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redis_queue_default_response_timeout_is_background_queue_budget() {
+        assert_eq!(RedisQueueConfig::default().response_timeout_ms, 30000);
+        assert_eq!(RedisClusterQueueConfig::default().request_timeout_ms, 5000);
     }
 }

--- a/crates/sockudo-core/src/options/server.rs
+++ b/crates/sockudo-core/src/options/server.rs
@@ -101,7 +101,7 @@ impl Default for ServerOptions {
             ai_transport: AiTransportConfig::default(),
             push: PushConfig::default(),
             push_rules: Vec::new(),
-            health_check_timeout_ms: 400,
+            health_check_timeout_ms: 2000,
         }
     }
 }
@@ -285,5 +285,15 @@ impl ServerOptions {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_health_check_timeout_leaves_probe_headroom() {
+        assert_eq!(ServerOptions::default().health_check_timeout_ms, 2000);
     }
 }

--- a/crates/sockudo-core/src/queue.rs
+++ b/crates/sockudo-core/src/queue.rs
@@ -23,6 +23,18 @@ type ArcJobProcessorFn = Arc<
 #[async_trait]
 pub trait QueueInterface: Send + Sync {
     async fn add_to_queue(&self, queue_name: &str, data: JobData) -> crate::error::Result<()>;
+
+    async fn add_batch_to_queue(
+        &self,
+        queue_name: &str,
+        data: Vec<JobData>,
+    ) -> crate::error::Result<()> {
+        for job in data {
+            self.add_to_queue(queue_name, job).await?;
+        }
+        Ok(())
+    }
+
     // Changed callback type to accept 'static lifetime needed by Redis workers
     async fn process_queue(
         &self,

--- a/crates/sockudo-queue/src/manager.rs
+++ b/crates/sockudo-queue/src/manager.rs
@@ -53,6 +53,7 @@ impl QueueManagerFactory {
         redis_url: Option<&str>,
         prefix: Option<&str>,
         concurrency: Option<usize>,
+        response_timeout_ms: Option<u64>,
     ) -> Result<Box<dyn QueueInterface>> {
         match driver {
             #[cfg(feature = "redis")]
@@ -60,12 +61,15 @@ impl QueueManagerFactory {
                 let url = redis_url.unwrap_or("redis://127.0.0.1:6379/");
                 let prefix_str = prefix.unwrap_or("sockudo");
                 let concurrency_val = concurrency.unwrap_or(5);
+                let response_timeout_ms = response_timeout_ms.unwrap_or(30000);
                 info!(
-                    "Creating Redis queue manager (Prefix: {}, Concurrency: {})",
-                    prefix_str, concurrency_val
+                    "Creating Redis queue manager (Prefix: {}, Concurrency: {}, Response timeout: {}ms)",
+                    prefix_str, concurrency_val, response_timeout_ms
                 );
                 debug!("Redis queue manager URL: {}", url);
-                let manager = RedisQueueManager::new(url, prefix_str, concurrency_val).await?;
+                let manager =
+                    RedisQueueManager::new(url, prefix_str, concurrency_val, response_timeout_ms)
+                        .await?;
                 Ok(Box::new(manager))
             }
             #[cfg(feature = "redis-cluster")]
@@ -77,16 +81,21 @@ impl QueueManagerFactory {
                     nodes_str.split(',').map(|s| s.trim().to_string()).collect();
                 let prefix_str = prefix.unwrap_or("sockudo");
                 let concurrency_val = concurrency.unwrap_or(5);
+                let response_timeout_ms = response_timeout_ms.unwrap_or(5000);
 
                 info!(
-                    "Creating Redis Cluster queue manager (Prefix: {}, Concurrency: {})",
-                    prefix_str, concurrency_val
+                    "Creating Redis Cluster queue manager (Prefix: {}, Concurrency: {}, Request timeout: {}ms)",
+                    prefix_str, concurrency_val, response_timeout_ms
                 );
                 debug!("Redis Cluster queue manager nodes: {:?}", cluster_nodes);
 
-                let manager =
-                    RedisClusterQueueManager::new(cluster_nodes, prefix_str, concurrency_val)
-                        .await?;
+                let manager = RedisClusterQueueManager::new(
+                    cluster_nodes,
+                    prefix_str,
+                    concurrency_val,
+                    response_timeout_ms,
+                )
+                .await?;
                 Ok(Box::new(manager))
             }
             #[cfg(feature = "nats")]
@@ -334,6 +343,11 @@ impl QueueManager {
     /// Adds data to the specified queue via the underlying driver.
     pub async fn add_to_queue(&self, queue_name: &str, data: JobData) -> Result<()> {
         self.driver.add_to_queue(queue_name, data).await
+    }
+
+    /// Adds multiple jobs to the specified queue via the underlying driver.
+    pub async fn add_batch_to_queue(&self, queue_name: &str, data: Vec<JobData>) -> Result<()> {
+        self.driver.add_batch_to_queue(queue_name, data).await
     }
 
     /// Registers a processor for the specified queue and starts processing (if applicable for the driver).

--- a/crates/sockudo-queue/src/memory_queue_manager.rs
+++ b/crates/sockudo-queue/src/memory_queue_manager.rs
@@ -171,6 +171,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_add_batch_to_queue() {
+        let manager = MemoryQueueManager::new();
+        let data = JobData {
+            app_key: "test_key".to_string(),
+            app_id: "test_id".to_string(),
+            app_secret: "test_secret".to_string(),
+            payload: JobPayload {
+                time_ms: chrono::Utc::now().timestamp_millis(),
+                events: vec![],
+            },
+            original_signature: "test_signature".to_string(),
+        };
+
+        manager
+            .add_batch_to_queue("test_queue", vec![data.clone(), data])
+            .await
+            .unwrap();
+
+        assert_eq!(manager.queues.get("test_queue").unwrap().len(), 2);
+    }
+
+    #[tokio::test]
     async fn test_disconnect() {
         let manager = MemoryQueueManager::new();
         let data = JobData {

--- a/crates/sockudo-queue/src/redis_cluster_queue_manager.rs
+++ b/crates/sockudo-queue/src/redis_cluster_queue_manager.rs
@@ -1,6 +1,6 @@
 use crate::ArcJobProcessorFn;
 use async_trait::async_trait;
-use redis::cluster::ClusterClient;
+use redis::cluster::{ClusterClient, ClusterClientBuilder};
 use redis::cluster_async::ClusterConnection;
 use redis::{AsyncCommands, RedisResult};
 use serde::Serialize;
@@ -8,12 +8,20 @@ use serde::de::DeserializeOwned;
 use sockudo_core::queue::QueueInterface;
 use sockudo_core::webhook_types::{JobData, JobProcessorFnAsync};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tracing::{debug, error, info};
+
+const MAX_PRODUCER_CONNECTIONS: usize = 8;
+const RPUSH_ATTEMPTS: usize = 3;
+const RPUSH_RETRY_BASE_DELAY: Duration = Duration::from_millis(50);
+const WORKER_BLPOP_TIMEOUT_SECONDS: f64 = 1.0;
 
 pub struct RedisClusterQueueManager {
     redis_client: ClusterClient,
     redis_connection: ClusterConnection,
+    producer_connections: Box<[ClusterConnection]>,
+    next_producer_connection: AtomicUsize,
     prefix: String,
     concurrency: usize,
 }
@@ -23,29 +31,30 @@ impl RedisClusterQueueManager {
         cluster_nodes: Vec<String>,
         prefix: &str,
         concurrency: usize,
+        request_timeout_ms: u64,
     ) -> sockudo_core::error::Result<Self> {
-        let client = ClusterClient::new(cluster_nodes.clone()).map_err(|e| {
-            sockudo_core::error::Error::Config(format!(
-                "Failed to create Redis cluster client: {e}"
-            ))
-        })?;
+        let client = Self::create_cluster_client(cluster_nodes.clone(), request_timeout_ms)?;
 
         let connection = client.get_async_connection().await.map_err(|e| {
             sockudo_core::error::Error::Connection(format!(
                 "Failed to get Redis cluster connection: {e}"
             ))
         })?;
+        let producer_connections = Self::create_producer_connections(&client, concurrency).await?;
 
         info!(
-            "Connected to Redis cluster with {} nodes, prefix: {}, concurrency: {}",
+            "Connected to Redis cluster with {} nodes, prefix: {}, concurrency: {}, request timeout: {}ms",
             cluster_nodes.len(),
             prefix,
-            concurrency
+            concurrency,
+            request_timeout_ms
         );
 
         Ok(Self {
             redis_client: client,
             redis_connection: connection,
+            producer_connections,
+            next_producer_connection: AtomicUsize::new(0),
             prefix: prefix.to_string(),
             concurrency,
         })
@@ -54,8 +63,85 @@ impl RedisClusterQueueManager {
     #[allow(dead_code)]
     pub fn start_processing(&self) {}
 
-    async fn format_key(&self, queue_name: &str) -> String {
+    fn create_cluster_client(
+        cluster_nodes: Vec<String>,
+        request_timeout_ms: u64,
+    ) -> sockudo_core::error::Result<ClusterClient> {
+        let builder = ClusterClientBuilder::new(cluster_nodes);
+        let builder = if request_timeout_ms == 0 {
+            builder.overall_response_timeout(None)
+        } else {
+            let request_timeout = Duration::from_millis(request_timeout_ms);
+            builder
+                .response_timeout(request_timeout)
+                .overall_response_timeout(Some(request_timeout))
+        };
+
+        builder.build().map_err(|e| {
+            sockudo_core::error::Error::Config(format!(
+                "Failed to create Redis cluster client: {e}"
+            ))
+        })
+    }
+
+    async fn create_producer_connections(
+        client: &ClusterClient,
+        concurrency: usize,
+    ) -> sockudo_core::error::Result<Box<[ClusterConnection]>> {
+        let producer_count = concurrency.clamp(1, MAX_PRODUCER_CONNECTIONS);
+        let mut producer_connections = Vec::with_capacity(producer_count);
+
+        for _ in 0..producer_count {
+            producer_connections.push(client.get_async_connection().await.map_err(|e| {
+                sockudo_core::error::Error::Connection(format!(
+                    "Failed to get Redis cluster producer connection: {e}"
+                ))
+            })?);
+        }
+
+        Ok(producer_connections.into_boxed_slice())
+    }
+
+    fn producer_connection(&self) -> ClusterConnection {
+        let connection_index = self
+            .next_producer_connection
+            .fetch_add(1, Ordering::Relaxed)
+            % self.producer_connections.len();
+
+        self.producer_connections[connection_index].clone()
+    }
+
+    fn format_key(&self, queue_name: &str) -> String {
         format!("{}:queue:{}", self.prefix, queue_name)
+    }
+
+    async fn rpush_serialized_jobs(
+        &self,
+        queue_name: &str,
+        queue_key: &str,
+        data_json: &[String],
+    ) -> sockudo_core::error::Result<()> {
+        let mut last_error = None;
+
+        for attempt in 0..RPUSH_ATTEMPTS {
+            let mut conn = self.producer_connection();
+            match conn.rpush::<_, _, ()>(queue_key, data_json.to_vec()).await {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    last_error = Some(error);
+                    if attempt + 1 < RPUSH_ATTEMPTS {
+                        tokio::time::sleep(RPUSH_RETRY_BASE_DELAY * (attempt as u32 + 1)).await;
+                    }
+                }
+            }
+        }
+
+        let error = last_error
+            .map(|error| error.to_string())
+            .unwrap_or_else(|| "unknown Redis Cluster error".to_string());
+        Err(sockudo_core::error::Error::Queue(format!(
+            "Redis Cluster RPUSH failed for queue {queue_name}: {error}"
+        )))
     }
 
     async fn start_worker(
@@ -86,8 +172,9 @@ impl RedisClusterQueueManager {
             );
 
             loop {
-                let blpop_result: RedisResult<Option<(String, String)>> =
-                    worker_conn.blpop(&queue_key, 0.01).await;
+                let blpop_result: RedisResult<Option<(String, String)>> = worker_conn
+                    .blpop(&queue_key, WORKER_BLPOP_TIMEOUT_SECONDS)
+                    .await;
 
                 match blpop_result {
                     Ok(Some((_key, job_data_str))) => {
@@ -133,19 +220,31 @@ impl QueueInterface for RedisClusterQueueManager {
     where
         JobData: Serialize,
     {
-        let queue_key = self.format_key(queue_name).await;
-        let data_json = sonic_rs::to_string(&data)?;
-        let mut conn = self.redis_connection.clone();
-
-        conn.rpush::<_, _, ()>(&queue_key, data_json)
+        let queue_key = self.format_key(queue_name);
+        let data_json = vec![sonic_rs::to_string(&data)?];
+        self.rpush_serialized_jobs(queue_name, &queue_key, &data_json)
             .await
-            .map_err(|e| {
-                sockudo_core::error::Error::Queue(format!(
-                    "Redis Cluster RPUSH failed for queue {queue_name}: {e}"
-                ))
-            })?;
+    }
 
-        Ok(())
+    async fn add_batch_to_queue(
+        &self,
+        queue_name: &str,
+        data: Vec<JobData>,
+    ) -> sockudo_core::error::Result<()>
+    where
+        JobData: Serialize,
+    {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let queue_key = self.format_key(queue_name);
+        let data_json = data
+            .iter()
+            .map(sonic_rs::to_string)
+            .collect::<Result<Vec<_>, _>>()?;
+        self.rpush_serialized_jobs(queue_name, &queue_key, &data_json)
+            .await
     }
 
     async fn process_queue(
@@ -156,7 +255,7 @@ impl QueueInterface for RedisClusterQueueManager {
     where
         JobData: DeserializeOwned + Send + 'static,
     {
-        let queue_key = self.format_key(queue_name).await;
+        let queue_key = self.format_key(queue_name);
         let processor_arc: ArcJobProcessorFn = Arc::from(callback);
 
         debug!(

--- a/crates/sockudo-queue/src/redis_queue_manager.rs
+++ b/crates/sockudo-queue/src/redis_queue_manager.rs
@@ -7,12 +7,22 @@ use serde::de::DeserializeOwned;
 use sockudo_core::queue::QueueInterface;
 use sockudo_core::webhook_types::{JobData, JobProcessorFnAsync};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tracing::{debug, error};
+
+const MAX_PRODUCER_CONNECTIONS: usize = 8;
+const HEALTH_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+const RPUSH_ATTEMPTS: usize = 3;
+const RPUSH_RETRY_BASE_DELAY: Duration = Duration::from_millis(50);
+const WORKER_BLPOP_TIMEOUT_SECONDS: f64 = 1.0;
 
 pub struct RedisQueueManager {
     redis_client: redis::Client,
     redis_connection: ConnectionManager,
+    producer_connections: Box<[ConnectionManager]>,
+    next_producer_connection: AtomicUsize,
+    health_connection: ConnectionManager,
     prefix: String,
     concurrency: usize,
 }
@@ -22,16 +32,25 @@ impl RedisQueueManager {
         redis_url: &str,
         prefix: &str,
         concurrency: usize,
+        response_timeout_ms: u64,
     ) -> sockudo_core::error::Result<Self> {
         let client = redis::Client::open(redis_url).map_err(|e| {
             sockudo_core::error::Error::Config(format!("Failed to open Redis client: {e}"))
         })?;
 
-        let connection = Self::create_connection_manager(&client).await?;
+        let response_timeout = Self::response_timeout_from_ms(response_timeout_ms);
+        let connection = Self::create_connection_manager(&client, response_timeout).await?;
+        let health_connection =
+            Self::create_connection_manager(&client, Some(HEALTH_RESPONSE_TIMEOUT)).await?;
+        let producer_connections =
+            Self::create_producer_connections(&client, concurrency, response_timeout).await?;
 
         Ok(Self {
             redis_client: client,
             redis_connection: connection,
+            producer_connections,
+            next_producer_connection: AtomicUsize::new(0),
+            health_connection,
             prefix: prefix.to_string(),
             concurrency,
         })
@@ -42,11 +61,13 @@ impl RedisQueueManager {
 
     async fn create_connection_manager(
         client: &redis::Client,
+        response_timeout: Option<Duration>,
     ) -> sockudo_core::error::Result<ConnectionManager> {
         let connection_manager_config = redis::aio::ConnectionManagerConfig::new()
             .set_number_of_retries(5)
             .set_exponent_base(2.0)
-            .set_max_delay(std::time::Duration::from_millis(5000));
+            .set_max_delay(Duration::from_millis(5000))
+            .set_response_timeout(response_timeout);
 
         client
             .get_connection_manager_with_config(connection_manager_config)
@@ -58,8 +79,70 @@ impl RedisQueueManager {
             })
     }
 
-    async fn format_key(&self, queue_name: &str) -> String {
+    async fn create_producer_connections(
+        client: &redis::Client,
+        concurrency: usize,
+        response_timeout: Option<Duration>,
+    ) -> sockudo_core::error::Result<Box<[ConnectionManager]>> {
+        let producer_count = concurrency.clamp(1, MAX_PRODUCER_CONNECTIONS);
+        let mut producer_connections = Vec::with_capacity(producer_count);
+
+        for _ in 0..producer_count {
+            producer_connections
+                .push(Self::create_connection_manager(client, response_timeout).await?);
+        }
+
+        Ok(producer_connections.into_boxed_slice())
+    }
+
+    fn response_timeout_from_ms(response_timeout_ms: u64) -> Option<Duration> {
+        if response_timeout_ms == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(response_timeout_ms))
+        }
+    }
+
+    fn producer_connection(&self) -> ConnectionManager {
+        let connection_index = self
+            .next_producer_connection
+            .fetch_add(1, Ordering::Relaxed)
+            % self.producer_connections.len();
+
+        self.producer_connections[connection_index].clone()
+    }
+
+    fn format_key(&self, queue_name: &str) -> String {
         format!("{}:queue:{}", self.prefix, queue_name)
+    }
+
+    async fn rpush_serialized_jobs(
+        &self,
+        queue_name: &str,
+        queue_key: &str,
+        data_json: &[String],
+    ) -> sockudo_core::error::Result<()> {
+        let mut last_error = None;
+
+        for attempt in 0..RPUSH_ATTEMPTS {
+            let mut conn = self.producer_connection();
+            match conn.rpush::<_, _, ()>(queue_key, data_json.to_vec()).await {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    last_error = Some(error);
+                    if attempt + 1 < RPUSH_ATTEMPTS {
+                        tokio::time::sleep(RPUSH_RETRY_BASE_DELAY * (attempt as u32 + 1)).await;
+                    }
+                }
+            }
+        }
+
+        let error = last_error
+            .map(|error| error.to_string())
+            .unwrap_or_else(|| "unknown Redis error".to_string());
+        Err(sockudo_core::error::Error::Queue(format!(
+            "Redis RPUSH failed for queue {queue_name}: {error}"
+        )))
     }
 
     async fn start_worker(
@@ -69,7 +152,7 @@ impl RedisQueueManager {
         processor: ArcJobProcessorFn,
         worker_id: usize,
     ) -> sockudo_core::error::Result<tokio::task::JoinHandle<()>> {
-        let mut worker_conn = Self::create_connection_manager(&self.redis_client).await?;
+        let mut worker_conn = Self::create_connection_manager(&self.redis_client, None).await?;
         let worker_queue_name = queue_name.to_string();
 
         Ok(tokio::spawn(async move {
@@ -82,8 +165,9 @@ impl RedisQueueManager {
             );
 
             loop {
-                let blpop_result: RedisResult<Option<(String, String)>> =
-                    worker_conn.blpop(&queue_key, 0.01).await;
+                let blpop_result: RedisResult<Option<(String, String)>> = worker_conn
+                    .blpop(&queue_key, WORKER_BLPOP_TIMEOUT_SECONDS)
+                    .await;
 
                 match blpop_result {
                     Ok(Some((_key, job_data_str))) => {
@@ -132,19 +216,31 @@ impl QueueInterface for RedisQueueManager {
     where
         JobData: Serialize,
     {
-        let queue_key = self.format_key(queue_name).await;
-        let data_json = sonic_rs::to_string(&data)?;
-        let mut conn = self.redis_connection.clone();
-
-        conn.rpush::<_, _, ()>(&queue_key, data_json)
+        let queue_key = self.format_key(queue_name);
+        let data_json = vec![sonic_rs::to_string(&data)?];
+        self.rpush_serialized_jobs(queue_name, &queue_key, &data_json)
             .await
-            .map_err(|e| {
-                sockudo_core::error::Error::Queue(format!(
-                    "Redis RPUSH failed for queue {queue_name}: {e}"
-                ))
-            })?;
+    }
 
-        Ok(())
+    async fn add_batch_to_queue(
+        &self,
+        queue_name: &str,
+        data: Vec<JobData>,
+    ) -> sockudo_core::error::Result<()>
+    where
+        JobData: Serialize,
+    {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let queue_key = self.format_key(queue_name);
+        let data_json = data
+            .iter()
+            .map(sonic_rs::to_string)
+            .collect::<Result<Vec<_>, _>>()?;
+        self.rpush_serialized_jobs(queue_name, &queue_key, &data_json)
+            .await
     }
 
     async fn process_queue(
@@ -155,7 +251,7 @@ impl QueueInterface for RedisQueueManager {
     where
         JobData: DeserializeOwned + Send + 'static,
     {
-        let queue_key = self.format_key(queue_name).await;
+        let queue_key = self.format_key(queue_name);
         let processor_arc: ArcJobProcessorFn = Arc::from(callback);
 
         debug!(
@@ -214,13 +310,7 @@ impl QueueInterface for RedisQueueManager {
     }
 
     async fn check_health(&self) -> sockudo_core::error::Result<()> {
-        let mut conn = self
-            .redis_client
-            .get_multiplexed_async_connection()
-            .await
-            .map_err(|e| {
-                sockudo_core::error::Error::Redis(format!("Queue Redis connection failed: {e}"))
-            })?;
+        let mut conn = self.health_connection.clone();
 
         let response = redis::cmd("PING")
             .query_async::<String>(&mut conn)
@@ -236,5 +326,19 @@ impl QueueInterface for RedisQueueManager {
                 "Queue Redis PING returned unexpected response: {response}"
             )))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_response_timeout_disables_redis_client_deadline() {
+        assert_eq!(RedisQueueManager::response_timeout_from_ms(0), None);
+        assert_eq!(
+            RedisQueueManager::response_timeout_from_ms(5000),
+            Some(Duration::from_millis(5000))
+        );
     }
 }

--- a/crates/sockudo-server/src/bootstrap/server.rs
+++ b/crates/sockudo-server/src/bootstrap/server.rs
@@ -364,62 +364,69 @@ impl SockudoServer {
                 None
             }
             QueueDriver::Redis | QueueDriver::RedisCluster | QueueDriver::Memory => {
-                let (queue_redis_url_or_nodes, queue_prefix, queue_concurrency) =
-                    match config.queue.driver {
-                        QueueDriver::Redis => {
-                            let owned_default_queue_redis_url: String;
-                            let queue_redis_url_arg: Option<&str>;
+                let (
+                    queue_redis_url_or_nodes,
+                    queue_prefix,
+                    queue_concurrency,
+                    queue_response_timeout_ms,
+                ) = match config.queue.driver {
+                    QueueDriver::Redis => {
+                        let owned_default_queue_redis_url: String;
+                        let queue_redis_url_arg: Option<&str>;
 
-                            if let Some(url_override) = config.queue.redis.url_override.as_ref() {
-                                queue_redis_url_arg = Some(url_override.as_str());
-                            } else {
-                                owned_default_queue_redis_url = config.database.redis.to_url();
-                                queue_redis_url_arg = Some(&owned_default_queue_redis_url);
-                            }
-
-                            (
-                                queue_redis_url_arg.map(|s| s.to_string()),
-                                config
-                                    .queue
-                                    .redis
-                                    .prefix
-                                    .as_deref()
-                                    .unwrap_or("sockudo_queue:"),
-                                config.queue.redis.concurrency as usize,
-                            )
+                        if let Some(url_override) = config.queue.redis.url_override.as_ref() {
+                            queue_redis_url_arg = Some(url_override.as_str());
+                        } else {
+                            owned_default_queue_redis_url = config.database.redis.to_url();
+                            queue_redis_url_arg = Some(&owned_default_queue_redis_url);
                         }
-                        QueueDriver::RedisCluster => {
-                            let cluster_nodes = if config.queue.redis_cluster.nodes.is_empty() {
-                                vec![
-                                    "redis://127.0.0.1:7000".to_string(),
-                                    "redis://127.0.0.1:7001".to_string(),
-                                    "redis://127.0.0.1:7002".to_string(),
-                                ]
-                            } else {
-                                config.queue.redis_cluster.nodes.clone()
-                            };
 
-                            let nodes_str = cluster_nodes.join(",");
+                        (
+                            queue_redis_url_arg.map(|s| s.to_string()),
+                            config
+                                .queue
+                                .redis
+                                .prefix
+                                .as_deref()
+                                .unwrap_or("sockudo_queue:"),
+                            config.queue.redis.concurrency as usize,
+                            Some(config.queue.redis.response_timeout_ms),
+                        )
+                    }
+                    QueueDriver::RedisCluster => {
+                        let cluster_nodes = if config.queue.redis_cluster.nodes.is_empty() {
+                            vec![
+                                "redis://127.0.0.1:7000".to_string(),
+                                "redis://127.0.0.1:7001".to_string(),
+                                "redis://127.0.0.1:7002".to_string(),
+                            ]
+                        } else {
+                            config.queue.redis_cluster.nodes.clone()
+                        };
 
-                            (
-                                Some(nodes_str),
-                                config
-                                    .queue
-                                    .redis_cluster
-                                    .prefix
-                                    .as_deref()
-                                    .unwrap_or("sockudo_queue:"),
-                                config.queue.redis_cluster.concurrency as usize,
-                            )
-                        }
-                        _ => (None, "sockudo_queue:", 5),
-                    };
+                        let nodes_str = cluster_nodes.join(",");
+
+                        (
+                            Some(nodes_str),
+                            config
+                                .queue
+                                .redis_cluster
+                                .prefix
+                                .as_deref()
+                                .unwrap_or("sockudo_queue:"),
+                            config.queue.redis_cluster.concurrency as usize,
+                            Some(config.queue.redis_cluster.request_timeout_ms),
+                        )
+                    }
+                    _ => (None, "sockudo_queue:", 5, None),
+                };
 
                 match QueueManagerFactory::create(
                     config.queue.driver.as_ref(),
                     queue_redis_url_or_nodes.as_deref(),
                     Some(queue_prefix),
                     Some(queue_concurrency),
+                    queue_response_timeout_ms,
                 )
                 .await
                 {

--- a/crates/sockudo-server/src/http_handler/events/processor.rs
+++ b/crates/sockudo-server/src/http_handler/events/processor.rs
@@ -1,6 +1,5 @@
 use futures_util::future::join_all;
 use sockudo_adapter::ConnectionHandler;
-use sockudo_adapter::channel_manager::ChannelManager;
 use sockudo_core::app::App;
 use sockudo_core::utils::{self, validate_channel_name};
 use sockudo_core::websocket::SocketId;
@@ -270,12 +269,10 @@ pub(super) async fn process_single_event_parallel(
                 }
 
                 if is_presence && info_for_task.as_deref().is_some_and(|s| s.contains("user_count")) {
-                    match ChannelManager::get_channel_members(
-                        handler_clone.connection_manager(),
-                        &app.id,
-                        &target_channel_str
-                    )
-                    .await
+                    match handler_clone
+                        .connection_manager()
+                        .get_local_channel_members(&app.id, &target_channel_str)
+                        .await
                     {
                         Ok(members_map) => {
                             current_channel_info_map

--- a/crates/sockudo-webhook/src/integration.rs
+++ b/crates/sockudo-webhook/src/integration.rs
@@ -72,6 +72,10 @@ impl QueueManager {
         self.driver.add_to_queue(queue_name, data).await
     }
 
+    pub async fn add_batch_to_queue(&self, queue_name: &str, data: Vec<JobData>) -> Result<()> {
+        self.driver.add_batch_to_queue(queue_name, data).await
+    }
+
     pub async fn process_queue(
         &self,
         queue_name: &str,
@@ -184,16 +188,15 @@ impl WebhookIntegration {
                 );
 
                 if let Some(qm) = &queue_manager_clone {
-                    for batch in Self::merge_jobs_for_queue(jobs_to_process, batch_size) {
-                        if let Err(e) = qm.add_to_queue(WEBHOOK_QUEUE_NAME, batch).await {
-                            error!(
-                                "{}",
-                                format!(
-                                    "Failed to add batched job to queue {}: {}",
-                                    WEBHOOK_QUEUE_NAME, e
-                                )
-                            );
-                        }
+                    let batches = Self::merge_jobs_for_queue(jobs_to_process, batch_size);
+                    if let Err(e) = qm.add_batch_to_queue(WEBHOOK_QUEUE_NAME, batches).await {
+                        error!(
+                            "{}",
+                            format!(
+                                "Failed to add batched jobs to queue {}: {}",
+                                WEBHOOK_QUEUE_NAME, e
+                            )
+                        );
                     }
                 }
             }
@@ -718,7 +721,7 @@ mod tests {
     use sockudo_queue::manager::QueueManagerFactory;
 
     async fn create_test_queue_manager() -> Arc<QueueManager> {
-        let driver = QueueManagerFactory::create("memory", None, None, None)
+        let driver = QueueManagerFactory::create("memory", None, None, None, None)
             .await
             .expect("Failed to create test queue manager");
         Arc::new(QueueManager::new(driver))

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -23,7 +23,7 @@ This page lists every runtime environment variable referenced by the server, cor
 | `WEBSOCKET_MAX_PAYLOAD_KB` | Legacy maximum WebSocket payload size in KiB. |
 | `INSTANCE_PROCESS_ID` | Stable node/process identity used by clustering and Iggy consumers. |
 | `HOSTNAME` | Fallback node identity for Iggy when `INSTANCE_PROCESS_ID` is not set. |
-| `HEALTH_CHECK_TIMEOUT_MS` | Dependency timeout for health checks. |
+| `HEALTH_CHECK_TIMEOUT_MS` | Per-dependency timeout for `/up` health checks in milliseconds. Defaults to `2000`. |
 | `HTTP_API_USAGE_ENABLED` | Enables `/usage` and `/stats` operational endpoints. |
 
 ## Logging
@@ -207,6 +207,8 @@ This page lists every runtime environment variable referenced by the server, cor
 | --- | --- |
 | `QUEUE_REDIS_CONCURRENCY` | Redis queue worker concurrency. |
 | `QUEUE_REDIS_PREFIX` | Redis queue key prefix. |
+| `QUEUE_REDIS_RESPONSE_TIMEOUT_MS` | Redis queue command response timeout in milliseconds. Set to `0` to disable the client-side deadline. |
+| `REDIS_CLUSTER_QUEUE_REQUEST_TIMEOUT_MS` | Redis Cluster queue command request timeout in milliseconds. Set to `0` to disable the cluster client deadline. |
 | `QUEUE_SQS_REGION` | SQS region. |
 | `QUEUE_SQS_VISIBILITY_TIMEOUT` | SQS visibility timeout. |
 | `QUEUE_SQS_MAX_MESSAGES` | SQS receive batch size. |
@@ -236,6 +238,7 @@ This page lists every runtime environment variable referenced by the server, cor
 | `NATS_CLIENT_CAPACITY` | NATS client channel capacity. |
 | `NATS_MAX_RECONNECTS` | NATS reconnect limit. |
 | `NATS_PRESENCE_SYNC_CHUNK_SIZE` | Presence sync chunk size for NATS. |
+| `NATS_NO_ECHO` | Suppress delivery of a NATS connection's own horizontal messages. |
 | `PULSAR_URL` | Pulsar service URL. |
 | `PULSAR_PREFIX` | Pulsar topic prefix. |
 | `PULSAR_TOKEN` | Pulsar auth token. |

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -48,6 +48,7 @@ This page lists every runtime environment variable referenced by the server, cor
 | `ADAPTER_BUFFER_MULTIPLIER_PER_CPU` | Adapter fanout buffer sizing multiplier. |
 | `ADAPTER_ENABLE_SOCKET_COUNTING` | Enables adapter socket counting. |
 | `ADAPTER_AGGREGATE_COUNTS` | Enables gossiped aggregate channel counts for local count reads. |
+| `ADAPTER_FAST_PRESENCE_TRANSITIONS` | Uses the replicated presence registry for first-join/last-leave checks; faster but eventually consistent. |
 | `ADAPTER_FALLBACK_TO_LOCAL` | Falls back to the local adapter when a configured adapter cannot start. |
 | `APP_MANAGER_REGISTER_INLINE_APPS` | Allows inline app definitions from config to be registered. |
 | `SOCKUDO_SKIP_INLINE_APPS` | Skips inline apps even if present in the config file. |

--- a/docs/content/docs/server/configuration.mdx
+++ b/docs/content/docs/server/configuration.mdx
@@ -79,6 +79,7 @@ The adapter controls cross-node fanout.
 driver = "redis"
 enable_socket_counting = true
 aggregate_counts = false
+fast_presence_transitions = false
 
 [adapter.redis]
 host = "redis"
@@ -91,12 +92,17 @@ Use a shared adapter for every multi-node deployment. Local memory adapters are 
 `enable_socket_counting` keeps the adapter's request/reply socket-count path enabled by default.
 `aggregate_counts` is off by default; enable it when you want each node to maintain gossiped
 cluster-wide channel counts for local count reads.
+`fast_presence_transitions` is off by default. Enabling it uses the replicated presence registry
+for first-join and last-leave checks, which avoids request/reply fanout but makes presence
+webhook/history transition decisions eventually consistent.
 
 For high-churn benchmark runs that should avoid distributed count fanout, use:
 
 ```bash
 ADAPTER_ENABLE_SOCKET_COUNTING=false
 ADAPTER_AGGREGATE_COUNTS=true
+# Optional: enables eventual-consistency presence transition checks.
+ADAPTER_FAST_PRESENCE_TRANSITIONS=true
 ```
 
 ## Recovery and history

--- a/docs/content/docs/server/scaling.mdx
+++ b/docs/content/docs/server/scaling.mdx
@@ -62,7 +62,8 @@ For Kubernetes NATS clusters, prefer explicit StatefulSet pod DNS entries over a
       "connection_timeout_ms": 5000,
       "subscription_capacity": 131072,
       "client_capacity": 131072,
-      "max_reconnects": 60
+      "max_reconnects": 60,
+      "no_echo": true
     }
   }
 }

--- a/docs/content/docs/server/scaling.mdx
+++ b/docs/content/docs/server/scaling.mdx
@@ -46,6 +46,14 @@ ADAPTER_ENABLE_SOCKET_COUNTING=false
 ADAPTER_AGGREGATE_COUNTS=true
 ```
 
+Presence first-join and last-leave checks remain strict by default because they drive member
+webhooks and presence history. For workloads that prefer maximum churn throughput over immediate
+transition consistency, opt into the replicated presence-registry fast path:
+
+```bash
+ADAPTER_FAST_PRESENCE_TRANSITIONS=true
+```
+
 For Kubernetes NATS clusters, prefer explicit StatefulSet pod DNS entries over a single headless service URL when you want better initial client spread:
 
 ```json


### PR DESCRIPTION
Avoid presence-related NATS request fanout where replicated registries already provide the answer, batch webhook queue writes, harden Redis queue/cache health behavior, and isolate app readiness lookups from slow shared cache access.

Local NATS benchmark improved from readiness 503s/RPUSH failures/publisher failures to zero 503s, zero queue errors, zero NATS request timeouts, and zero app-manager/cache timeout logs in the latest run.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
