### PR TITLE
chore(sockudo-swift): strict concurrency compliance with background processing pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ sockudo-blog
 .apns-e2e/
 .tmp
 .macos-push-probe/DerivedData/
+.swiftpm/
 
 # Local push provider secrets and canary inputs
 AuthKey_*.p8

--- a/client-sdks/sockudo-swift/Package.swift
+++ b/client-sdks/sockudo-swift/Package.swift
@@ -40,9 +40,6 @@ let package = Package(
       dependencies: [
         .product(name: "Sodium", package: "swift-sodium"),
         "CXDelta3",
-      ],
-      swiftSettings: [
-        .unsafeFlags(["-Xfrontend", "-strict-concurrency=minimal"])
       ]
     ),
     .testTarget(
@@ -52,10 +49,7 @@ let package = Package(
         .product(name: "Testing", package: "swift-testing"),
       ],
       swiftSettings: [
-        .unsafeFlags([
-          "-Xfrontend", "-strict-concurrency=minimal",
-          "-suppress-warnings",
-        ])
+        .unsafeFlags(["-suppress-warnings"])
       ]
     ),
   ]

--- a/client-sdks/sockudo-swift/README.md
+++ b/client-sdks/sockudo-swift/README.md
@@ -364,6 +364,104 @@ The live suite covers:
 - filter validation and delta option serialization
 - encrypted, private, and delta-enabled runtime paths through the client core
 
+## Threading Model
+
+`SockudoClient`, all channel types, and their callback closures are `@MainActor`-isolated.
+
+### Internal pipeline
+
+Message processing runs on a background actor before reaching MainActor:
+
+```
+URLSession background queue
+  → MessageProcessor actor (decode, dedup, delta reconstruction)
+    → MainActor (routing, state updates, callback delivery)
+```
+
+CPU-intensive work — protocol decoding (JSON, MessagePack, Protobuf), message deduplication, and delta reconstruction — runs off the main thread. Only fully-processed events reach MainActor.
+
+### What this means for your code
+
+All public API must be called from the main thread (or an `@MainActor` context):
+
+```swift
+// ✅ SwiftUI — already @MainActor, no change needed
+struct ContentView: View {
+    var body: some View {
+        Button("Connect") { client.connect() }
+    }
+}
+
+// ✅ UIKit — UIViewController is @MainActor in Swift 6, no change needed
+class MyViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        client.connect()
+    }
+}
+
+// ✅ From a non-isolated async context — use await
+func setup() async {
+    await MainActor.run { client.connect() }
+}
+
+// ✅ From a Combine publisher — dispatch to main first
+publisher
+    .receive(on: DispatchQueue.main)
+    .sink { [weak self] _ in self?.client.connect() }
+    .store(in: &cancellables)
+```
+
+### Callbacks execute on MainActor
+
+All event callbacks (`bind`, `on`, `onGlobal`) fire on the main thread:
+
+```swift
+channel.bind("price-updated") { data, _ in
+    // Already on @MainActor — safe to update UI directly
+    self.label.text = "\(data ?? "")"
+}
+```
+
+### Reconnection
+
+On disconnect, the client reconnects automatically using exponential backoff:
+
+- Delay formula: `attempt² seconds` (1s, 4s, 9s, 16s, 25s, ...)
+- Maximum delay: 120 seconds (configurable via `Options.maxReconnectGapInSeconds`)
+- Maximum attempts: 6 (configurable via `Options.maxReconnectAttempts`, `nil` = unlimited)
+- Counter resets on successful connection
+
+```swift
+let client = try SockudoClient(
+    "app-key",
+    options: .init(
+        cluster: "local",
+        maxReconnectAttempts: 10,
+        maxReconnectGapInSeconds: 60
+    )
+)
+```
+
+### Client event buffering
+
+Client events triggered on a channel while disconnected are buffered and replayed automatically after re-subscription:
+
+```swift
+// Triggered while disconnected — buffered, not dropped
+channel.trigger(event: "client-typing", data: ["user": "alice"])
+
+// After reconnect and re-subscription, the event is sent automatically
+```
+
+- Buffer capacity: 50 events per channel (oldest dropped on overflow)
+- Buffer is preserved across disconnect/reconnect cycles
+- Buffer is cleared when `unsubscribe()` is called
+
+### Migration from pre-2.2
+
+If you were calling SockudoSwift methods from a background thread or Combine sink without a main-thread dispatch, those calls were data races. Wrap them in `.receive(on: DispatchQueue.main)` or `Task { @MainActor in }`.
+
 ## Release Model
 
 Swift packages are distributed by git tag rather than a central package registry by default.

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/Auth.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/Auth.swift
@@ -40,21 +40,19 @@ public struct UserAuthenticationRequest: Sendable, Equatable {
   }
 }
 
-public typealias ChannelAuthorizationHandler =
-  (
-    ChannelAuthorizationRequest,
-    @escaping @Sendable (Result<ChannelAuthorizationData, Error>) -> Void
-  ) -> Void
-public typealias UserAuthenticationHandler =
-  (
-    UserAuthenticationRequest,
-    @escaping @Sendable (Result<UserAuthenticationData, Error>) -> Void
-  ) -> Void
+public typealias ChannelAuthorizationHandler = @Sendable (
+  ChannelAuthorizationRequest,
+  @escaping @Sendable (Result<ChannelAuthorizationData, Error>) -> Void
+) -> Void
+public typealias UserAuthenticationHandler = @Sendable (
+  UserAuthenticationRequest,
+  @escaping @Sendable (Result<UserAuthenticationData, Error>) -> Void
+) -> Void
 public typealias CapabilityTokenProvider =
-  (@escaping @Sendable (Result<String, Error>) -> Void) -> Void
+  @Sendable (@escaping @Sendable (Result<String, Error>) -> Void) -> Void
 public typealias CapabilityTokenAsyncProvider = @Sendable () async throws -> String
 
-public struct ChannelAuthorizationOptions {
+public struct ChannelAuthorizationOptions: Sendable {
   public var endpoint: String
   public var headers: [String: String]
   public var params: [String: AuthValue]
@@ -79,7 +77,7 @@ public struct ChannelAuthorizationOptions {
   }
 }
 
-public struct UserAuthenticationOptions {
+public struct UserAuthenticationOptions: Sendable {
   public var endpoint: String
   public var headers: [String: String]
   public var params: [String: AuthValue]
@@ -126,7 +124,7 @@ public struct CapabilityTokenExpiredData: Sendable, Equatable {
   }
 }
 
-public struct CapabilityTokenOptions {
+public struct CapabilityTokenOptions: Sendable {
   public var token: String?
   public var provider: CapabilityTokenProvider?
 
@@ -155,7 +153,7 @@ public struct CapabilityTokenOptions {
   }
 }
 
-public struct PresenceHistoryOptions {
+public struct PresenceHistoryOptions: Sendable {
   public var endpoint: String
   public var headers: [String: String]
   public var headersProvider: (@Sendable () -> [String: String])?
@@ -171,7 +169,7 @@ public struct PresenceHistoryOptions {
   }
 }
 
-public struct VersionedMessagesOptions {
+public struct VersionedMessagesOptions: Sendable {
   public var endpoint: String
   public var headers: [String: String]
   public var headersProvider: (@Sendable () -> [String: String])?

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/Channels.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/Channels.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Sodium
 
-public class Channel: @unchecked Sendable {
+@MainActor public class Channel: Sendable {
   public let name: String
   unowned let client: SockudoClient
   let dispatcher: EventDispatcher
@@ -15,6 +15,16 @@ public class Channel: @unchecked Sendable {
   var eventsFilter: [String]?
   var rewind: SubscriptionRewind?
   var annotationSubscribe = false
+
+  private struct QueuedClientEvent {
+    let name: String
+    let data: Any
+  }
+
+  private var unsentEvents: [QueuedClientEvent] = []
+  private let maxBufferedEvents = 50
+
+  var bufferedEventCount: Int { unsentEvents.count }
 
   init(name: String, client: SockudoClient) {
     self.name = name
@@ -68,10 +78,27 @@ public class Channel: @unchecked Sendable {
     guard event.hasPrefix("client-") else {
       throw SockudoError.badEventName("Event '\(event)' does not start with 'client-'")
     }
-    if isSubscribed == false {
-      Logger.warn("Client event triggered before channel subscription succeeded")
+    if isSubscribed {
+      return (try? client.sendEvent(name: event, data: data, channel: name)) ?? false
+    } else {
+      if unsentEvents.count >= maxBufferedEvents {
+        unsentEvents.removeFirst()
+        Logger.warn("Client event buffer full for channel '\(name)', dropping oldest event")
+      }
+      unsentEvents.append(QueuedClientEvent(name: event, data: data))
+      return true
     }
-    return try client.sendEvent(name: event, data: data, channel: name)
+  }
+
+  fileprivate func drainUnsentEvents() {
+    while !unsentEvents.isEmpty {
+      let queued = unsentEvents.removeFirst()
+      _ = try? client.sendEvent(name: queued.name, data: queued.data, channel: name)
+    }
+  }
+
+  func clearUnsentEvents() {
+    unsentEvents.removeAll()
   }
 
   func authorize(
@@ -95,52 +122,54 @@ public class Channel: @unchecked Sendable {
     subscriptionPending = true
     subscriptionCancelled = false
     authorize(socketID: client.socketID ?? "") { [weak self] result in
-      guard let self else { return }
-      switch result {
-      case .failure(let error):
-        self.subscriptionPending = false
-        self.dispatcher.emit(
-          self.client.p.event("subscription_error"),
-          data: [
-            "type": "AuthError",
-            "error": error.localizedDescription,
-          ])
-      case .success(let data):
-        var payload: [String: Any] = [
-          "auth": data.auth,
-          "channel": self.name,
-        ]
-        if let channelData = data.channelData {
-          payload["channel_data"] = channelData
-        }
-        if let filter = self.tagsFilter, let filterJSON = try? JSON.encodeData(filter),
-          let json = try? JSON.decode(filterJSON)
-        {
-          payload["tags_filter"] = json
-        }
-        if let deltaSettings = self.deltaSettings {
-          payload["delta"] = deltaSettings.subscriptionValue()
-        }
-        if let eventsFilter = self.eventsFilter {
-          payload["events"] = eventsFilter
-        }
-        if let rewind = self.rewind {
-          payload["rewind"] = rewind.subscriptionValue()
-        }
-        if self.annotationSubscribe {
-          payload["modes"] = ["SUBSCRIBE", "ANNOTATION_SUBSCRIBE"]
-        }
-        do {
-          _ = try self.client.sendEvent(
-            name: self.client.p.event("subscribe"), data: payload, channel: nil)
-        } catch {
+      Task { @MainActor in
+        guard let self else { return }
+        switch result {
+        case .failure(let error):
           self.subscriptionPending = false
           self.dispatcher.emit(
             self.client.p.event("subscription_error"),
             data: [
-              "type": "ConnectionError",
+              "type": "AuthError",
               "error": error.localizedDescription,
             ])
+        case .success(let data):
+          var payload: [String: Any] = [
+            "auth": data.auth,
+            "channel": self.name,
+          ]
+          if let channelData = data.channelData {
+            payload["channel_data"] = channelData
+          }
+          if let filter = self.tagsFilter, let filterJSON = try? JSON.encodeData(filter),
+            let json = try? JSON.decode(filterJSON)
+          {
+            payload["tags_filter"] = json
+          }
+          if let deltaSettings = self.deltaSettings {
+            payload["delta"] = deltaSettings.subscriptionValue()
+          }
+          if let eventsFilter = self.eventsFilter {
+            payload["events"] = eventsFilter
+          }
+          if let rewind = self.rewind {
+            payload["rewind"] = rewind.subscriptionValue()
+          }
+          if self.annotationSubscribe {
+            payload["modes"] = ["SUBSCRIBE", "ANNOTATION_SUBSCRIBE"]
+          }
+          do {
+            _ = try self.client.sendEvent(
+              name: self.client.p.event("subscribe"), data: payload, channel: nil)
+          } catch {
+            self.subscriptionPending = false
+            self.dispatcher.emit(
+              self.client.p.event("subscription_error"),
+              data: [
+                "type": "ConnectionError",
+                "error": error.localizedDescription,
+              ])
+          }
         }
       }
     }
@@ -168,6 +197,7 @@ public class Channel: @unchecked Sendable {
       if subscriptionCancelled {
         client.unsubscribe(name)
       } else {
+        drainUnsentEvents()
         dispatcher.emit(p.event("subscription_succeeded"), data: event.data)
       }
     } else if event.event == p.internal("subscription_count") {
@@ -320,7 +350,7 @@ public class Channel: @unchecked Sendable {
   }
 }
 
-public class PrivateChannel: Channel, @unchecked Sendable {
+@MainActor public class PrivateChannel: Channel {
   override func authorize(
     socketID: String,
     completion: @escaping @Sendable (Result<ChannelAuthorizationData, Error>) -> Void
@@ -332,7 +362,7 @@ public class PrivateChannel: Channel, @unchecked Sendable {
   }
 }
 
-public final class PresenceMembers: @unchecked Sendable {
+@MainActor public final class PresenceMembers: Sendable {
   private(set) var members: [String: AnyHashable] = [:]
   public private(set) var count = 0
   public private(set) var myID: String?
@@ -422,7 +452,7 @@ public final class PresenceMembers: @unchecked Sendable {
   }
 }
 
-public final class PresenceChannel: PrivateChannel, @unchecked Sendable {
+@MainActor public final class PresenceChannel: PrivateChannel {
   public let members = PresenceMembers()
 
   override func authorize(
@@ -430,31 +460,33 @@ public final class PresenceChannel: PrivateChannel, @unchecked Sendable {
     completion: @escaping @Sendable (Result<ChannelAuthorizationData, Error>) -> Void
   ) {
     super.authorize(socketID: socketID) { [weak self] result in
-      guard let self else { return }
-      switch result {
-      case .failure:
-        completion(result)
-      case .success(let data):
-        if let channelData = data.channelData,
-          let channelDataAny = try? JSON.decodeString(channelData),
-          let dictionary = channelDataAny as? [String: Any],
-          let userID = dictionary["user_id"] as? String
-        {
-          self.members.setMyID(userID)
-          completion(.success(data))
-          return
-        }
+      Task { @MainActor in
+        guard let self else { return }
+        switch result {
+        case .failure:
+          completion(result)
+        case .success(let data):
+          if let channelData = data.channelData,
+            let channelDataAny = try? JSON.decodeString(channelData),
+            let dictionary = channelDataAny as? [String: Any],
+            let userID = dictionary["user_id"] as? String
+          {
+            self.members.setMyID(userID)
+            completion(.success(data))
+            return
+          }
 
-        if let userID = self.client.user.userID {
-          self.members.setMyID(userID)
-          completion(.success(data))
-        } else {
-          completion(
-            .failure(
-              SockudoError.authFailure(
-                statusCode: nil,
-                message: "Invalid auth response for presence channel '\(self.name)'"
-              )))
+          if let userID = self.client.user.userID {
+            self.members.setMyID(userID)
+            completion(.success(data))
+          } else {
+            completion(
+              .failure(
+                SockudoError.authFailure(
+                  statusCode: nil,
+                  message: "Invalid auth response for presence channel '\(self.name)'"
+                )))
+          }
         }
       }
     }
@@ -469,6 +501,7 @@ public final class PresenceChannel: PrivateChannel, @unchecked Sendable {
       if subscriptionCancelled {
         client.unsubscribe(name)
       } else if let data = event.data as? [String: Any] {
+        drainUnsentEvents()
         members.applySubscriptionData(data)
         dispatcher.emit(p.event("subscription_succeeded"), data: members)
       }
@@ -566,7 +599,7 @@ public final class PresenceChannel: PrivateChannel, @unchecked Sendable {
   }
 }
 
-public final class EncryptedChannel: PrivateChannel, @unchecked Sendable {
+@MainActor public final class EncryptedChannel: PrivateChannel {
   private var sharedSecret: Bytes?
   private let sodium = Sodium()
 
@@ -575,27 +608,29 @@ public final class EncryptedChannel: PrivateChannel, @unchecked Sendable {
     completion: @escaping @Sendable (Result<ChannelAuthorizationData, Error>) -> Void
   ) {
     super.authorize(socketID: socketID) { [weak self] result in
-      guard let self else { return }
-      switch result {
-      case .failure:
-        completion(result)
-      case .success(let data):
-        guard let secret = data.sharedSecret, let decoded = Data(base64Encoded: secret)
-        else {
+      Task { @MainActor in
+        guard let self else { return }
+        switch result {
+        case .failure:
+          completion(result)
+        case .success(let data):
+          guard let secret = data.sharedSecret, let decoded = Data(base64Encoded: secret)
+          else {
+            completion(
+              .failure(
+                SockudoError.authFailure(
+                  statusCode: nil,
+                  message:
+                    "No shared_secret key in auth payload for encrypted channel: \(self.name)"
+                )))
+            return
+          }
+          self.sharedSecret = Array(decoded)
           completion(
-            .failure(
-              SockudoError.authFailure(
-                statusCode: nil,
-                message:
-                  "No shared_secret key in auth payload for encrypted channel: \(self.name)"
-              )))
-          return
+            .success(
+              ChannelAuthorizationData(
+                auth: data.auth, channelData: data.channelData, sharedSecret: nil)))
         }
-        self.sharedSecret = Array(decoded)
-        completion(
-          .success(
-            ChannelAuthorizationData(
-              auth: data.auth, channelData: data.channelData, sharedSecret: nil)))
       }
     }
   }
@@ -629,13 +664,15 @@ public final class EncryptedChannel: PrivateChannel, @unchecked Sendable {
         nonce: Array(nonceData))
     else {
       super.authorize(socketID: client.socketID ?? "") { [weak self] result in
-        guard let self else { return }
-        if case .success(let authData) = result,
-          let sharedSecret = authData.sharedSecret,
-          let refreshedData = Data(base64Encoded: sharedSecret)
-        {
-          self.sharedSecret = Array(refreshedData)
-          self.handle(event: event)
+        Task { @MainActor in
+          guard let self else { return }
+          if case .success(let authData) = result,
+            let sharedSecret = authData.sharedSecret,
+            let refreshedData = Data(base64Encoded: sharedSecret)
+          {
+            self.sharedSecret = Array(refreshedData)
+            self.handle(event: event)
+          }
         }
       }
       return

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/DeltaCompression.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/DeltaCompression.swift
@@ -79,38 +79,18 @@ private final class ChannelState {
 
 final class DeltaCompressionManager {
   private let options: DeltaOptions
-  private let sendEvent: (String, Any) -> Bool
   private let prefix: ProtocolPrefix
-  private var enabled = false
   private var channelStates: [String: ChannelState] = [:]
   private var defaultAlgorithm: DeltaAlgorithm = .fossil
   private var totals = (messages: 0, delta: 0, full: 0, rawBytes: 0, wireBytes: 0, errors: 0)
 
-  init(
-    options: DeltaOptions, prefix: ProtocolPrefix = ProtocolPrefix(version: 2),
-    sendEvent: @escaping (String, Any) -> Bool
-  ) {
+  init(options: DeltaOptions, prefix: ProtocolPrefix = ProtocolPrefix(version: 2)) {
     self.options = options
     self.prefix = prefix
-    self.sendEvent = sendEvent
-  }
-
-  func enable() {
-    guard enabled == false else { return }
-    let payload: [String: Any] = ["algorithms": options.algorithms.map(\.rawValue)]
-    _ = sendEvent(prefix.event("enable_delta_compression"), payload)
-  }
-
-  func disable() {
-    enabled = false
   }
 
   func handleEnabled(_ data: Any?) {
-    guard let dictionary = data as? [String: Any] else {
-      enabled = true
-      return
-    }
-    enabled = dictionary["enabled"] as? Bool ?? true
+    guard let dictionary = data as? [String: Any] else { return }
     if let algorithmName = dictionary["algorithm"] as? String,
       let algorithm = DeltaAlgorithm(rawValue: algorithmName)
     {
@@ -258,7 +238,6 @@ final class DeltaCompressionManager {
   }
 
   private func requestResync(channel: String) {
-    _ = sendEvent(prefix.event("delta_sync_error"), ["channel": channel])
     channelStates[channel] = nil
   }
 

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/FossilDelta.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/FossilDelta.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum FossilDelta {
+enum FossilDelta: Sendable {
   private static let nHash = 16
   private static let digits = Array(
     "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~".utf8)

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/MessageDeduplicator.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/MessageDeduplicator.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Tracks recently seen message IDs to skip duplicate deliveries.
 /// Uses an insertion-ordered set with LRU eviction when capacity is exceeded.
-final class MessageDeduplicator: @unchecked Sendable {
+final class MessageDeduplicator {
   private let capacity: Int
   private var order: [String] = []
   private var seen: Set<String> = []

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/MessagePipeline.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/MessagePipeline.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+final class MessagePipeline: Sendable {
+  let wireFormat: SockudoWireFormat
+
+  init(wireFormat: SockudoWireFormat) {
+    self.wireFormat = wireFormat
+  }
+
+  func decode(_ message: URLSessionWebSocketTask.Message) throws -> SockudoEvent {
+    try ProtocolCodec.decodeEvent(message, format: wireFormat)
+  }
+
+  func reconstructDelta(base: String, deltaPayload: Data, algorithm: DeltaAlgorithm) throws
+    -> String
+  {
+    switch algorithm {
+    case .fossil:
+      return try String(
+        decoding: FossilDelta.apply(base: Data(base.utf8), delta: deltaPayload), as: UTF8.self)
+    case .xdelta3:
+      return try String(
+        decoding: XDelta3.decode(delta: deltaPayload, base: Data(base.utf8)), as: UTF8.self)
+    }
+  }
+
+  func parseJSON(_ string: String) -> Any? {
+    guard let data = string.data(using: .utf8) else { return nil }
+    return try? JSON.decode(data)
+  }
+
+  func stripDeltaMetadata(from rawMessage: URLSessionWebSocketTask.Message) -> String {
+    let decoded =
+      (try? ProtocolCodec.decodeEnvelope(rawMessage, format: wireFormat).rawMessage) ?? ""
+    var result = decoded
+    result = result.replacingOccurrences(
+      of: #","__delta_seq":\d+"#, with: "", options: .regularExpression)
+    result = result.replacingOccurrences(
+      of: #"__delta_seq":\d+,"#, with: "", options: .regularExpression)
+    result = result.replacingOccurrences(
+      of: #","__conflation_key":"[^"]*""#, with: "", options: .regularExpression)
+    result = result.replacingOccurrences(
+      of: #"__conflation_key":"[^"]*","#, with: "", options: .regularExpression)
+    return result
+  }
+}

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/MessageProcessor.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/MessageProcessor.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+struct ProcessedMessage: Sendable {
+  let event: SockudoEvent
+  let recoveryUpdate: (channel: String, position: RecoveryPosition)?
+  let resyncChannel: String?
+  let updatedDeltaStats: DeltaStats?
+}
+
+/// Processes incoming WebSocket messages off MainActor: protocol decoding,
+/// deduplication, and delta reconstruction. Delivers fully-processed
+/// `ProcessedMessage` values for MainActor routing and callback delivery.
+actor MessageProcessor {
+  private let pipeline: MessagePipeline
+  private let prefix: ProtocolPrefix
+  private var deduplicator: MessageDeduplicator?
+  private var deltaManager: DeltaCompressionManager?
+
+  init(
+    pipeline: MessagePipeline, prefix: ProtocolPrefix,
+    deduplicationCapacity: Int?, deltaOptions: DeltaOptions?
+  ) {
+    self.pipeline = pipeline
+    self.prefix = prefix
+    self.deduplicator = deduplicationCapacity.map { MessageDeduplicator(capacity: $0) }
+    self.deltaManager = deltaOptions.map { DeltaCompressionManager(options: $0, prefix: prefix) }
+  }
+
+  func process(_ message: URLSessionWebSocketTask.Message) throws -> ProcessedMessage? {
+    let event = try pipeline.decode(message)
+
+    if let id = event.messageId {
+      if deduplicator?.isDuplicate(id) == true { return nil }
+      deduplicator?.track(id)
+    }
+
+    let recoveryUpdate: (channel: String, position: RecoveryPosition)?
+    if let ch = event.channel, let serial = event.serial {
+      recoveryUpdate = (
+        ch,
+        RecoveryPosition(
+          streamID: event.streamID, serial: serial, lastMessageID: event.messageId)
+      )
+    } else {
+      recoveryUpdate = nil
+    }
+
+    if event.event == prefix.event("delta"), let ch = event.channel {
+      guard let reconstructed = deltaManager?.handleDeltaMessage(channel: ch, data: event.data)
+      else {
+        return ProcessedMessage(
+          event: event, recoveryUpdate: recoveryUpdate,
+          resyncChannel: ch, updatedDeltaStats: deltaManager?.getStats())
+      }
+      return ProcessedMessage(
+        event: reconstructed, recoveryUpdate: recoveryUpdate,
+        resyncChannel: nil, updatedDeltaStats: deltaManager?.getStats())
+    }
+
+    if event.event == prefix.event("delta_cache_sync"), let ch = event.channel {
+      deltaManager?.handleCacheSync(channel: ch, data: event.data)
+    }
+    if event.event == prefix.event("delta_compression_enabled") {
+      deltaManager?.handleEnabled(event.data)
+    }
+
+    if let ch = event.channel, let seq = event.sequence,
+      !prefix.isPlatformEvent(event.event), !prefix.isInternalEvent(event.event)
+    {
+      let stripped = pipeline.stripDeltaMetadata(from: message)
+      deltaManager?.handleFullMessage(
+        channel: ch, rawMessage: stripped,
+        sequence: seq, conflationKey: event.conflationKey)
+    }
+
+    return ProcessedMessage(
+      event: event, recoveryUpdate: recoveryUpdate,
+      resyncChannel: nil, updatedDeltaStats: nil)
+  }
+
+  func clearDeltaState(_ channel: String?) { deltaManager?.clearChannelState(channel) }
+  func getDeltaStats() -> DeltaStats? { deltaManager?.getStats() }
+  func resetDeltaStats() { deltaManager?.resetStats() }
+  func handleFullMessage(
+    channel: String, rawMessage: String, sequence: Int?, conflationKey: String?
+  ) {
+    deltaManager?.handleFullMessage(
+      channel: channel, rawMessage: rawMessage,
+      sequence: sequence, conflationKey: conflationKey)
+  }
+}

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/ProtocolCodec.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/ProtocolCodec.swift
@@ -1,16 +1,16 @@
 import Foundation
 
-enum EncodedPayload {
+enum EncodedPayload: Sendable {
   case string(String)
   case data(Data)
 }
 
-struct DecodedEnvelope {
+struct DecodedEnvelope: @unchecked Sendable {
   let envelope: [String: Any]
   let rawMessage: String
 }
 
-enum ProtocolCodec {
+enum ProtocolCodec: Sendable {
   static func encodeEnvelope(_ envelope: [String: Any], format: SockudoWireFormat) throws
     -> EncodedPayload
   {
@@ -186,7 +186,7 @@ enum ProtocolCodec {
   }
 }
 
-private enum MessagePackCodec {
+private enum MessagePackCodec: Sendable {
   private static let envelopeFields = [
     "event",
     "channel",
@@ -307,7 +307,8 @@ private enum MessagePackCodec {
   }
 }
 
-private struct MessagePackEncoder {
+private struct MessagePackEncoder: @unchecked Sendable {
+  // @unchecked Sendable: value type with mutable field, created and consumed within a single synchronous call stack, never shared across threads
   private(set) var data = Data()
 
   mutating func encode(_ value: Any) throws {
@@ -460,7 +461,8 @@ private struct MessagePackEncoder {
   }
 }
 
-private struct MessagePackDecoder {
+private struct MessagePackDecoder: @unchecked Sendable {
+  // @unchecked Sendable: value type with mutable field, created and consumed within a single synchronous call stack, never shared across threads
   let data: Data
   var offset: Data.Index
 
@@ -566,7 +568,7 @@ private struct MessagePackDecoder {
   }
 }
 
-private enum ProtobufCodec {
+private enum ProtobufCodec: Sendable {
   static func encode(_ envelope: [String: Any]) throws -> Data {
     var writer = ProtoWriter()
     if let event = envelope["event"] as? String {
@@ -886,7 +888,8 @@ private enum ProtobufCodec {
   }
 }
 
-private struct ProtoWriter {
+private struct ProtoWriter: @unchecked Sendable {
+  // @unchecked Sendable: value type with mutable field, created and consumed within a single synchronous call stack, never shared across threads
   private(set) var data = Data()
 
   mutating func writeString(field: UInt64, value: String) {
@@ -934,14 +937,15 @@ private struct ProtoWriter {
   }
 }
 
-private enum ProtoWireType: UInt64 {
+private enum ProtoWireType: UInt64, Sendable {
   case varint = 0
   case fixed64 = 1
   case lengthDelimited = 2
   case fixed32 = 5
 }
 
-private struct ProtoReader {
+private struct ProtoReader: @unchecked Sendable {
+  // @unchecked Sendable: value type with mutable fields, created and consumed within a single synchronous call stack, never shared across threads
   let data: Data
   var offset: Data.Index
   private var currentTag: UInt64 = 0

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/Push.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/Push.swift
@@ -73,7 +73,7 @@ public struct PushSubscriptionParams: Sendable, Equatable {
   }
 }
 
-public final class SockudoPushRegistration: @unchecked Sendable {
+public final class SockudoPushRegistration: Sendable {
   private let endpoint: String
   private let headers: [String: String]
   private let headersProvider: (@Sendable () -> [String: String])?

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Network
 
-public final class SockudoClient: @unchecked Sendable {
+@MainActor public final class SockudoClient: Sendable {
   public struct Options {
     public var cluster: String
     public var protocolVersion: Int
@@ -35,6 +35,8 @@ public final class SockudoClient: @unchecked Sendable {
     public var wireFormat: SockudoWireFormat
     public var appendMode: SockudoAppendMode
     public var appendRollupWindow: Int?
+    public var maxReconnectAttempts: Int? = 6
+    public var maxReconnectGapInSeconds: Double = 120
 
     public init(
       cluster: String,
@@ -68,7 +70,9 @@ public final class SockudoClient: @unchecked Sendable {
       echoMessages: Bool = true,
       wireFormat: SockudoWireFormat = .json,
       appendMode: SockudoAppendMode = .delta,
-      appendRollupWindow: Int? = nil
+      appendRollupWindow: Int? = nil,
+      maxReconnectAttempts: Int? = 6,
+      maxReconnectGapInSeconds: Double = 120
     ) {
       self.cluster = cluster
       self.protocolVersion = protocolVersion
@@ -102,6 +106,8 @@ public final class SockudoClient: @unchecked Sendable {
       self.wireFormat = wireFormat
       self.appendMode = appendMode
       self.appendRollupWindow = appendRollupWindow
+      self.maxReconnectAttempts = maxReconnectAttempts
+      self.maxReconnectGapInSeconds = maxReconnectGapInSeconds
     }
   }
 
@@ -117,6 +123,8 @@ public final class SockudoClient: @unchecked Sendable {
 
   public let key: String
   let p: ProtocolPrefix
+  nonisolated let pipeline: MessagePipeline
+  private nonisolated let messageProcessor: MessageProcessor
   var config: ResolvedConfiguration
   public private(set) var connectionState: ConnectionState = .initialized
   public private(set) var socketID: String?
@@ -136,8 +144,6 @@ public final class SockudoClient: @unchecked Sendable {
   private var timelineSenderTimer: Timer?
   private var capabilityTokenRefreshTimer: Timer?
   private let reachability = ReachabilityMonitor()
-  private var deltaManager: DeltaCompressionManager?
-  private var deduplicator: MessageDeduplicator?
   private var channelPositions: [String: RecoveryPosition] = [:]
   private var timeline = Timeline()
   private var currentTransport: Transport?
@@ -145,6 +151,8 @@ public final class SockudoClient: @unchecked Sendable {
   private var manuallyDisconnected = false
   private var terminalEventHandled = false
   private var tokenRequestInFlight = false
+  var reconnectAttempts = 0
+  private var cachedDeltaStats: DeltaStats?
 
   public init(_ key: String, options: Options, urlSession: URLSession? = nil) throws {
     guard key.isEmpty == false else { throw SockudoError.invalidAppKey }
@@ -157,8 +165,17 @@ public final class SockudoClient: @unchecked Sendable {
       )
     }
 
+    let p = ProtocolPrefix(version: options.protocolVersion)
+    let pipeline = MessagePipeline(wireFormat: options.wireFormat)
     self.key = key
-    self.p = ProtocolPrefix(version: options.protocolVersion)
+    self.p = p
+    self.pipeline = pipeline
+    self.messageProcessor = MessageProcessor(
+      pipeline: pipeline,
+      prefix: p,
+      deduplicationCapacity: options.messageDeduplication ? options.messageDeduplicationCapacity : nil,
+      deltaOptions: options.deltaCompression
+    )
     self.config = ResolvedConfiguration(options: options)
     self.user = UserFacade()
     self.watchlist = WatchlistFacade()
@@ -168,11 +185,6 @@ public final class SockudoClient: @unchecked Sendable {
       urlSession
       ?? URLSession(
         configuration: configuration, delegate: webSocketDelegate, delegateQueue: nil)
-
-    self.deltaManager = nil
-    if options.messageDeduplication {
-      self.deduplicator = MessageDeduplicator(capacity: options.messageDeduplicationCapacity)
-    }
 
     reachability.stateDidChange = { [weak self] isOnline in
       Task { @MainActor in
@@ -189,14 +201,6 @@ public final class SockudoClient: @unchecked Sendable {
 
     user.attach(client: self)
     watchlist.attach(client: self)
-
-    if let deltaOptions = options.deltaCompression {
-      self.deltaManager = DeltaCompressionManager(options: deltaOptions, prefix: self.p) {
-        [weak self] event, data in
-        guard let self else { return false }
-        return (try? self.sendEvent(name: event, data: data, channel: nil)) ?? false
-      }
-    }
   }
 
   private static func isAllowedAppendRollupWindow(_ value: Int?) -> Bool {
@@ -251,7 +255,10 @@ public final class SockudoClient: @unchecked Sendable {
   }
 
   deinit {
-    invalidateTimers()
+    // Timer cleanup is handled by disconnect(). The timers hold [weak self]
+    // so any stragglers become no-ops once this instance is released.
+    // NWPathMonitor.cancel() and URLSession invalidation are safe from any
+    // context and must run here to release system resources.
     reachability.stop()
     urlSession.invalidateAndCancel()
   }
@@ -321,11 +328,14 @@ public final class SockudoClient: @unchecked Sendable {
   public func unsubscribe(_ name: String) {
     if let channel = channels[name], channel.subscriptionPending {
       channel.subscriptionCancelled = true
-    } else if let channel = channels.removeValue(forKey: name), channel.isSubscribed {
-      channel.unsubscribe()
+    } else if let channel = channels.removeValue(forKey: name) {
+      channel.clearUnsentEvents()
+      if channel.isSubscribed {
+        channel.unsubscribe()
+      }
     }
     channelPositions.removeValue(forKey: name)
-    deltaManager?.clearChannelState(name)
+    Task { [messageProcessor] in await messageProcessor.clearDeltaState(name) }
   }
 
   public func connect() {
@@ -338,6 +348,7 @@ public final class SockudoClient: @unchecked Sendable {
     manuallyDisconnected = false
     terminalEventHandled = false
     attemptedFallback = false
+    reconnectAttempts = 0
     updateState(.connecting)
     openWebSocketAfterInitialAuth(using: transports[0])
     setUnavailableTimer()
@@ -346,6 +357,7 @@ public final class SockudoClient: @unchecked Sendable {
   public func disconnect() {
     manuallyDisconnected = true
     terminalEventHandled = true
+    reconnectAttempts = 0
     invalidateTimers()
     webSocketTask?.cancel(with: .normalClosure, reason: nil)
     webSocketTask = nil
@@ -369,14 +381,16 @@ public final class SockudoClient: @unchecked Sendable {
     }
 
     requestCapabilityToken { [weak self] result in
-      guard let self else { return }
-      switch result {
-      case .success:
-        self.openWebSocket(using: transport)
-      case .failure(let error):
-        self.clearUnavailableTimer()
-        self.updateState(.failed)
-        self.dispatcher.emit("error", data: error)
+      Task { @MainActor in
+        guard let self else { return }
+        switch result {
+        case .success:
+          self.openWebSocket(using: transport)
+        case .failure(let error):
+          self.clearUnavailableTimer()
+          self.updateState(.failed)
+          self.dispatcher.emit("error", data: error)
+        }
       }
     }
   }
@@ -390,11 +404,12 @@ public final class SockudoClient: @unchecked Sendable {
   }
 
   public func getDeltaStats() -> DeltaStats? {
-    deltaManager?.getStats()
+    cachedDeltaStats
   }
 
   public func resetDeltaStats() {
-    deltaManager?.resetStats()
+    cachedDeltaStats = nil
+    Task { [messageProcessor] in await messageProcessor.resetDeltaStats() }
   }
 
   public func recoveryPosition(for channelName: String) -> RecoveryPosition? {
@@ -466,7 +481,7 @@ public final class SockudoClient: @unchecked Sendable {
       let url = try socketURL(for: transport)
       let task = urlSession.webSocketTask(with: url)
       webSocketDelegate.didOpen = { [weak self] in
-        self?.readNextMessage()
+        Task { @MainActor in self?.readNextMessage() }
       }
       webSocketDelegate.didClose = { [weak self] code, reason in
         Task { @MainActor in
@@ -520,51 +535,50 @@ public final class SockudoClient: @unchecked Sendable {
   }
 
   private func readNextMessage() {
-    webSocketTask?.receive { [weak self] result in
+    webSocketTask?.receive { [weak self, messageProcessor] result in
       guard let self else { return }
-      Task { @MainActor in
-        switch result {
-        case .failure(let error):
+      switch result {
+      case .failure(let error):
+        Task { @MainActor in
           self.dispatcher.emit("error", data: error)
-          self.handleSocketClosed(
-            code: .abnormalClosure, reason: error.localizedDescription)
-        case .success(let message):
-          switch message {
-          case .string(let text):
-            self.handle(rawMessage: .string(text))
-          case .data(let data):
-            self.handle(rawMessage: .data(data))
-          @unknown default:
-            break
+          self.handleSocketClosed(code: .abnormalClosure, reason: error.localizedDescription)
+        }
+      case .success(let message):
+        Task {
+          do {
+            guard let processed = try await messageProcessor.process(message) else {
+              await MainActor.run { self.readNextMessage() }
+              return
+            }
+            await MainActor.run {
+              self.deliverMessage(processed)
+              self.readNextMessage()
+            }
+          } catch {
+            await MainActor.run {
+              self.dispatcher.emit("error", data: error)
+              self.readNextMessage()
+            }
           }
-          self.readNextMessage()
         }
       }
     }
   }
 
-  func handle(rawMessage: URLSessionWebSocketTask.Message) {
+  func deliverMessage(_ message: ProcessedMessage) {
+    if config.connectionRecovery, let update = message.recoveryUpdate {
+      channelPositions[update.channel] = update.position
+    }
+    if let resyncChannel = message.resyncChannel {
+      _ = try? sendEvent(name: p.event("delta_sync_error"), data: ["channel": resyncChannel], channel: nil)
+    }
+    if let stats = message.updatedDeltaStats {
+      cachedDeltaStats = stats
+    }
+    resetActivityTimer()
+
     do {
-      let event = try decodeEvent(rawMessage: rawMessage)
-      resetActivityTimer()
-
-      if let messageId = event.messageId, let deduplicator {
-        if deduplicator.isDuplicate(messageId) {
-          Logger.debug("Skipping duplicate message", messageId)
-          return
-        }
-        deduplicator.track(messageId)
-      }
-
-      // Track serial per channel for connection recovery
-      if config.connectionRecovery, let channelName = event.channel, let serial = event.serial {
-        channelPositions[channelName] = RecoveryPosition(
-          streamID: event.streamID,
-          serial: serial,
-          lastMessageID: event.messageId
-        )
-      }
-
+      let event = message.event
       let eventName = event.event
       if eventName == p.event("connection_established") {
         guard let payload = event.data as? [String: Any],
@@ -577,6 +591,7 @@ public final class SockudoClient: @unchecked Sendable {
           (payload["activity_timeout"] as? Double ?? config.activityTimeout) * 1000
         config.activityTimeout =
           min(config.activityTimeout * 1000, negotiatedTimeout) / 1000
+        reconnectAttempts = 0
         clearUnavailableTimer()
         updateState(.connected, metadata: ["socket_id": socketID])
         reachability.start()
@@ -602,89 +617,71 @@ public final class SockudoClient: @unchecked Sendable {
         if config.enableStats {
           startTimelineSender()
         }
-        if deltaManager != nil, config.deltaCompressionEnabled {
-          deltaManager?.enable()
+        if let deltaOptions = config.deltaOptions {
+          let payload: [String: Any] = ["algorithms": deltaOptions.algorithms.map(\.rawValue)]
+          _ = try? sendEvent(name: p.event("enable_delta_compression"), data: payload, channel: nil)
         }
         user.handleConnected()
-      } else if eventName == p.event("error") {
-        dispatcher.emit("error", data: event.data)
-      } else if eventName == p.event("ping") {
-        _ = try? sendEvent(name: p.event("pong"), data: [:], channel: nil)
-      } else if eventName == p.event("pong") {
-        // no-op
-      } else if eventName == p.event("signin_success") {
-        user.handleSignInSuccess(event.data)
-      } else if eventName == p.event("auth_success") {
-        capabilityTokenAuth = Self.decodeCapabilityTokenAuthData(event.data)
-        dispatcher.emit(eventName, data: event.data)
-      } else if eventName == p.event("token_expired") {
-        let expired = Self.decodeCapabilityTokenExpiredData(event.data)
-        lastCapabilityTokenExpired = expired
-        dispatcher.emit(eventName, data: event.data)
-        if expired.code == 40142 || expired.code == 40160 {
-          refreshCapabilityToken()
-        }
-      } else if eventName == p.internal("watchlist_events") {
-        watchlist.handle(event.data)
-      } else if eventName == p.event("delta_compression_enabled") {
-        deltaManager?.handleEnabled(event.data)
-        dispatcher.emit(eventName, data: event.data)
-      } else if eventName == p.event("delta_cache_sync") {
-        if let channel = event.channel {
-          deltaManager?.handleCacheSync(channel: channel, data: event.data)
-        }
-      } else if eventName == p.event("delta") {
-        if let channelName = event.channel,
-          let reconstructed = deltaManager?.handleDeltaMessage(
-            channel: channelName, data: event.data)
-        {
-          channels[channelName]?.handle(event: reconstructed)
-          dispatcher.emit(reconstructed.event, data: reconstructed.data)
-        }
-      } else if eventName == p.event("resume_success") {
-        let data = Self.decodeResumeSuccessData(event.data)
-        Logger.debug("Connection recovery succeeded", data)
-        dispatcher.emit(eventName, data: data)
-      } else if eventName == p.event("resume_failed") {
-        let failData = Self.decodeResumeFailedData(event.data)
-        if failData.channel.isEmpty == false {
-          channelPositions.removeValue(forKey: failData.channel)
-          Logger.warn("Connection recovery failed for channel", failData.channel)
-          channels[failData.channel]?.subscribeIfPossible()
-        }
-        dispatcher.emit(eventName, data: failData)
       } else {
-        let normalizedEvent =
-          eventName == p.event("rewind_complete")
-          ? SockudoEvent(
-            event: event.event,
-            channel: event.channel,
-            data: Self.decodeRewindCompleteData(event.data),
-            userID: event.userID,
-            streamID: event.streamID,
-            messageId: event.messageId,
-            rawMessage: event.rawMessage,
-            sequence: event.sequence,
-            conflationKey: event.conflationKey,
-            serial: event.serial,
-            extras: event.extras
-          ) : event
-        if let channelName = normalizedEvent.channel {
-          channels[channelName]?.handle(event: normalizedEvent)
-          if let sequence = normalizedEvent.sequence, p.isPlatformEvent(eventName) == false,
-            p.isInternalEvent(eventName) == false
-          {
-            let stripped = stripDeltaMetadata(from: rawMessage)
-            deltaManager?.handleFullMessage(
-              channel: channelName, rawMessage: stripped, sequence: sequence,
-              conflationKey: normalizedEvent.conflationKey)
+        if eventName == p.event("error") {
+          dispatcher.emit("error", data: event.data)
+        } else if eventName == p.event("ping") {
+          _ = try? sendEvent(name: p.event("pong"), data: [:], channel: nil)
+        } else if eventName == p.event("pong") {
+        } else if eventName == p.event("signin_success") {
+          user.handleSignInSuccess(event.data)
+        } else if eventName == p.event("auth_success") {
+          capabilityTokenAuth = Self.decodeCapabilityTokenAuthData(event.data)
+          dispatcher.emit(eventName, data: event.data)
+        } else if eventName == p.event("token_expired") {
+          let expired = Self.decodeCapabilityTokenExpiredData(event.data)
+          lastCapabilityTokenExpired = expired
+          dispatcher.emit(eventName, data: event.data)
+          if expired.code == 40142 || expired.code == 40160 {
+            refreshCapabilityToken()
           }
-        }
-        if shouldEmitClientEvent(eventName) {
-          dispatcher.emit(
-            eventName, data: normalizedEvent.data,
-            metadata: EventMetadata(userID: normalizedEvent.userID)
-          )
+        } else if eventName == p.internal("watchlist_events") {
+          watchlist.handle(event.data)
+        } else if eventName == p.event("delta_compression_enabled") {
+          dispatcher.emit(eventName, data: event.data)
+        } else if eventName == p.event("delta_cache_sync") {
+        } else if eventName == p.event("resume_success") {
+          let data = Self.decodeResumeSuccessData(event.data)
+          Logger.debug("Connection recovery succeeded", data)
+          dispatcher.emit(eventName, data: data)
+        } else if eventName == p.event("resume_failed") {
+          let failData = Self.decodeResumeFailedData(event.data)
+          if failData.channel.isEmpty == false {
+            channelPositions.removeValue(forKey: failData.channel)
+            Logger.warn("Connection recovery failed for channel", failData.channel)
+            channels[failData.channel]?.subscribeIfPossible()
+          }
+          dispatcher.emit(eventName, data: failData)
+        } else {
+          let normalizedEvent =
+            eventName == p.event("rewind_complete")
+            ? SockudoEvent(
+              event: event.event,
+              channel: event.channel,
+              data: Self.decodeRewindCompleteData(event.data),
+              userID: event.userID,
+              streamID: event.streamID,
+              messageId: event.messageId,
+              rawMessage: event.rawMessage,
+              sequence: event.sequence,
+              conflationKey: event.conflationKey,
+              serial: event.serial,
+              extras: event.extras
+            ) : event
+          if let channelName = normalizedEvent.channel {
+            channels[channelName]?.handle(event: normalizedEvent)
+          }
+          if shouldEmitClientEvent(eventName) {
+            dispatcher.emit(
+              eventName, data: normalizedEvent.data,
+              metadata: EventMetadata(userID: normalizedEvent.userID)
+            )
+          }
         }
       }
     } catch {
@@ -692,31 +689,34 @@ public final class SockudoClient: @unchecked Sendable {
     }
   }
 
-  private func decodeEvent(rawMessage: URLSessionWebSocketTask.Message) throws -> SockudoEvent {
-    try ProtocolCodec.decodeEvent(rawMessage, format: config.wireFormat)
+  func handle(rawMessage: URLSessionWebSocketTask.Message) {
+    guard let event = try? pipeline.decode(rawMessage) else { return }
+    deliverMessage(ProcessedMessage(event: event, recoveryUpdate: nil, resyncChannel: nil, updatedDeltaStats: nil))
   }
 
   private func refreshCapabilityToken() {
     guard config.protocolVersion == 2, config.capabilityTokenProvider != nil else { return }
     invalidateCapabilityTokenRefreshTimer()
     requestCapabilityToken { [weak self] result in
-      guard let self else { return }
-      switch result {
-      case .success(let token):
-        do {
-          let sent = try self.sendEvent(
-            name: self.p.event("auth"),
-            data: ["token": token],
-            channel: nil
-          )
-          if sent == false {
-            self.dispatcher.emit("error", data: SockudoError.connectionUnavailable)
+      Task { @MainActor in
+        guard let self else { return }
+        switch result {
+        case .success(let token):
+          do {
+            let sent = try self.sendEvent(
+              name: self.p.event("auth"),
+              data: ["token": token],
+              channel: nil
+            )
+            if sent == false {
+              self.dispatcher.emit("error", data: SockudoError.connectionUnavailable)
+            }
+          } catch {
+            self.dispatcher.emit("error", data: error)
           }
-        } catch {
+        case .failure(let error):
           self.dispatcher.emit("error", data: error)
         }
-      case .failure(let error):
-        self.dispatcher.emit("error", data: error)
       }
     }
   }
@@ -739,22 +739,6 @@ public final class SockudoClient: @unchecked Sendable {
       || eventName == p.internal("presence_update")
   }
 
-  private func stripDeltaMetadata(from rawMessage: URLSessionWebSocketTask.Message) -> String {
-    let decoded =
-      (try? ProtocolCodec.decodeEnvelope(rawMessage, format: config.wireFormat).rawMessage)
-      ?? ""
-    var result = decoded
-    result = result.replacingOccurrences(
-      of: #","__delta_seq":\d+"#, with: "", options: .regularExpression)
-    result = result.replacingOccurrences(
-      of: #"__delta_seq":\d+,"#, with: "", options: .regularExpression)
-    result = result.replacingOccurrences(
-      of: #","__conflation_key":"[^"]*""#, with: "", options: .regularExpression)
-    result = result.replacingOccurrences(
-      of: #"__conflation_key":"[^"]*","#, with: "", options: .regularExpression)
-    return result
-  }
-
   private func handleSocketClosed(code: URLSessionWebSocketTask.CloseCode, reason: String?) {
     guard !terminalEventHandled else { return }
     terminalEventHandled = true
@@ -769,16 +753,16 @@ public final class SockudoClient: @unchecked Sendable {
     switch action {
     case .tlsOnly:
       config.useTLS = true
-      scheduleRetry(after: 0)
+      scheduleRetry(after: reconnectDelay(for: action))
     case .backoff:
-      scheduleRetry(after: 1)
+      scheduleRetry(after: reconnectDelay(for: action))
     case .retry:
-      scheduleRetry(after: 0)
+      scheduleRetry(after: reconnectDelay(for: action))
     case .refused:
       updateState(.disconnected)
     case .none:
       if manuallyDisconnected == false {
-        scheduleRetry(after: 1)
+        scheduleRetry(after: reconnectDelay(for: nil))
       }
     }
 
@@ -786,6 +770,13 @@ public final class SockudoClient: @unchecked Sendable {
       dispatcher.emit("error", data: SockudoError.connectionUnavailable)
       Logger.warn("Socket closed", code.rawValue, reason)
     }
+  }
+
+  func reconnectDelay(for action: CloseAction?) -> TimeInterval {
+    if action == .retry { return 0 }  // close codes 4200-4299: reconnect immediately
+    if action == .tlsOnly { return 0 }  // TLS upgrade: reconnect immediately
+    let interval = Double(reconnectAttempts * reconnectAttempts)
+    return min(interval, config.maxReconnectGapInSeconds)
   }
 
   private func closeAction(for code: URLSessionWebSocketTask.CloseCode) -> CloseAction? {
@@ -909,8 +900,13 @@ public final class SockudoClient: @unchecked Sendable {
     unavailableTimer = nil
   }
 
-  private func scheduleRetry(after seconds: TimeInterval) {
+  func scheduleRetry(after seconds: TimeInterval) {
     guard manuallyDisconnected == false else { return }
+    if let max = config.maxReconnectAttempts, reconnectAttempts >= max {
+      updateState(.disconnected)
+      return
+    }
+    reconnectAttempts += 1
     retryTimer?.invalidate()
     retryTimer = Timer.scheduledTimer(withTimeInterval: seconds, repeats: false) {
       [weak self] _ in
@@ -919,7 +915,7 @@ public final class SockudoClient: @unchecked Sendable {
         self.terminalEventHandled = false
         self.webSocketTask?.cancel(with: .goingAway, reason: nil)
         self.webSocketTask = nil
-        self.updateState(.connecting)
+        self.updateState(.reconnecting)
         let transports = self.transportSequence()
         if self.currentTransport == .ws, self.attemptedFallback == false,
           transports.contains(.wss)
@@ -1012,7 +1008,7 @@ public final class SockudoClient: @unchecked Sendable {
   }
 }
 
-public final class UserFacade: @unchecked Sendable {
+@MainActor public final class UserFacade: Sendable {
   private(set) weak var client: SockudoClient?
   private let dispatcher = EventDispatcher { event, _ in
     Logger.debug("No callbacks on user for \(event)")
@@ -1106,7 +1102,7 @@ public final class UserFacade: @unchecked Sendable {
   }
 }
 
-public final class WatchlistFacade: @unchecked Sendable {
+@MainActor public final class WatchlistFacade: Sendable {
   private weak var client: SockudoClient?
   private let dispatcher = EventDispatcher { event, _ in
     Logger.debug("No callbacks on watchlist for \(event)")
@@ -1227,9 +1223,12 @@ extension SockudoClient {
     let presenceHistory: PresenceHistoryOptions?
     let versionedMessages: VersionedMessagesOptions?
     let deltaCompressionEnabled: Bool
+    let deltaOptions: DeltaOptions?
     let messageDeduplication: Bool
     let messageDeduplicationCapacity: Int
     let connectionRecovery: Bool
+    let maxReconnectAttempts: Int?
+    let maxReconnectGapInSeconds: Double
 
     init(options: Options) {
       cluster = options.cluster
@@ -1257,9 +1256,12 @@ extension SockudoClient {
       enabledTransports = options.enabledTransports
       disabledTransports = options.disabledTransports
       deltaCompressionEnabled = options.deltaCompression?.enabled == true
+      deltaOptions = options.deltaCompression
       messageDeduplication = options.messageDeduplication
       messageDeduplicationCapacity = options.messageDeduplicationCapacity
       connectionRecovery = options.connectionRecovery
+      maxReconnectAttempts = options.maxReconnectAttempts
+      maxReconnectGapInSeconds = options.maxReconnectGapInSeconds
       channelAuthorizer =
         options.channelAuthorization.customHandler
         ?? Self.makeChannelAuthorizer(options.channelAuthorization)
@@ -1844,7 +1846,7 @@ extension SockudoClient {
     }
   }
 
-  private func decodePresenceHistoryPage(
+  private nonisolated func decodePresenceHistoryPage(
     payload: [String: Any],
     channelName: String,
     originalParams: PresenceHistoryParams
@@ -1874,26 +1876,28 @@ extension SockudoClient {
       bounds: decodePresenceHistoryBounds(payload["bounds"] as? [String: Any]),
       continuity: decodePresenceHistoryContinuity(payload["continuity"] as? [String: Any]),
       fetchNext: { [weak self] cursor, completion in
-        self?.fetchPresenceHistory(
-          channelName: channelName,
-          params: PresenceHistoryParams(
-            direction: originalParams.direction,
-            limit: originalParams.limit,
-            cursor: cursor,
-            startSerial: originalParams.startSerial,
-            endSerial: originalParams.endSerial,
-            startTimeMS: originalParams.startTimeMS,
-            endTimeMS: originalParams.endTimeMS,
-            start: originalParams.start,
-            end: originalParams.end
-          ),
-          completion: completion
-        )
+        Task { @MainActor in
+          self?.fetchPresenceHistory(
+            channelName: channelName,
+            params: PresenceHistoryParams(
+              direction: originalParams.direction,
+              limit: originalParams.limit,
+              cursor: cursor,
+              startSerial: originalParams.startSerial,
+              endSerial: originalParams.endSerial,
+              startTimeMS: originalParams.startTimeMS,
+              endTimeMS: originalParams.endTimeMS,
+              start: originalParams.start,
+              end: originalParams.end
+            ),
+            completion: completion
+          )
+        }
       }
     )
   }
 
-  private func decodePresenceSnapshot(payload: [String: Any]) -> PresenceSnapshot {
+  private nonisolated func decodePresenceSnapshot(payload: [String: Any]) -> PresenceSnapshot {
     let members = ((payload["members"] as? [Any]) ?? []).compactMap { raw -> PresenceSnapshotMember? in
       guard let member = raw as? [String: Any] else { return nil }
       return PresenceSnapshotMember(
@@ -1915,7 +1919,7 @@ extension SockudoClient {
     )
   }
 
-  private func decodeChannelHistoryPage(
+  private nonisolated func decodeChannelHistoryPage(
     payload: [String: Any],
     channelName: String,
     originalParams: ChannelHistoryParams
@@ -1931,25 +1935,27 @@ extension SockudoClient {
       bounds: payload["bounds"] as? [String: Any] ?? [:],
       continuity: payload["continuity"] as? [String: Any] ?? [:],
       fetchNext: { [weak self] cursor, completion in
-        self?.fetchChannelHistory(
-          channelName: channelName,
-          params: ChannelHistoryParams(
-            direction: originalParams.direction,
-            limit: originalParams.limit,
-            cursor: cursor,
-            startSerial: originalParams.startSerial,
-            endSerial: originalParams.endSerial,
-            startTimeMS: originalParams.startTimeMS,
-            endTimeMS: originalParams.endTimeMS,
-            untilAttach: originalParams.untilAttach
-          ),
-          completion: completion
-        )
+        Task { @MainActor in
+          self?.fetchChannelHistory(
+            channelName: channelName,
+            params: ChannelHistoryParams(
+              direction: originalParams.direction,
+              limit: originalParams.limit,
+              cursor: cursor,
+              startSerial: originalParams.startSerial,
+              endSerial: originalParams.endSerial,
+              startTimeMS: originalParams.startTimeMS,
+              endTimeMS: originalParams.endTimeMS,
+              untilAttach: originalParams.untilAttach
+            ),
+            completion: completion
+          )
+        }
       }
     )
   }
 
-  private func decodeMessageVersionsPage(
+  private nonisolated func decodeMessageVersionsPage(
     payload: [String: Any],
     channelName: String,
     messageSerial: String,
@@ -1965,21 +1971,23 @@ extension SockudoClient {
       hasMore: payload["has_more"] as? Bool ?? false,
       nextCursor: payload["next_cursor"] as? String,
       fetchNext: { [weak self] cursor, completion in
-        self?.fetchMessageVersions(
-          channelName: channelName,
-          messageSerial: messageSerial,
-          params: MessageVersionsParams(
-            direction: originalParams.direction,
-            limit: originalParams.limit,
-            cursor: cursor
-          ),
-          completion: completion
-        )
+        Task { @MainActor in
+          self?.fetchMessageVersions(
+            channelName: channelName,
+            messageSerial: messageSerial,
+            params: MessageVersionsParams(
+              direction: originalParams.direction,
+              limit: originalParams.limit,
+              cursor: cursor
+            ),
+            completion: completion
+          )
+        }
       }
     )
   }
 
-  private static func decodeVersionedMessageAck(
+  private nonisolated static func decodeVersionedMessageAck(
     payload: [String: Any],
     channelName: String,
     messageSerial: String?,
@@ -2016,7 +2024,7 @@ extension SockudoClient {
       ))
   }
 
-  private static func extractVersionedMessageAckPayload(
+  private nonisolated static func extractVersionedMessageAckPayload(
     _ payload: [String: Any],
     channelName: String
   ) -> [String: Any] {
@@ -2031,7 +2039,7 @@ extension SockudoClient {
     return payload
   }
 
-  private func decodeAnnotationEventsPage(
+  private nonisolated func decodeAnnotationEventsPage(
     payload: [String: Any],
     channelName: String,
     messageSerial: String,
@@ -2046,23 +2054,25 @@ extension SockudoClient {
       hasMore: payload["has_more"] as? Bool ?? false,
       nextCursor: payload["next_cursor"] as? String,
       fetchNext: { [weak self] cursor, completion in
-        self?.listAnnotations(
-          channelName: channelName,
-          messageSerial: messageSerial,
-          params: AnnotationEventsParams(
-            direction: originalParams.direction,
-            limit: originalParams.limit,
-            cursor: cursor,
-            type: originalParams.type,
-            fromSerial: originalParams.fromSerial
-          ),
-          completion: completion
-        )
+        Task { @MainActor in
+          self?.listAnnotations(
+            channelName: channelName,
+            messageSerial: messageSerial,
+            params: AnnotationEventsParams(
+              direction: originalParams.direction,
+              limit: originalParams.limit,
+              cursor: cursor,
+              type: originalParams.type,
+              fromSerial: originalParams.fromSerial
+            ),
+            completion: completion
+          )
+        }
       }
     )
   }
 
-  private func decodePresenceHistoryBounds(_ payload: [String: Any]?) -> PresenceHistoryBounds {
+  private nonisolated func decodePresenceHistoryBounds(_ payload: [String: Any]?) -> PresenceHistoryBounds {
     PresenceHistoryBounds(
       startSerial: (payload?["start_serial"] as? NSNumber)?.int64Value,
       endSerial: (payload?["end_serial"] as? NSNumber)?.int64Value,
@@ -2071,7 +2081,7 @@ extension SockudoClient {
     )
   }
 
-  private func decodePresenceHistoryContinuity(_ payload: [String: Any]?) -> PresenceHistoryContinuity {
+  private nonisolated func decodePresenceHistoryContinuity(_ payload: [String: Any]?) -> PresenceHistoryContinuity {
     PresenceHistoryContinuity(
       streamID: payload?["stream_id"] as? String,
       oldestAvailableSerial: (payload?["oldest_available_serial"] as? NSNumber)?.int64Value,
@@ -2088,8 +2098,8 @@ extension SockudoClient {
 }
 
 private final class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate, @unchecked Sendable {
-  var didOpen: (() -> Void)?
-  var didClose: ((URLSessionWebSocketTask.CloseCode, String?) -> Void)?
+  var didOpen: (@Sendable () -> Void)?
+  var didClose: (@Sendable (URLSessionWebSocketTask.CloseCode, String?) -> Void)?
 
   func urlSession(
     _ session: URLSession, webSocketTask: URLSessionWebSocketTask,
@@ -2107,14 +2117,14 @@ private final class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate, @u
   }
 }
 
-private enum CloseAction {
+enum CloseAction {
   case tlsOnly
   case refused
   case backoff
   case retry
 }
 
-private final class ReachabilityMonitor: @unchecked Sendable {
+@MainActor private final class ReachabilityMonitor: Sendable {
   private let monitor = NWPathMonitor()
   private let queue = DispatchQueue(label: "sockudo.reachability")
   var stateDidChange: (@Sendable (Bool) -> Void)?
@@ -2129,7 +2139,7 @@ private final class ReachabilityMonitor: @unchecked Sendable {
     monitor.start(queue: queue)
   }
 
-  func stop() {
+  nonisolated func stop() {
     monitor.cancel()
   }
 }

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/Support.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/Support.swift
@@ -89,6 +89,8 @@ public struct PresenceSnapshotParams: Sendable, Equatable {
   }
 }
 
+// @unchecked Sendable: presenceEvent uses [String: AnyHashable] which is not Sendable;
+// safe — constructed from JSON decoding and only read on @MainActor.
 public struct PresenceHistoryItem: @unchecked Sendable, Equatable {
   public let streamID: String
   public let serial: Int64
@@ -183,6 +185,8 @@ public struct ChannelHistoryParams: Sendable, Equatable {
   }
 }
 
+// @unchecked Sendable: items uses [[String: Any]] which is not Sendable;
+// safe — all let, constructed from JSON decoding, consumed on @MainActor.
 public final class ChannelHistoryPage: @unchecked Sendable {
   public let items: [[String: Any]]
   public let direction: String
@@ -252,6 +256,8 @@ public struct MessageVersionsParams: Sendable, Equatable {
   }
 }
 
+// @unchecked Sendable: items uses [[String: Any]] which is not Sendable;
+// safe — all let, constructed from JSON decoding, consumed on @MainActor.
 public final class MessageVersionsPage: @unchecked Sendable {
   public let channel: String
   public let items: [[String: Any]]
@@ -294,6 +300,8 @@ public final class MessageVersionsPage: @unchecked Sendable {
   }
 }
 
+// @unchecked Sendable: items uses [PresenceHistoryItem] whose presenceEvent is [String: AnyHashable];
+// safe — all let, constructed from JSON decoding, consumed on @MainActor.
 public final class PresenceHistoryPage: @unchecked Sendable {
   public let items: [PresenceHistoryItem]
   public let direction: String
@@ -436,11 +444,13 @@ enum QueryString {
   }
 }
 
-final class EventDispatcher {
+@MainActor final class EventDispatcher {
   typealias EventCallback = (Any?, EventMetadata?) -> Void
   typealias GlobalCallback = (String, Any?) -> Void
 
+  private var callbackOrder: [String: [EventBindingToken]] = [:]
   private var callbacks: [String: [EventBindingToken: EventCallback]] = [:]
+  private var globalCallbackOrder: [EventBindingToken] = []
   private var globalCallbacks: [EventBindingToken: GlobalCallback] = [:]
   private let failThrough: ((String, Any?) -> Void)?
 
@@ -451,6 +461,7 @@ final class EventDispatcher {
   @discardableResult
   func bind(_ eventName: String, callback: @escaping EventCallback) -> EventBindingToken {
     let token = EventBindingToken()
+    callbackOrder[eventName, default: []].append(token)
     callbacks[eventName, default: [:]][token] = callback
     return token
   }
@@ -458,6 +469,7 @@ final class EventDispatcher {
   @discardableResult
   func bindGlobal(_ callback: @escaping GlobalCallback) -> EventBindingToken {
     let token = EventBindingToken()
+    globalCallbackOrder.append(token)
     globalCallbacks[token] = callback
     return token
   }
@@ -465,11 +477,14 @@ final class EventDispatcher {
   func unbind(eventName: String? = nil, token: EventBindingToken? = nil) {
     if let eventName {
       guard let token else {
+        callbackOrder[eventName] = nil
         callbacks[eventName] = nil
         return
       }
+      callbackOrder[eventName]?.removeAll { $0 == token }
       callbacks[eventName]?[token] = nil
       if callbacks[eventName]?.isEmpty == true {
+        callbackOrder[eventName] = nil
         callbacks[eventName] = nil
       }
       return
@@ -477,27 +492,38 @@ final class EventDispatcher {
 
     if let token {
       for key in callbacks.keys {
+        callbackOrder[key]?.removeAll { $0 == token }
         callbacks[key]?[token] = nil
         if callbacks[key]?.isEmpty == true {
+          callbackOrder[key] = nil
           callbacks[key] = nil
         }
       }
+      globalCallbackOrder.removeAll { $0 == token }
       globalCallbacks[token] = nil
       return
     }
 
+    callbackOrder.removeAll()
     callbacks.removeAll()
+    globalCallbackOrder.removeAll()
     globalCallbacks.removeAll()
   }
 
   func emit(_ eventName: String, data: Any?, metadata: EventMetadata? = nil) {
-    for callback in globalCallbacks.values {
-      callback(eventName, data)
+    for token in globalCallbackOrder {
+      if let callback = globalCallbacks[token] {
+        callback(eventName, data)
+      }
     }
 
-    if let eventCallbacks = callbacks[eventName], eventCallbacks.isEmpty == false {
-      for callback in eventCallbacks.values {
-        callback(data, metadata)
+    if let order = callbackOrder[eventName], !order.isEmpty,
+       let eventCallbacks = callbacks[eventName]
+    {
+      for token in order {
+        if let callback = eventCallbacks[token] {
+          callback(data, metadata)
+        }
       }
     } else {
       failThrough?(eventName, data)
@@ -556,6 +582,7 @@ public enum SockudoAppendMode: String, Sendable, Codable, Equatable {
 public enum ConnectionState: String, Sendable, Equatable {
   case initialized
   case connecting
+  case reconnecting
   case connected
   case disconnected
   case unavailable
@@ -888,6 +915,8 @@ public struct PublishAnnotationRequest: Sendable, Equatable {
   }
 }
 
+// @unchecked Sendable: annotation and summary use [String: Any] which is not Sendable;
+// safe — all let, constructed from HTTP response decoding, consumed on @MainActor.
 public struct PublishAnnotationResponse: @unchecked Sendable {
   public let annotation: [String: Any]
   public let summary: [String: Any]?
@@ -898,6 +927,8 @@ public struct PublishAnnotationResponse: @unchecked Sendable {
   }
 }
 
+// @unchecked Sendable: summary uses [String: Any]? which is not Sendable;
+// safe — all let, constructed from HTTP response decoding, consumed on @MainActor.
 public struct DeleteAnnotationResponse: @unchecked Sendable {
   public let deleted: Bool
   public let annotationSerial: String
@@ -942,6 +973,8 @@ public struct AnnotationEventsParams: Sendable, Equatable {
   }
 }
 
+// @unchecked Sendable: items uses [[String: Any]] which is not Sendable;
+// safe — all let, constructed from JSON decoding, consumed on @MainActor.
 public final class AnnotationEventsPage: @unchecked Sendable {
   public let items: [[String: Any]]
   public let direction: String
@@ -1036,7 +1069,7 @@ public struct RewindCompleteData: Sendable, Codable, Equatable {
   public let truncatedByLimit: Bool
 }
 
-public struct DeltaOptions {
+public struct DeltaOptions: Sendable {
   public var enabled: Bool?
   public var algorithms: [DeltaAlgorithm]
   public var debug: Bool
@@ -1090,6 +1123,8 @@ public struct PresenceMember: Equatable {
   }
 }
 
+// @unchecked Sendable: data uses Any? which is not Sendable;
+// safe — constructed from JSON decoding on @MainActor, never mutated after creation.
 public struct SockudoEvent: @unchecked Sendable {
   let event: String
   let channel: String?
@@ -1138,9 +1173,9 @@ func wireInt64(_ value: Any?) -> Int64? {
   }
 }
 
-enum Logger {
-  nonisolated(unsafe) static var logToConsole = false
-  nonisolated(unsafe) static var customLog: ((String) -> Void)?
+@MainActor enum Logger {
+  static var logToConsole = false
+  static var customLog: ((String) -> Void)?
 
   static func debug(_ items: Any...) {
     log(items)

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/VersionedMessages.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/VersionedMessages.swift
@@ -35,6 +35,8 @@ public enum VersionedMessageClearField: String, Sendable, Codable, Equatable, Ca
   case extras
 }
 
+// @unchecked Sendable: data uses Any which is not Sendable;
+// safe — fire-and-forget value type, created by caller and serialized on @MainActor.
 public struct VersionedMessageCreateRequest: @unchecked Sendable {
   public let name: String
   public let data: Any
@@ -76,6 +78,8 @@ public struct VersionedMessageCreateRequest: @unchecked Sendable {
   }
 }
 
+// @unchecked Sendable: data and metadata use Any?/Any which is not Sendable;
+// safe — fire-and-forget value type, created by caller and serialized on @MainActor.
 public struct VersionedMessageUpdateRequest: @unchecked Sendable {
   public let name: String?
   public let data: Any?
@@ -124,6 +128,8 @@ public struct VersionedMessageUpdateRequest: @unchecked Sendable {
   }
 }
 
+// @unchecked Sendable: metadata uses Any? which is not Sendable;
+// safe — fire-and-forget value type, created by caller and serialized on @MainActor.
 public struct VersionedMessageAppendRequest: @unchecked Sendable {
   public let data: String
   public let extras: MessageExtras?
@@ -163,6 +169,8 @@ public struct VersionedMessageAppendRequest: @unchecked Sendable {
   }
 }
 
+// @unchecked Sendable: data and metadata use Any?/Any which is not Sendable;
+// safe — fire-and-forget value type, created by caller and serialized on @MainActor.
 public struct VersionedMessageDeleteRequest: @unchecked Sendable {
   public let data: Any?
   public let extras: MessageExtras?
@@ -207,6 +215,8 @@ public struct VersionedMessageDeleteRequest: @unchecked Sendable {
   }
 }
 
+// @unchecked Sendable: raw uses [String: Any] which is not Sendable;
+// safe — all let, constructed from HTTP response decoding, consumed on @MainActor.
 public struct VersionedMessageAck: @unchecked Sendable {
   public let channel: String
   public let messageSerial: String
@@ -266,6 +276,8 @@ public struct MutableMessageVersionInfo: Sendable, Equatable {
   }
 }
 
+// @unchecked Sendable: data uses Any? which is not Sendable;
+// safe — all let, produced by reduceMutableMessageEvent on @MainActor, never mutated after creation.
 public struct MutableMessageState: @unchecked Sendable, Equatable {
   public let messageSerial: String
   public let action: MutableMessageAction

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/XDelta3.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/XDelta3.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CXDelta3
 
-enum XDelta3 {
+enum XDelta3: Sendable {
   static func decode(delta: Data, base: Data) throws -> Data {
     try delta.withUnsafeBytes { deltaPtr in
       try base.withUnsafeBytes { basePtr in

--- a/client-sdks/sockudo-swift/Tests/SockudoSwiftTests/SockudoSwiftTests.swift
+++ b/client-sdks/sockudo-swift/Tests/SockudoSwiftTests/SockudoSwiftTests.swift
@@ -75,7 +75,7 @@ private final class VersionedProxyURLProtocol: URLProtocol, @unchecked Sendable 
 
 private struct TimeoutError: Error {}
 
-private func waitForValue<T>(
+@MainActor private func waitForValue<T>(
   timeout: TimeInterval = 5,
   pollInterval: UInt64 = 50_000_000,
   _ body: @escaping () -> T?
@@ -285,7 +285,7 @@ private func requestBodyData(_ request: URLRequest) -> Data? {
   return data.isEmpty ? nil : data
 }
 
-@Test
+@Test @MainActor
 func filterValidationAcceptsNestedFilters() {
   let filter = Filter.or(
     .init(key: "sport", cmp: "eq", val: "football"),
@@ -298,13 +298,13 @@ func filterValidationAcceptsNestedFilters() {
   #expect(validateFilter(filter) == nil)
 }
 
-@Test
+@Test @MainActor
 func filterValidationRejectsInvalidNotNode() {
   let invalid = FilterNode(op: "not", nodes: [])
   #expect(validateFilter(invalid) == "NOT operation requires exactly one child node, got 0")
 }
 
-@Test
+@Test @MainActor
 func deltaSettingsSerializeAsExpected() {
   #expect(ChannelDeltaSettings(enabled: true).subscriptionValue() as? Bool == true)
   #expect(ChannelDeltaSettings(enabled: false).subscriptionValue() as? Bool == false)
@@ -313,7 +313,7 @@ func deltaSettingsSerializeAsExpected() {
   #expect((SubscriptionRewind.seconds(30).subscriptionValue() as? [String: Int])?["seconds"] == 30)
 }
 
-@Test
+@Test @MainActor
 func presenceHistoryParamsNormalizeAblyAliases() {
   let payload = PresenceHistoryParams(
     direction: "newest_first",
@@ -328,7 +328,7 @@ func presenceHistoryParamsNormalizeAblyAliases() {
   #expect(payload["end_time_ms"] as? Int64 == 2000)
 }
 
-@Test
+@Test @MainActor
 func channelHistoryParamsIncludeUntilAttach() {
   let payload = ChannelHistoryParams(
     direction: "newest_first",
@@ -341,7 +341,7 @@ func channelHistoryParamsIncludeUntilAttach() {
   #expect(payload["until_attach"] as? Bool == true)
 }
 
-@Test
+@Test @MainActor
 func presenceHistoryPageNextUsesNextCursor() async throws {
   let cursor = Box<String>()
   let page = PresenceHistoryPage(
@@ -406,7 +406,7 @@ func presenceHistoryPageNextUsesNextCursor() async throws {
   #expect(cursor.value == "cursor-2")
 }
 
-@Test
+@Test @MainActor
 func annotationRequestPayloadUsesProxyShape() {
   let payload = PublishAnnotationRequest(
     type: "reactions:distinct.v1",
@@ -427,7 +427,7 @@ func annotationRequestPayloadUsesProxyShape() {
   #expect(payload["idempotencyKey"] as? String == "anno-1")
 }
 
-@Test
+@Test @MainActor
 func annotationEventsPageNextUsesNextCursor() {
   let cursor = Box<String>()
   let page = AnnotationEventsPage(
@@ -456,7 +456,7 @@ func annotationEventsPageNextUsesNextCursor() {
   #expect(cursor.value == "anno-cursor-2")
 }
 
-@Test
+@Test @MainActor
 func pushProxyHelpersUseBackendEndpointAndAsyncPublishDefaults() async throws {
   let requests = Box<[URLRequest]>()
   requests.value = []
@@ -556,7 +556,7 @@ func pushProxyHelpersUseBackendEndpointAndAsyncPublishDefaults() async throws {
   )
 }
 
-@Test
+@Test @MainActor
 func versionedMessageProxyWritesUseEndpointTimeoutAndTypedAcks() async throws {
   let requests = Box<[URLRequest]>()
   requests.value = []
@@ -717,7 +717,7 @@ func versionedMessageProxyWritesUseEndpointTimeoutAndTypedAcks() async throws {
   #expect(deleteBody["action"] as? String == "delete_message")
 }
 
-@Test
+@Test @MainActor
 func channelExposesAnnotationInternalEvents() throws {
   let client = try SockudoClient(
     "app-key",
@@ -767,7 +767,7 @@ func channelExposesAnnotationInternalEvents() throws {
   #expect(raw.value?["action"] as? String == "annotation.create")
 }
 
-@Test
+@Test @MainActor
 func subscriptionSucceededCapturesAttachSerial() throws {
   let client = try SockudoClient(
     "app-key",
@@ -793,7 +793,7 @@ func subscriptionSucceededCapturesAttachSerial() throws {
   #expect(channel.attachSerial == 42)
 }
 
-@Test
+@Test @MainActor
 func websocketURLIncludesV2FormatQuery() throws {
   let client = try SockudoClient(
     "app-key",
@@ -825,7 +825,7 @@ func websocketURLIncludesV2FormatQuery() throws {
   #expect(query["token"] == "jwt-1")
 }
 
-@Test
+@Test @MainActor
 func websocketURLUsesV1ByDefaultAndOmitsFormatQuery() throws {
   let client = try SockudoClient(
     "app-key",
@@ -852,7 +852,7 @@ func websocketURLUsesV1ByDefaultAndOmitsFormatQuery() throws {
   #expect(query["token"] == nil)
 }
 
-@Test
+@Test @MainActor
 func appendRollupWindowRejectsUnsupportedValues() {
   do {
     _ = try SockudoClient(
@@ -867,7 +867,7 @@ func appendRollupWindowRejectsUnsupportedValues() {
   }
 }
 
-@Test
+@Test @MainActor
 func capabilityTokenAuthEventsUpdateStateAndProviderRefreshes() async throws {
   let tokenRequests = Box<Int>()
   tokenRequests.value = 0
@@ -900,7 +900,7 @@ func capabilityTokenAuthEventsUpdateStateAndProviderRefreshes() async throws {
   #expect(tokenRequests.value == 1)
 }
 
-@Test
+@Test @MainActor
 func capabilityTokenRefreshDelayUsesJWTIatAndExp() throws {
   let token = try unsignedJWT(claims: ["iat": 1_000, "exp": 2_000])
   let delay = try #require(
@@ -912,7 +912,7 @@ func capabilityTokenRefreshDelayUsesJWTIatAndExp() throws {
   #expect(abs(delay - 100) < 0.001)
 }
 
-@Test
+@Test @MainActor
 func capabilityTokenRefreshDelayFallsBackToNowWhenIatMissing() throws {
   let token = try unsignedJWT(claims: ["exp": 2_000])
   let delay = try #require(
@@ -926,7 +926,7 @@ func capabilityTokenRefreshDelayFallsBackToNowWhenIatMissing() throws {
   #expect(SockudoClient.capabilityTokenRefreshDelay(for: try unsignedJWT(claims: ["iat": 1])) == nil)
 }
 
-@Test
+@Test @MainActor
 func providerJWTCapabilityTokenSchedulesProactiveRefresh() async throws {
   let issuedAt = 1_000
   let expiresAt = 2_000
@@ -959,7 +959,7 @@ func providerJWTCapabilityTokenSchedulesProactiveRefresh() async throws {
   #expect(client.hasCapabilityTokenRefreshTimer == false)
 }
 
-@Test
+@Test @MainActor
 func staticOnlyAndOpaqueCapabilityTokensDoNotScheduleProactiveRefresh() throws {
   let token = try unsignedJWT(claims: ["iat": 1_000, "exp": 2_000])
   let staticOnly = try SockudoClient(
@@ -991,7 +991,7 @@ func staticOnlyAndOpaqueCapabilityTokensDoNotScheduleProactiveRefresh() throws {
   #expect(providerOpaque.hasCapabilityTokenRefreshTimer == false)
 }
 
-@Test
+@Test @MainActor
 func messagePackRoundTrip() throws {
   let payload = try ProtocolCodec.encodeEnvelope(
     [
@@ -1028,7 +1028,7 @@ func messagePackRoundTrip() throws {
   #expect(decoded.conflationKey == "room")
 }
 
-@Test
+@Test @MainActor
 func protobufRoundTrip() throws {
   let payload = try ProtocolCodec.encodeEnvelope(
     [
@@ -1083,7 +1083,7 @@ func protobufRoundTrip() throws {
   #expect(decoded.extras?.raw?["ai"]?["codec"]?["x-custom"]?.stringValue == "opaque")
 }
 
-@Test
+@Test @MainActor
 func forwardCompatFixturesReplayThroughClientDispatch() throws {
   let client = try SockudoClient(
     "app-key",
@@ -1133,7 +1133,7 @@ func forwardCompatFixturesReplayThroughClientDispatch() throws {
   #expect(channelEvents.value?.contains("ai-output") == true)
 }
 
-@Test
+@Test @MainActor
 func forwardCompatJSONPreservesSerialBoundariesAndRawExtras() throws {
   let futureFrame = try ProtocolCodec.decodeEvent(
     .string(try forwardCompatFixture("future-v2-frame.json")),
@@ -1162,7 +1162,7 @@ func forwardCompatJSONPreservesSerialBoundariesAndRawExtras() throws {
   #expect(extrasFrame.extras?.raw?["futureExtrasField"] == .bool(true))
 }
 
-@Test
+@Test @MainActor
 func binaryCodecsPreserveLargeSerialsAndAIExtras() throws {
   let largeSerial = 9_007_199_254_740_993
   let payload: [String: Any] = [
@@ -1202,7 +1202,7 @@ func binaryCodecsPreserveLargeSerialsAndAIExtras() throws {
   #expect(protobuf.extras?.raw?["ai"]?["transport"]?["turn-id"]?.stringValue == "turn-1")
 }
 
-@Test
+@Test @MainActor
 func presenceUnknownInternalEventsDoNotCorruptMembers() throws {
   let client = try SockudoClient(
     "app-key",
@@ -1264,7 +1264,7 @@ func presenceUnknownInternalEventsDoNotCorruptMembers() throws {
   #expect(channel.members.member(id: "undefined") == nil)
 }
 
-@Test
+@Test @MainActor
 func presenceUpdateRequiresV2AndUsesConnectionSendPath() throws {
   let v1Client = try SockudoClient(
     "app-key",
@@ -1290,7 +1290,7 @@ func presenceUpdateRequiresV2AndUsesConnectionSendPath() throws {
   #expect(try v2Channel.update(data: ["status": "thinking"]) == false)
 }
 
-@Test
+@Test @MainActor
 func localSockudoIntegrationConnectsAndReceivesPublishedEvent() async throws {
   guard ProcessInfo.processInfo.environment["SOCKUDO_LIVE_TESTS"] == "1" else {
     return
@@ -1345,7 +1345,7 @@ func localSockudoIntegrationConnectsAndReceivesPublishedEvent() async throws {
   client.disconnect()
 }
 
-@Test
+@Test @MainActor
 func liveV2HeartbeatUsesControlFramesOnIdle() async throws {
   guard ProcessInfo.processInfo.environment["SOCKUDO_LIVE_TESTS"] == "1" else {
     return
@@ -1371,7 +1371,7 @@ func liveV2HeartbeatUsesControlFramesOnIdle() async throws {
   }
 }
 
-@Test
+@Test @MainActor
 func liveV2FallbackPongHasNoMetadata() async throws {
   guard ProcessInfo.processInfo.environment["SOCKUDO_LIVE_TESTS"] == "1" else {
     return
@@ -1396,7 +1396,7 @@ func liveV2FallbackPongHasNoMetadata() async throws {
   #expect(pong.streamID == nil)
 }
 
-@Test
+@Test @MainActor
 func liveV1HeartbeatStillUsesProtocolPing() async throws {
   guard ProcessInfo.processInfo.environment["SOCKUDO_LIVE_TESTS"] == "1" else {
     return
@@ -1465,5 +1465,282 @@ func liveV1HeartbeatStillUsesProtocolPing() async throws {
   let base = Data("some base".utf8)
   #expect(throws: (any Error).self) {
     try XDelta3.decode(delta: garbage, base: base)
+  }
+}
+
+@Test @MainActor
+func clientEventBufferedWhenNotSubscribed() throws {
+  let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
+  let channel = client.subscribe("private-chat")
+
+  let result = try channel.trigger(event: "client-hello", data: ["msg": "hi"])
+
+  #expect(result == true)
+  #expect(channel.bufferedEventCount == 1)
+}
+
+@Test @MainActor
+func clientEventBufferDrainedAfterSubscriptionSucceeded() throws {
+  let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
+  let channel = client.subscribe("private-chat")
+
+  _ = try channel.trigger(event: "client-msg1", data: "first")
+  _ = try channel.trigger(event: "client-msg2", data: "second")
+  #expect(channel.bufferedEventCount == 2)
+
+  channel.handle(
+    event: SockudoEvent(
+      event: "sockudo_internal:subscription_succeeded",
+      channel: "private-chat",
+      data: [:] as [String: Any],
+      userID: nil,
+      streamID: nil,
+      messageId: nil,
+      rawMessage: "",
+      sequence: nil,
+      conflationKey: nil,
+      serial: nil,
+      extras: nil
+    ))
+
+  #expect(channel.isSubscribed == true)
+  #expect(channel.bufferedEventCount == 0)
+}
+
+@Test @MainActor
+func clientEventBufferCapDropsOldestAtOverflow() throws {
+  let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
+  let channel = client.subscribe("private-chat")
+
+  for i in 0..<51 {
+    _ = try channel.trigger(event: "client-event", data: i)
+  }
+
+  #expect(channel.bufferedEventCount == 50)
+}
+
+@Test @MainActor
+func unsubscribeClearsClientEventBuffer() throws {
+  let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
+  let channel = client.subscribe("private-chat")
+
+  _ = try channel.trigger(event: "client-hello", data: "data")
+  #expect(channel.bufferedEventCount == 1)
+
+  client.unsubscribe("private-chat")
+  #expect(channel.bufferedEventCount == 0)
+}
+
+@Test @MainActor
+func clientEventBufferSurvivesDisconnect() throws {
+  let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
+  let channel = client.subscribe("private-chat")
+
+  _ = try channel.trigger(event: "client-hello", data: "data")
+  #expect(channel.bufferedEventCount == 1)
+
+  channel.disconnect()
+
+  #expect(channel.bufferedEventCount == 1)
+}
+
+// MARK: - Connection State
+
+@Test @MainActor
+func connectionStateTransitionIncludesReconnecting() async throws {
+  let client = try SockudoClient(
+    "app-key",
+    options: .init(
+      cluster: "local",
+      forceTLS: false,
+      enabledTransports: [.ws],
+      wsHost: "127.0.0.1",
+      wsPort: 6001,
+      wssPort: 6001
+    )
+  )
+
+  #expect(client.connectionState == .initialized)
+  client.connect()
+  #expect(client.connectionState == .connecting)
+
+  let connEstablished = URLSessionWebSocketTask.Message.string(
+    "{\"event\":\"pusher:connection_established\",\"data\":\"{\\\"socket_id\\\":\\\"42.1\\\",\\\"activity_timeout\\\":120}\"}"
+  )
+  client.handle(rawMessage: connEstablished)
+  #expect(client.connectionState == .connected)
+
+  let sawReconnecting = Box<Bool>()
+  client.bind("reconnecting") { _, _ in
+    sawReconnecting.value = true
+  }
+  client.scheduleRetry(after: 0)
+  let reconnecting = try await waitForValue(timeout: 2) { sawReconnecting.value }
+  #expect(reconnecting)
+
+  client.disconnect()
+}
+
+// MARK: - Reconnect Backoff
+
+@Suite("Reconnect Backoff")
+@MainActor
+struct ReconnectBackoffTests {
+
+  @Test func delayProgressionFollowsSquaredFormula() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", maxReconnectAttempts: nil)
+    )
+    let expectedDelays: [(Int, Double)] = [(0, 0), (1, 1), (2, 4), (3, 9), (4, 16), (5, 25)]
+    for (attempt, expectedDelay) in expectedDelays {
+      client.reconnectAttempts = attempt
+      #expect(client.reconnectDelay(for: .backoff) == expectedDelay)
+    }
+  }
+
+  @Test func retryAndTlsOnlyActionsReturnZeroDelay() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local")
+    )
+    client.reconnectAttempts = 10
+    #expect(client.reconnectDelay(for: .retry) == 0)
+    #expect(client.reconnectDelay(for: .tlsOnly) == 0)
+  }
+
+  @Test func delayCapAtMaxReconnectGapInSeconds() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", maxReconnectGapInSeconds: 10)
+    )
+    client.reconnectAttempts = 5
+    #expect(client.reconnectDelay(for: .backoff) == 10)
+    client.reconnectAttempts = 20
+    #expect(client.reconnectDelay(for: .backoff) == 10)
+  }
+
+  @Test func maxAttemptsReachedTransitionsToDisconnected() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", maxReconnectAttempts: 3)
+    )
+    client.reconnectAttempts = 3
+    client.scheduleRetry(after: 0)
+    #expect(client.connectionState == .disconnected)
+  }
+
+  @Test func counterResetsAfterConnectionEstablished() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local")
+    )
+    client.reconnectAttempts = 4
+    client.handle(
+      rawMessage: .string(
+        #"{"event":"pusher:connection_established","data":{"socket_id":"abc.123","activity_timeout":120}}"#
+      ))
+    #expect(client.reconnectAttempts == 0)
+  }
+
+  @Test func counterResetsOnConnect() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", wsHost: "127.0.0.1", wsPort: 6001)
+    )
+    client.reconnectAttempts = 5
+    client.connect()
+    #expect(client.reconnectAttempts == 0)
+    client.disconnect()
+  }
+
+  @Test func manualDisconnectStopsRetries() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", maxReconnectAttempts: nil)
+    )
+    client.reconnectAttempts = 2
+    client.disconnect()
+    #expect(client.reconnectAttempts == 0)
+    #expect(client.connectionState == .disconnected)
+    client.scheduleRetry(after: 0)
+    #expect(client.connectionState == .disconnected)
+  }
+}
+
+// MARK: - Concurrency Compliance
+
+@Suite("Concurrency Compliance")
+@MainActor
+struct ConcurrencyComplianceTests {
+
+  // Verifies that sequential connect/disconnect on @MainActor does not crash.
+  // The parallel case (calling from a background thread) is now a compile-time
+  // error due to @MainActor isolation on SockudoClient — that's the real guard.
+  @Test func connectDisconnect_sequential_doesNotCrash() throws {
+    let client = try SockudoClient(
+      "test-key",
+      options: .init(cluster: "local", wsHost: "127.0.0.1", wsPort: 6001)
+    )
+    client.connect()
+    client.disconnect()
+    // Reaching here without a crash is the assertion.
+  }
+
+  // Verifies callback ordering: events bound before emit fire in bind order.
+  @Test func eventCallbacks_fireInOrder() throws {
+    let client = try SockudoClient(
+      "test-key",
+      options: .init(cluster: "local", wsHost: "127.0.0.1", wsPort: 6001)
+    )
+    var received: [Int] = []
+    client.bind("test-event") { _, _ in received.append(1) }
+    client.bind("test-event") { _, _ in received.append(2) }
+    client.dispatcher.emit("test-event", data: nil)
+    #expect(received == [1, 2])
+  }
+
+  // Verifies MessageDeduplicator isolation: isDuplicate/track are @MainActor-safe.
+  @Test func messageDeduplicator_trackAndCheck() {
+    let dedup = MessageDeduplicator(capacity: 10)
+    dedup.track("msg-1")
+    #expect(dedup.isDuplicate("msg-1") == true)
+    #expect(dedup.isDuplicate("msg-2") == false)
+  }
+
+  // Documents the @unchecked Sendable count does not regress above the
+  // post-migration threshold of 19 type declarations.
+  // This test passes trivially at compile time — if @MainActor were removed and
+  // more @unchecked Sendable added, this comment serves as the documented baseline.
+  @Test func uncheckedSendableCount_documentedThreshold() {
+    // Baseline established post-migration: 19 @unchecked Sendable type declarations.
+    // All 19 are data-transfer types with [String: Any] or Any fields.
+    // See individual // @unchecked Sendable comments in source files for justifications.
+    // If this number grows, revisit: https://github.com/sockudo/sockudo
+    #expect(Bool(true)) // Compile-time contract; runtime is a formality.
+  }
+
+  @Test @MainActor
+  func deliveredCallbacksFireOnMainActor() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", protocolVersion: 2)
+    )
+    defer { client.disconnect() }
+
+    let channel = client.subscribe("test-channel")
+    let fired = Box<Bool>()
+    fired.value = false
+
+    channel.bind("test-event") { _, _ in
+      MainActor.assertIsolated()
+      fired.value = true
+    }
+
+    client.handle(
+      rawMessage: .string(
+        #"{"event":"test-event","channel":"test-channel","data":{}}"#))
+
+    #expect(fired.value == true)
   }
 }


### PR DESCRIPTION
Swift 6 strict concurrency compliance and PusherSwift-parity architecture for the sockudo-swift client SDK.

Concurrency model
- SockudoClient, Channel hierarchy, UserFacade, WatchlistFacade, EventDispatcher, Logger, and ReachabilityMonitor are @MainActor-isolated
- MessageProcessor actor owns MessageDeduplicator and DeltaCompressionManager on a background executor (plain actor, iOS 13+ compatible)
- MessagePipeline is a stateless Sendable helper for protocol decode, delta reconstruct, JSON parse, and delta metadata stripping
- URLSession delegateQueue is nil; WebSocket callbacks arrive on a background queue, route through the actor, and hop to MainActor for delivery only
- readNextMessage() enqueues to actor; deliverMessage(ProcessedMessage) receives fully-processed events with zero parsing on MainActor
- Stateless enums (FossilDelta, XDelta3, ProtocolCodec) marked Sendable
- Auth handler typealiases marked `@Sendable`
- Option structs marked Sendable
- 19 `@unchecked Sendable` remain on immutable data-transfer types with [String: Any] fields, each justified
- -strict-concurrency=minimal removed; clean under Swift 6.2 complete mode

Reconnection
- Exponential backoff: attempt² seconds, capped at maxReconnectGapInSeconds (default 120s), max 6 attempts (configurable via Options)
- Counter resets on connection_established, connect(), disconnect()
- Immediate retry for close codes 4200-4299 and TLS upgrade
- ConnectionState.reconnecting distinguishes retry from first connection

Client event buffering
- trigger() buffers when !isSubscribed instead of dropping silently
- 50-event cap per channel, FIFO replay after subscription_succeeded
- Buffer survives disconnect/reconnect; cleared on unsubscribe()

EventDispatcher ordering
- Callbacks delivered in bind order via ordered token array + lookup dict

Tests: 51 total (14 new)

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
